### PR TITLE
Add soft delete for cuidados

### DIFF
--- a/api-cuidados/pom.xml
+++ b/api-cuidados/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
@@ -50,6 +50,9 @@ public class Cuidado {
     @Column(length=500)
     private String observaciones;
 
+    @Column(nullable = false)
+    private Boolean eliminado = false;
+
     @Temporal(TemporalType.TIMESTAMP)
     @Column(name="created_at", nullable=false)
     private Date createdAt;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -24,6 +24,7 @@ public class CuidadoMapper {
         Date now = new Date();
         c.setCreatedAt(now);
         c.setUpdatedAt(now);
+        c.setEliminado(false);
         return c;
     }
 

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
@@ -2,13 +2,15 @@ package com.babytrackmaster.api_cuidados.repository;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 
 public interface CuidadoRepository extends JpaRepository<Cuidado, Long> {
-    List<Cuidado> findByBebeIdOrderByInicioDesc(Long bebeId);
-    List<Cuidado> findByBebeIdAndTipoOrderByInicioDesc(Long bebeId, String tipo);
-    List<Cuidado> findByBebeIdAndInicioBetweenOrderByInicioDesc(Long bebeId, Date desde, Date hasta);
+    Optional<Cuidado> findByIdAndEliminadoFalse(Long id);
+    List<Cuidado> findByBebeIdAndEliminadoFalseOrderByInicioDesc(Long bebeId);
+    List<Cuidado> findByBebeIdAndTipoAndEliminadoFalseOrderByInicioDesc(Long bebeId, String tipo);
+    List<Cuidado> findByBebeIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -32,7 +32,7 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     public CuidadoResponse actualizar(Long id, CuidadoRequest request) {
-        Cuidado c = repo.findById(id).orElse(null);
+        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
@@ -42,15 +42,18 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     public void eliminar(Long id) {
-        if (!repo.existsById(id)) {
+        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
+        if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
-        repo.deleteById(id);
+        c.setEliminado(true);
+        c.setUpdatedAt(new Date());
+        repo.save(c);
     }
 
     @Transactional(readOnly = true)
     public CuidadoResponse obtener(Long id) {
-        Cuidado c = repo.findById(id).orElse(null);
+        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
@@ -59,7 +62,7 @@ public class CuidadoServiceImpl implements CuidadoService {
 
     @Transactional(readOnly = true)
     public List<CuidadoResponse> listarPorBebe(Long bebeId) {
-        List<Cuidado> list = repo.findByBebeIdOrderByInicioDesc(bebeId);
+        List<Cuidado> list = repo.findByBebeIdAndEliminadoFalseOrderByInicioDesc(bebeId);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));
@@ -69,7 +72,7 @@ public class CuidadoServiceImpl implements CuidadoService {
 
     @Transactional(readOnly = true)
     public List<CuidadoResponse> listarPorBebeYTipo(Long bebeId, String tipo) {
-        List<Cuidado> list = repo.findByBebeIdAndTipoOrderByInicioDesc(bebeId, tipo);
+        List<Cuidado> list = repo.findByBebeIdAndTipoAndEliminadoFalseOrderByInicioDesc(bebeId, tipo);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));
@@ -79,7 +82,7 @@ public class CuidadoServiceImpl implements CuidadoService {
 
     @Transactional(readOnly = true)
     public List<CuidadoResponse> listarPorRango(Long bebeId, Date desde, Date hasta) {
-        List<Cuidado> list = repo.findByBebeIdAndInicioBetweenOrderByInicioDesc(bebeId, desde, hasta);
+        List<Cuidado> list = repo.findByBebeIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(bebeId, desde, hasta);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoRepositoryTests.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoRepositoryTests.java
@@ -1,0 +1,51 @@
+package com.babytrackmaster.api_cuidados;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.babytrackmaster.api_cuidados.entity.Cuidado;
+import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
+
+@DataJpaTest
+class CuidadoRepositoryTests {
+
+    @Autowired
+    private CuidadoRepository repo;
+
+    @Test
+    void listarExcluyeEliminados() {
+        Date now = new Date();
+
+        Cuidado activo = new Cuidado();
+        activo.setBebeId(1L);
+        activo.setUsuarioId(1L);
+        activo.setTipo("TEST");
+        activo.setInicio(now);
+        activo.setCreatedAt(now);
+        activo.setUpdatedAt(now);
+        repo.save(activo);
+
+        Cuidado eliminado = new Cuidado();
+        eliminado.setBebeId(1L);
+        eliminado.setUsuarioId(1L);
+        eliminado.setTipo("TEST");
+        eliminado.setInicio(new Date(now.getTime() + 1000));
+        eliminado.setCreatedAt(now);
+        eliminado.setUpdatedAt(now);
+        eliminado.setEliminado(true);
+        repo.save(eliminado);
+
+        List<Cuidado> list = repo.findByBebeIdAndEliminadoFalseOrderByInicioDesc(1L);
+
+        assertEquals(1, list.size());
+        assertFalse(list.get(0).getEliminado());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `eliminado` flag to `Cuidado` entity
- update repository/service to ignore soft-deleted records
- add H2 test dependency and unit test for filtering

## Testing
- `./mvnw test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afa415ac448327a6e9279cc68c6605