### PR TITLE
fix: decode JWT secret using Base64

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/JwtAuthFilter.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/JwtAuthFilter.java
@@ -12,6 +12,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -53,7 +54,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
             try {
-                Claims claims = Jwts.parser().setSigningKey(secret.getBytes("UTF-8")).parseClaimsJws(token).getBody();
+                Claims claims = Jwts.parser().setSigningKey(Decoders.BASE64.decode(secret)).parseClaimsJws(token).getBody();
                 String username = claims.getSubject();
 
                 @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- use `Decoders.BASE64.decode` for JWT secret in JwtAuthFilter
- include `Decoders` import

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa58071a3c8327a4cd0acae4d2140f