### PR TITLE
feat: add category creation endpoint

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
@@ -1,0 +1,39 @@
+package com.babytrackmaster.api_gastos.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.security.JwtService;
+import com.babytrackmaster.api_gastos.service.CategoriaService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/categorias")
+@RequiredArgsConstructor
+@Tag(name = "Categorias", description = "Gestión de categorías de gasto")
+public class CategoriaController {
+
+    private final CategoriaService categoriaService;
+    private final JwtService jwtService;
+
+    @Operation(summary = "Crear una categoría", description = "Crea una nueva categoría de gasto")
+    @PostMapping
+    public ResponseEntity<CategoriaResponse> crear(@Valid @RequestBody CategoriaCreateRequest req) {
+        Long userId = jwtService.resolveUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CategoriaResponse resp = categoriaService.crear(req);
+        return new ResponseEntity<CategoriaResponse>(resp, HttpStatus.CREATED);
+    }
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaCreateRequest.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaCreateRequest.java
@@ -1,0 +1,13 @@
+package com.babytrackmaster.api_gastos.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+@Schema(name = "CategoriaCreateRequest", description = "Datos para crear una categoría de gasto")
+public class CategoriaCreateRequest {
+    @NotBlank
+    @Schema(example = "Pañales", description = "Nombre de la categoría")
+    private String nombre;
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaResponse.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaResponse.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_gastos.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(name = "CategoriaResponse", description = "Representación de una categoría de gasto")
+public class CategoriaResponse {
+    @Schema(example = "1")
+    private Long id;
+
+    @Schema(example = "Pañales")
+    private String nombre;
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/mapper/CategoriaMapper.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/mapper/CategoriaMapper.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_gastos.mapper;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
+
+public class CategoriaMapper {
+
+    public static CategoriaResponse toResponse(CategoriaGasto c) {
+        CategoriaResponse dto = new CategoriaResponse();
+        dto.setId(c.getId());
+        dto.setNombre(c.getNombre());
+        return dto;
+    }
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_gastos.service;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+
+public interface CategoriaService {
+    CategoriaResponse crear(CategoriaCreateRequest req);
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
@@ -1,0 +1,29 @@
+package com.babytrackmaster.api_gastos.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
+import com.babytrackmaster.api_gastos.mapper.CategoriaMapper;
+import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
+import com.babytrackmaster.api_gastos.service.CategoriaService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategoriaServiceImpl implements CategoriaService {
+
+    private final CategoriaGastoRepository categoriaRepository;
+
+    @Override
+    public CategoriaResponse crear(CategoriaCreateRequest req) {
+        CategoriaGasto c = new CategoriaGasto();
+        c.setNombre(req.getNombre());
+        c = categoriaRepository.save(c);
+        return CategoriaMapper.toResponse(c);
+    }
+}

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -1,0 +1,45 @@
+package com.babytrackmaster.api_gastos.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.security.JwtService;
+import com.babytrackmaster.api_gastos.service.CategoriaService;
+
+@WebMvcTest(CategoriaController.class)
+class CategoriaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoriaService categoriaService;
+
+    @MockBean
+    private JwtService jwtService;
+
+    @Test
+    void crearRetornaCreated() throws Exception {
+        CategoriaResponse resp = new CategoriaResponse();
+        resp.setId(1L);
+        resp.setNombre("Ropa");
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.crear(Mockito.any())).thenReturn(resp);
+
+        mockMvc.perform(post("/api/v1/categorias")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nombre\":\"Ropa\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+}

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
@@ -1,0 +1,44 @@
+package com.babytrackmaster.api_gastos.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
+import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
+import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
+import com.babytrackmaster.api_gastos.service.impl.CategoriaServiceImpl;
+
+class CategoriaServiceTest {
+
+    private CategoriaGastoRepository categoriaRepository;
+    private CategoriaService categoriaService;
+
+    @BeforeEach
+    void setUp() {
+        categoriaRepository = Mockito.mock(CategoriaGastoRepository.class);
+        categoriaService = new CategoriaServiceImpl(categoriaRepository);
+    }
+
+    @Test
+    void crearCategoriaPersisteYDevuelveDTO() {
+        CategoriaCreateRequest req = new CategoriaCreateRequest();
+        req.setNombre("Lactancia");
+
+        CategoriaGasto guardada = new CategoriaGasto();
+        guardada.setId(10L);
+        guardada.setNombre("Lactancia");
+        when(categoriaRepository.save(any(CategoriaGasto.class))).thenReturn(guardada);
+
+        CategoriaResponse resp = categoriaService.crear(req);
+
+        assertNotNull(resp);
+        assertEquals(10L, resp.getId());
+        assertEquals("Lactancia", resp.getNombre());
+        verify(categoriaRepository).save(any(CategoriaGasto.class));
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs and mapper for expense categories
- implement category service and POST controller
- cover category logic with unit and MVC tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afad9328fc832780db0c1c473bb920