### PR TITLE
Add soft delete support for Rutina entity

### DIFF
--- a/api-rutinas/pom.xml
+++ b/api-rutinas/pom.xml
@@ -114,6 +114,11 @@
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/entity/Rutina.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/entity/Rutina.java
@@ -34,6 +34,9 @@ public class Rutina {
     @Column(nullable=false)
     private Boolean activa;
 
+    @Column(nullable=false)
+    private Boolean eliminado = Boolean.FALSE;
+
     @Column(name="created_at")
     private LocalDateTime createdAt;
 
@@ -45,6 +48,7 @@ public class Rutina {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = this.createdAt;
         if (this.activa == null) this.activa = Boolean.TRUE;
+        if (this.eliminado == null) this.eliminado = Boolean.FALSE;
     }
 
     @PreUpdate

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/repository/RutinaRepository.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/repository/RutinaRepository.java
@@ -10,10 +10,10 @@ import com.babytrackmaster.api_rutinas.entity.Rutina;
 
 public interface RutinaRepository extends JpaRepository<Rutina, Long> {
 
-    @Query("select r from Rutina r where r.id = :id and r.usuarioId = :usuarioId")
+    @Query("select r from Rutina r where r.id = :id and r.usuarioId = :usuarioId and r.eliminado = false")
     Rutina findOneByIdAndUsuario(@Param("id") Long id, @Param("usuarioId") Long usuarioId);
 
-    @Query("select r from Rutina r where r.usuarioId = :usuarioId" +
+    @Query("select r from Rutina r where r.usuarioId = :usuarioId and r.eliminado = false" +
            " and (:activo is null or r.activa = :activo)" +
            " and (:dia is null or r.diasSemana like concat('%', :dia, '%'))")
     Page<Rutina> findAllByUsuarioAndFilters(@Param("usuarioId") Long usuarioId,

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/impl/RutinaServiceImpl.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/impl/RutinaServiceImpl.java
@@ -41,13 +41,13 @@ public class RutinaServiceImpl implements RutinaService {
 
     public RutinaDTO obtener(Long usuarioId, Long id) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(id, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         return RutinaMapper.toDTO(r);
     }
 
     public RutinaDTO actualizar(Long usuarioId, Long id, RutinaCreateDTO dto) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(id, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         RutinaMapper.updateEntity(r, dto);
         r = rutinaRepository.save(r);
         return RutinaMapper.toDTO(r);
@@ -55,8 +55,9 @@ public class RutinaServiceImpl implements RutinaService {
 
     public void eliminar(Long usuarioId, Long id) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(id, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
-        rutinaRepository.delete(r);
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
+        r.setEliminado(Boolean.TRUE);
+        rutinaRepository.save(r);
     }
 
     public Page<RutinaDTO> listar(Long usuarioId, Boolean activo, String dia, Pageable pageable) {
@@ -70,7 +71,7 @@ public class RutinaServiceImpl implements RutinaService {
 
     public RutinaDTO activar(Long usuarioId, Long id) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(id, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         r.setActiva(Boolean.TRUE);
         r = rutinaRepository.save(r);
         return RutinaMapper.toDTO(r);
@@ -78,7 +79,7 @@ public class RutinaServiceImpl implements RutinaService {
 
     public RutinaDTO desactivar(Long usuarioId, Long id) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(id, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         r.setActiva(Boolean.FALSE);
         r = rutinaRepository.save(r);
         return RutinaMapper.toDTO(r);
@@ -86,7 +87,7 @@ public class RutinaServiceImpl implements RutinaService {
 
     public RutinaEjecucionDTO registrarEjecucion(Long usuarioId, Long rutinaId, RutinaEjecucionCreateDTO dto) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(rutinaId, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         RutinaEjecucion e = RutinaEjecucionMapper.toEntity(dto, r);
         e = ejecucionRepository.save(e);
         return RutinaEjecucionMapper.toDTO(e);
@@ -94,7 +95,7 @@ public class RutinaServiceImpl implements RutinaService {
 
     public List<RutinaEjecucionDTO> historial(Long usuarioId, Long rutinaId, LocalDate desde, LocalDate hasta) {
         Rutina r = rutinaRepository.findOneByIdAndUsuario(rutinaId, usuarioId);
-        if (r == null) throw new NotFoundException("Rutina no encontrada");
+        if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");
         LocalDateTime d = desde != null ? desde.atStartOfDay() : null;
         LocalDateTime h = hasta != null ? hasta.atTime(23,59,59) : null;
         List<RutinaEjecucion> lista = ejecucionRepository.buscarHistorial(rutinaId, usuarioId, d, h);

--- a/api-rutinas/src/test/java/com/babytrackmaster/api_rutinas/RutinaRepositoryTest.java
+++ b/api-rutinas/src/test/java/com/babytrackmaster/api_rutinas/RutinaRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.babytrackmaster.api_rutinas;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.babytrackmaster.api_rutinas.entity.Rutina;
+import com.babytrackmaster.api_rutinas.repository.RutinaRepository;
+
+@DataJpaTest
+class RutinaRepositoryTest {
+
+    @Autowired
+    private RutinaRepository rutinaRepository;
+
+    @Test
+    void shouldNotReturnDeletedRoutines() {
+        Rutina activa = Rutina.builder()
+                .usuarioId(1L)
+                .nombre("Activa")
+                .descripcion("desc")
+                .horaProgramada(LocalTime.NOON)
+                .diasSemana("L")
+                .activa(true)
+                .build();
+        rutinaRepository.save(activa);
+
+        Rutina eliminada = Rutina.builder()
+                .usuarioId(1L)
+                .nombre("Eliminada")
+                .descripcion("desc")
+                .horaProgramada(LocalTime.NOON)
+                .diasSemana("M")
+                .activa(true)
+                .eliminado(true)
+                .build();
+        rutinaRepository.save(eliminada);
+
+        Page<Rutina> page = rutinaRepository.findAllByUsuarioAndFilters(1L, null, null, PageRequest.of(0, 10));
+        assertEquals(1, page.getTotalElements());
+        assertEquals(activa.getNombre(), page.getContent().get(0).getNombre());
+
+        Rutina result = rutinaRepository.findOneByIdAndUsuario(eliminada.getId(), 1L);
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `eliminado` flag to `Rutina` entity and initialize to false
- filter out soft-deleted routines in repository queries and service methods
- replace hard deletes with soft delete and add test ensuring deleted routines are excluded

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af9f624c008327b2e1a4f3d546aeac