### PR TITLE
feat(hitos): add soft delete support

### DIFF
--- a/api-hitos/src/main/java/com/babytrackmaster/api_hitos/entity/Hito.java
+++ b/api-hitos/src/main/java/com/babytrackmaster/api_hitos/entity/Hito.java
@@ -39,6 +39,9 @@ public class Hito {
 
     @Column(name="imagen_url", length = 500)
     private String imagenUrl;
+
+    @Column(nullable = false)
+    private Boolean eliminado = false;
     
     @Column(name="creado_en", nullable = false)
     private LocalDateTime creadoEn;

--- a/api-hitos/src/main/java/com/babytrackmaster/api_hitos/repository/HitoRepository.java
+++ b/api-hitos/src/main/java/com/babytrackmaster/api_hitos/repository/HitoRepository.java
@@ -17,17 +17,17 @@ public interface HitoRepository extends JpaRepository<Hito, Long> {
 //	
 //	Hito findByIdAndUsuarioId(Long id, Long usuarioId);
 	
-	Optional<Hito> findByIdAndUsuarioId(Long id, Long usuarioId);
+        Optional<Hito> findByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
 
-    Hito findFirstByIdAndUsuarioId(Long id, Long usuarioId);
+    Hito findFirstByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
 
-    boolean existsByIdAndUsuarioId(Long id, Long usuarioId);
+    boolean existsByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
 
-    List<Hito> findByUsuarioIdOrderByFechaDesc(Long usuarioId);
+    List<Hito> findByUsuarioIdAndEliminadoFalseOrderByFechaDesc(Long usuarioId);
 
-    List<Hito> findByUsuarioIdAndBebeIdOrderByFechaDesc(Long usuarioId, Long bebeId);
+    List<Hito> findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaDesc(Long usuarioId, Long bebeId);
 
-    List<Hito> findByUsuarioIdAndFechaBetweenOrderByFechaDesc(Long usuarioId, LocalDate inicio, LocalDate fin);
+    List<Hito> findByUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(Long usuarioId, LocalDate inicio, LocalDate fin);
 
-    List<Hito> findByUsuarioIdAndTituloContainingIgnoreCaseOrderByFechaDesc(Long usuarioId, String titulo);
+    List<Hito> findByUsuarioIdAndTituloContainingIgnoreCaseAndEliminadoFalseOrderByFechaDesc(Long usuarioId, String titulo);
 }

--- a/api-hitos/src/main/java/com/babytrackmaster/api_hitos/service/impl/HitoServiceImpl.java
+++ b/api-hitos/src/main/java/com/babytrackmaster/api_hitos/service/impl/HitoServiceImpl.java
@@ -43,7 +43,7 @@ public class HitoServiceImpl implements HitoService {
     }
 
     public HitoResponse actualizar(Long usuarioId, Long id, HitoRequest req) {
-        Hito h = repository.findFirstByIdAndUsuarioId(id, usuarioId);
+        Hito h = repository.findFirstByIdAndUsuarioIdAndEliminadoFalse(id, usuarioId);
         if (h == null) {
             throw new NotFoundException("Hito no encontrado");
         }
@@ -69,8 +69,9 @@ public class HitoServiceImpl implements HitoService {
     }
 
     public void eliminar(Long usuarioId, Long id) {
-    	Hito h = getOwned(usuarioId, id);
-        repository.delete(h);
+        Hito h = getOwned(usuarioId, id);
+        h.setEliminado(true);
+        repository.save(h);
     }
     
     @Transactional(readOnly = true)
@@ -81,13 +82,13 @@ public class HitoServiceImpl implements HitoService {
 
     @Transactional(readOnly = true)
     public List<HitoResponse> listar(Long usuarioId) {
-        List<Hito> lista = repository.findByUsuarioIdOrderByFechaDesc(usuarioId);
+        List<Hito> lista = repository.findByUsuarioIdAndEliminadoFalseOrderByFechaDesc(usuarioId);
         return mapList(lista);
     }
 
     @Transactional(readOnly = true)
     public List<HitoResponse> listarPorBebe(Long usuarioId, Long bebeId) {
-        List<Hito> lista = repository.findByUsuarioIdAndBebeIdOrderByFechaDesc(usuarioId, bebeId);
+        List<Hito> lista = repository.findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaDesc(usuarioId, bebeId);
         return mapList(lista);
     }
 
@@ -95,13 +96,13 @@ public class HitoServiceImpl implements HitoService {
     public List<HitoResponse> listarPorMes(Long usuarioId, YearMonth mes) {
         LocalDate inicio = mes.atDay(1);
         LocalDate fin = mes.atEndOfMonth();
-        List<Hito> lista = repository.findByUsuarioIdAndFechaBetweenOrderByFechaDesc(usuarioId, inicio, fin);
+        List<Hito> lista = repository.findByUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(usuarioId, inicio, fin);
         return mapList(lista);
     }
 
     @Transactional(readOnly = true)
     public List<HitoResponse> buscarPorTitulo(Long usuarioId, String texto) {
-        List<Hito> lista = repository.findByUsuarioIdAndTituloContainingIgnoreCaseOrderByFechaDesc(usuarioId, texto);
+        List<Hito> lista = repository.findByUsuarioIdAndTituloContainingIgnoreCaseAndEliminadoFalseOrderByFechaDesc(usuarioId, texto);
         return mapList(lista);
     }
 
@@ -117,7 +118,7 @@ public class HitoServiceImpl implements HitoService {
 //    }
     
     private Hito getOwned(Long usuarioId, Long id) {
-    	return repository.findByIdAndUsuarioId(id, usuarioId).orElseThrow(() -> {
+        return repository.findByIdAndUsuarioIdAndEliminadoFalse(id, usuarioId).orElseThrow(() -> {
             log.debug("Hito no encontrado o no pertenece al usuario. id={}, usuarioId={}", id, usuarioId);
             return new NotFoundException("Hito no encontrado");
         });

--- a/api-hitos/src/test/java/com/babytrackmaster/api_hitos/repository/HitoRepositoryTest.java
+++ b/api-hitos/src/test/java/com/babytrackmaster/api_hitos/repository/HitoRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.babytrackmaster.api_hitos.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.babytrackmaster.api_hitos.entity.Hito;
+
+@DataJpaTest
+class HitoRepositoryTest {
+
+    @Autowired
+    private HitoRepository repository;
+
+    @Test
+    void softDeletedHitosAreExcludedFromQueries() {
+        Hito activo = new Hito();
+        activo.setUsuarioId(1L);
+        activo.setBebeId(1L);
+        activo.setTitulo("hito1");
+        activo.setFecha(LocalDate.now());
+        activo.setDescripcion("desc");
+        repository.save(activo);
+
+        Hito eliminado = new Hito();
+        eliminado.setUsuarioId(1L);
+        eliminado.setBebeId(1L);
+        eliminado.setTitulo("hito2");
+        eliminado.setFecha(LocalDate.now());
+        eliminado.setDescripcion("desc");
+        eliminado.setEliminado(true);
+        repository.save(eliminado);
+
+        List<Hito> lista = repository.findByUsuarioIdAndEliminadoFalseOrderByFechaDesc(1L);
+
+        assertEquals(1, lista.size());
+        assertEquals("hito1", lista.get(0).getTitulo());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `eliminado` flag to `Hito` entity for soft deletes
- filter repository queries by `eliminado=false`
- update service to mark milestones as deleted and ignore them in listings
- add repository test for soft delete behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6bf5f108327a8ba830becf08bd9