### PR TITLE
feat(gastos): agregar actualizacion de categorias

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
@@ -2,13 +2,11 @@ package com.babytrackmaster.api_gastos.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.dto.CategoriaUpdateRequest;
 import com.babytrackmaster.api_gastos.security.JwtService;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
 
@@ -35,5 +33,17 @@ public class CategoriaController {
         }
         CategoriaResponse resp = categoriaService.crear(req);
         return new ResponseEntity<CategoriaResponse>(resp, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Actualizar una categoría", description = "Actualiza una categoría de gasto existente")
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoriaResponse> actualizar(@PathVariable Long id,
+            @Valid @RequestBody CategoriaUpdateRequest req) {
+        Long userId = jwtService.resolveUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CategoriaResponse resp = categoriaService.actualizar(id, req);
+        return ResponseEntity.ok(resp);
     }
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaUpdateRequest.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/dto/CategoriaUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.babytrackmaster.api_gastos.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+@Schema(name = "CategoriaUpdateRequest", description = "Datos para actualizar una categoría de gasto")
+public class CategoriaUpdateRequest {
+    @NotBlank
+    @Schema(example = "Pañales", description = "Nombre de la categoría")
+    private String nombre;
+}

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
@@ -2,7 +2,10 @@ package com.babytrackmaster.api_gastos.service;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.dto.CategoriaUpdateRequest;
 
 public interface CategoriaService {
     CategoriaResponse crear(CategoriaCreateRequest req);
+
+    CategoriaResponse actualizar(Long id, CategoriaUpdateRequest req);
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
@@ -5,10 +5,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.dto.CategoriaUpdateRequest;
 import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.mapper.CategoriaMapper;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,5 +27,16 @@ public class CategoriaServiceImpl implements CategoriaService {
         c.setNombre(req.getNombre());
         c = categoriaRepository.save(c);
         return CategoriaMapper.toResponse(c);
+    }
+
+    @Override
+    public CategoriaResponse actualizar(Long id, CategoriaUpdateRequest req) {
+        CategoriaGasto existente = categoriaRepository.findOneById(id);
+        if (existente == null) {
+            throw new NotFoundException("Categoría no encontrada");
+        }
+        existente.setNombre(req.getNombre());
+        existente = categoriaRepository.save(existente);
+        return CategoriaMapper.toResponse(existente);
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -1,6 +1,7 @@
 package com.babytrackmaster.api_gastos.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 import com.babytrackmaster.api_gastos.security.JwtService;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 @WebMvcTest(CategoriaController.class)
 class CategoriaControllerTest {
@@ -41,5 +43,33 @@ class CategoriaControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+
+    @Test
+    void actualizarRetornaOk() throws Exception {
+        CategoriaResponse resp = new CategoriaResponse();
+        resp.setId(2L);
+        resp.setNombre("Comida");
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.actualizar(Mockito.eq(2L), Mockito.any())).thenReturn(resp);
+
+        mockMvc.perform(put("/api/v1/categorias/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nombre\":\"Comida\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(2L))
+            .andExpect(jsonPath("$.nombre").value("Comida"));
+    }
+
+    @Test
+    void actualizarNoEncontradaRetorna404() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.actualizar(Mockito.eq(99L), Mockito.any()))
+                .thenThrow(new NotFoundException("Categoría no encontrada"));
+
+        mockMvc.perform(put("/api/v1/categorias/99")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nombre\":\"X\"}"))
+            .andExpect(status().isNotFound());
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
@@ -9,9 +9,11 @@ import org.mockito.Mockito;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.dto.CategoriaUpdateRequest;
 import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.impl.CategoriaServiceImpl;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 class CategoriaServiceTest {
 
@@ -40,5 +42,36 @@ class CategoriaServiceTest {
         assertEquals(10L, resp.getId());
         assertEquals("Lactancia", resp.getNombre());
         verify(categoriaRepository).save(any(CategoriaGasto.class));
+    }
+
+    @Test
+    void actualizarCategoriaActualizaNombre() {
+        CategoriaUpdateRequest req = new CategoriaUpdateRequest();
+        req.setNombre("Ropa");
+
+        CategoriaGasto existente = new CategoriaGasto();
+        existente.setId(5L);
+        existente.setNombre("Pañales");
+
+        when(categoriaRepository.findOneById(5L)).thenReturn(existente);
+        when(categoriaRepository.save(any(CategoriaGasto.class))).thenReturn(existente);
+
+        CategoriaResponse resp = categoriaService.actualizar(5L, req);
+
+        assertNotNull(resp);
+        assertEquals(5L, resp.getId());
+        assertEquals("Ropa", resp.getNombre());
+        verify(categoriaRepository).findOneById(5L);
+        verify(categoriaRepository).save(existente);
+    }
+
+    @Test
+    void actualizarCategoriaNoEncontradaLanzaExcepcion() {
+        CategoriaUpdateRequest req = new CategoriaUpdateRequest();
+        req.setNombre("Ropa");
+
+        when(categoriaRepository.findOneById(99L)).thenReturn(null);
+
+        assertThrows(NotFoundException.class, () -> categoriaService.actualizar(99L, req));
     }
 }


### PR DESCRIPTION
## Summary
- add CategoriaUpdateRequest and update endpoint
- implement update logic with NotFound handling
- cover service and controller updates with tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68afb08291b08327b24ad5492fdddcbb