### PR TITLE
Implement soft delete for gastos

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/entity/Gasto.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/entity/Gasto.java
@@ -40,9 +40,15 @@ public class Gasto {
     @Column(name="actualizado_en")
     private LocalDateTime actualizadoEn;
 
+    @Column(nullable = false)
+    private Boolean eliminado = Boolean.FALSE;
+
     @PrePersist
     public void prePersist() {
         this.creadoEn = LocalDateTime.now();
+        if (this.eliminado == null) {
+            this.eliminado = Boolean.FALSE;
+        }
     }
 
     @PreUpdate

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/repository/GastoRepository.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/repository/GastoRepository.java
@@ -14,33 +14,33 @@ import com.babytrackmaster.api_gastos.entity.Gasto;
 
 public interface GastoRepository extends JpaRepository<Gasto, Long> {
 
-    @Query("select g from Gasto g where g.id = :id and g.usuarioId = :usuarioId")
+    @Query("select g from Gasto g where g.id = :id and g.usuarioId = :usuarioId and g.eliminado = false")
     Gasto findOneByIdAndUsuario(@Param("id") Long id, @Param("usuarioId") Long usuarioId);
 
-    @Query("select g from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta")
+    @Query("select g from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta and g.eliminado = false")
     Page<Gasto> findByUsuarioAndFechaBetween(@Param("usuarioId") Long usuarioId,
                                              @Param("desde") LocalDate desde,
                                              @Param("hasta") LocalDate hasta,
                                              Pageable pageable);
 
-    @Query("select g from Gasto g where g.usuarioId = :usuarioId and g.categoria.id = :categoriaId")
+    @Query("select g from Gasto g where g.usuarioId = :usuarioId and g.categoria.id = :categoriaId and g.eliminado = false")
     Page<Gasto> findByUsuarioAndCategoria(@Param("usuarioId") Long usuarioId,
                                           @Param("categoriaId") Long categoriaId,
                                           Pageable pageable);
 
-    @Query("select coalesce(sum(g.cantidad), 0) from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta")
+    @Query("select coalesce(sum(g.cantidad), 0) from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta and g.eliminado = false")
     BigDecimal sumTotalMes(@Param("usuarioId") Long usuarioId,
                            @Param("desde") LocalDate desde,
                            @Param("hasta") LocalDate hasta);
 
     @Query("select g.categoria.id, g.categoria.nombre, coalesce(sum(g.cantidad),0) " +
-           "from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta " +
+           "from Gasto g where g.usuarioId = :usuarioId and g.fecha between :desde and :hasta and g.eliminado = false " +
            "group by g.categoria.id, g.categoria.nombre order by g.categoria.nombre asc")
     List<Object[]> sumPorCategoriaDelMes(@Param("usuarioId") Long usuarioId,
                                          @Param("desde") LocalDate desde,
                                          @Param("hasta") LocalDate hasta);
-    
-    Page<Gasto> findByUsuarioIdAndFechaBetweenOrderByFechaDesc(Long usuarioId,
+
+    Page<Gasto> findByUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(Long usuarioId,
             LocalDate desde,
             LocalDate hasta,
             Pageable pageable);

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/GastoServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/GastoServiceImpl.java
@@ -88,7 +88,8 @@ public class GastoServiceImpl implements GastoService {
         if (g == null) {
             throw new NotFoundException("Gasto no encontrado");
         }
-        gastoRepository.delete(g);
+        g.setEliminado(true);
+        gastoRepository.save(g);
     }
 
     @Transactional(readOnly = true)
@@ -106,7 +107,7 @@ public class GastoServiceImpl implements GastoService {
         LocalDate desde = ym.atDay(1);
         LocalDate hasta = ym.atEndOfMonth();
 
-        Page<Gasto> page = gastoRepository.findByUsuarioIdAndFechaBetweenOrderByFechaDesc(
+        Page<Gasto> page = gastoRepository.findByUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(
                 usuarioId, desde, hasta, pageable
         );
 
@@ -122,7 +123,7 @@ public class GastoServiceImpl implements GastoService {
 
     @Transactional(readOnly = true)
     public Page<GastoResponse> listarPorCategoria(Long usuarioId, Long categoriaId, Pageable pageable) {
-        Page<Gasto> page = gastoRepository.findByUsuarioIdAndFechaBetweenOrderByFechaDesc(usuarioId, null, null, pageable);
+        Page<Gasto> page = gastoRepository.findByUsuarioAndCategoria(usuarioId, categoriaId, pageable);
 
         List<GastoResponse> dtos = new ArrayList<GastoResponse>();
         List<Gasto> content = page.getContent();

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/GastoRepositoryTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/GastoRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.babytrackmaster.api_gastos;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
+import com.babytrackmaster.api_gastos.entity.Gasto;
+import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
+import com.babytrackmaster.api_gastos.repository.GastoRepository;
+
+@DataJpaTest
+class GastoRepositoryTest {
+
+    @Autowired
+    private GastoRepository gastoRepository;
+
+    @Autowired
+    private CategoriaGastoRepository categoriaRepository;
+
+    @Test
+    void shouldExcludeDeletedGastosFromQueries() {
+        CategoriaGasto categoria = new CategoriaGasto();
+        categoria.setNombre("Test");
+        categoria = categoriaRepository.save(categoria);
+
+        LocalDate today = LocalDate.now();
+
+        Gasto activo = new Gasto();
+        activo.setUsuarioId(1L);
+        activo.setCategoria(categoria);
+        activo.setCantidad(new BigDecimal("100.00"));
+        activo.setFecha(today);
+        gastoRepository.save(activo);
+
+        Gasto eliminado = new Gasto();
+        eliminado.setUsuarioId(1L);
+        eliminado.setCategoria(categoria);
+        eliminado.setCantidad(new BigDecimal("50.00"));
+        eliminado.setFecha(today);
+        eliminado.setEliminado(true);
+        gastoRepository.save(eliminado);
+
+        assertNotNull(gastoRepository.findOneByIdAndUsuario(activo.getId(), 1L));
+        assertNull(gastoRepository.findOneByIdAndUsuario(eliminado.getId(), 1L));
+
+        Page<Gasto> page = gastoRepository
+                .findByUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(1L,
+                        today.minusDays(1), today.plusDays(1), PageRequest.of(0, 10));
+        assertEquals(1, page.getTotalElements());
+        assertEquals(activo.getId(), page.getContent().get(0).getId());
+
+        BigDecimal total = gastoRepository.sumTotalMes(1L, today.withDayOfMonth(1),
+                today.withDayOfMonth(today.lengthOfMonth()));
+        assertEquals(new BigDecimal("100.00"), total);
+
+        List<Object[]> rows = gastoRepository.sumPorCategoriaDelMes(1L, today.withDayOfMonth(1),
+                today.withDayOfMonth(today.lengthOfMonth()));
+        assertEquals(1, rows.size());
+        assertEquals(categoria.getId(), ((Number) rows.get(0)[0]).longValue());
+        assertEquals(new BigDecimal("100.00"), rows.get(0)[2]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `eliminado` flag to `Gasto` entity
- Filter repository queries to ignore soft-deleted expenses and adjust listings
- Use soft delete in service and add repository tests

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6d37adc83278361242ad45c6d85