### PR TITLE
chore: update springdoc dependencies for spring boot 3.4

### DIFF
--- a/api-bff/pom.xml
+++ b/api-bff/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.1.0</version>
+      <version>2.8.6</version>
     </dependency>
 
     <!-- Lombok -->

--- a/api-citas/pom.xml
+++ b/api-citas/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <springdoc.version>2.6.0</springdoc.version>
+    <springdoc.version>2.8.6</springdoc.version>
   </properties>
 
   <!-- BOM de Spring Cloud compatible con Spring Boot 3.4.x -->

--- a/api-cuidados/pom.xml
+++ b/api-cuidados/pom.xml
@@ -76,7 +76,7 @@
     <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.6</version>
     </dependency>
     <dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/api-diario/pom.xml
+++ b/api-diario/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <java.version>17</java.version>
     <spring-cloud.version>2024.0.2</spring-cloud.version>
-    <springdoc.version>2.6.0</springdoc.version>
+    <springdoc.version>2.8.6</springdoc.version>
     <lombok.version>1.18.34</lombok.version>
   </properties>
 

--- a/api-gastos/pom.xml
+++ b/api-gastos/pom.xml
@@ -21,7 +21,7 @@
     <java.version>17</java.version>
     <spring-cloud.version>2024.0.2</spring-cloud.version>
     <jjwt.version>0.11.5</jjwt.version>
-    <springdoc-openapi.version>2.1.0</springdoc-openapi.version>
+    <springdoc-openapi.version>2.8.6</springdoc-openapi.version>
   </properties>
 
   <dependencies>

--- a/api-rutinas/pom.xml
+++ b/api-rutinas/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>2.1.0</version>
+      <version>2.8.6</version>
     </dependency>
 
     <!-- Actuator (métricas/monitorización) -->

--- a/api-usuarios/pom.xml
+++ b/api-usuarios/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
         <groupId>org.springdoc</groupId>
         <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-        <version>2.1.0</version>
+        <version>2.8.6</version>
     </dependency>
 
 		<!-- Spring Cloud Config Client -->


### PR DESCRIPTION
## Summary
- bump springdoc-openapi-starter-webmvc-ui to 2.8.6 across microservices to support Spring Boot 3.4.x

## Testing
- `mvn clean package` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e859b52548327b9611996e2e8bef2