### PR TITLE
feat(gastos): add category deletion endpoint

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
@@ -3,6 +3,8 @@ package com.babytrackmaster.api_gastos.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +37,16 @@ public class CategoriaController {
         }
         CategoriaResponse resp = categoriaService.crear(req);
         return new ResponseEntity<CategoriaResponse>(resp, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Eliminar una categoría", description = "Elimina una categoría de gasto")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        Long userId = jwtService.resolveUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        categoriaService.eliminar(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
@@ -5,4 +5,5 @@ import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 
 public interface CategoriaService {
     CategoriaResponse crear(CategoriaCreateRequest req);
+    void eliminar(Long id);
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
@@ -9,6 +9,7 @@ import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.mapper.CategoriaMapper;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,5 +26,14 @@ public class CategoriaServiceImpl implements CategoriaService {
         c.setNombre(req.getNombre());
         c = categoriaRepository.save(c);
         return CategoriaMapper.toResponse(c);
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        CategoriaGasto categoria = categoriaRepository.findOneById(id);
+        if (categoria == null) {
+            throw new NotFoundException("Categoría no encontrada");
+        }
+        categoriaRepository.delete(categoria);
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -1,6 +1,7 @@
 package com.babytrackmaster.api_gastos.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 import com.babytrackmaster.api_gastos.security.JwtService;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 @WebMvcTest(CategoriaController.class)
 class CategoriaControllerTest {
@@ -41,5 +43,24 @@ class CategoriaControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+
+    @Test
+    void eliminarRetornaNoContent() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+
+        mockMvc.perform(delete("/api/v1/categorias/1"))
+            .andExpect(status().isNoContent());
+
+        Mockito.verify(categoriaService).eliminar(1L);
+    }
+
+    @Test
+    void eliminarCategoriaNoExisteRetornaNotFound() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.doThrow(new NotFoundException("no encontrada")).when(categoriaService).eliminar(1L);
+
+        mockMvc.perform(delete("/api/v1/categorias/1"))
+            .andExpect(status().isNotFound());
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
@@ -12,6 +12,7 @@ import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.impl.CategoriaServiceImpl;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 class CategoriaServiceTest {
 
@@ -40,5 +41,23 @@ class CategoriaServiceTest {
         assertEquals(10L, resp.getId());
         assertEquals("Lactancia", resp.getNombre());
         verify(categoriaRepository).save(any(CategoriaGasto.class));
+    }
+
+    @Test
+    void eliminarCategoriaExistenteLlamaDelete() {
+        CategoriaGasto categoria = new CategoriaGasto();
+        categoria.setId(5L);
+        when(categoriaRepository.findOneById(5L)).thenReturn(categoria);
+
+        categoriaService.eliminar(5L);
+
+        verify(categoriaRepository).delete(categoria);
+    }
+
+    @Test
+    void eliminarCategoriaNoExistenteLanzaNotFound() {
+        when(categoriaRepository.findOneById(5L)).thenReturn(null);
+
+        assertThrows(NotFoundException.class, () -> categoriaService.eliminar(5L));
     }
 }


### PR DESCRIPTION
## Summary
- add `eliminar` method to `CategoriaService` and implement repository deletion
- expose DELETE `/api/v1/categorias/{id}` endpoint with JWT authentication
- test category deletion success and not-found scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afb084ee9c83279cef70aea8f9239c