### PR TITLE
Add category retrieval endpoint

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
@@ -2,10 +2,7 @@ package com.babytrackmaster.api_gastos.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
@@ -35,5 +32,16 @@ public class CategoriaController {
         }
         CategoriaResponse resp = categoriaService.crear(req);
         return new ResponseEntity<CategoriaResponse>(resp, HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Obtener una categoría", description = "Devuelve una categoría de gasto por su ID")
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoriaResponse> obtener(@PathVariable Long id) {
+        Long userId = jwtService.resolveUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        CategoriaResponse resp = categoriaService.obtener(id);
+        return ResponseEntity.ok(resp);
     }
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
@@ -5,4 +5,5 @@ import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 
 public interface CategoriaService {
     CategoriaResponse crear(CategoriaCreateRequest req);
+    CategoriaResponse obtener(Long id);
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
@@ -7,6 +7,7 @@ import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.mapper.CategoriaMapper;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
 
@@ -24,6 +25,15 @@ public class CategoriaServiceImpl implements CategoriaService {
         CategoriaGasto c = new CategoriaGasto();
         c.setNombre(req.getNombre());
         c = categoriaRepository.save(c);
+        return CategoriaMapper.toResponse(c);
+    }
+
+    @Override
+    public CategoriaResponse obtener(Long id) {
+        CategoriaGasto c = categoriaRepository.findOneById(id);
+        if (c == null) {
+            throw new NotFoundException("Categoría no encontrada");
+        }
         return CategoriaMapper.toResponse(c);
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -1,6 +1,6 @@
 package com.babytrackmaster.api_gastos.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 import com.babytrackmaster.api_gastos.security.JwtService;
 import com.babytrackmaster.api_gastos.service.CategoriaService;
 
@@ -41,5 +42,28 @@ class CategoriaControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+
+    @Test
+    void obtenerRetornaOk() throws Exception {
+        CategoriaResponse resp = new CategoriaResponse();
+        resp.setId(1L);
+        resp.setNombre("Ropa");
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.obtener(1L)).thenReturn(resp);
+
+        mockMvc.perform(get("/api/v1/categorias/1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+
+    @Test
+    void obtenerNoExistenteRetornaNotFound() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.obtener(1L)).thenThrow(new NotFoundException("Categoría no encontrada"));
+
+        mockMvc.perform(get("/api/v1/categorias/1"))
+            .andExpect(status().isNotFound());
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
@@ -12,6 +12,7 @@ import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 import com.babytrackmaster.api_gastos.entity.CategoriaGasto;
 import com.babytrackmaster.api_gastos.repository.CategoriaGastoRepository;
 import com.babytrackmaster.api_gastos.service.impl.CategoriaServiceImpl;
+import com.babytrackmaster.api_gastos.exception.NotFoundException;
 
 class CategoriaServiceTest {
 
@@ -40,5 +41,28 @@ class CategoriaServiceTest {
         assertEquals(10L, resp.getId());
         assertEquals("Lactancia", resp.getNombre());
         verify(categoriaRepository).save(any(CategoriaGasto.class));
+    }
+
+    @Test
+    void obtenerExistenteDevuelveDTO() {
+        CategoriaGasto categoria = new CategoriaGasto();
+        categoria.setId(5L);
+        categoria.setNombre("Ropa");
+        when(categoriaRepository.findOneById(5L)).thenReturn(categoria);
+
+        CategoriaResponse resp = categoriaService.obtener(5L);
+
+        assertNotNull(resp);
+        assertEquals(5L, resp.getId());
+        assertEquals("Ropa", resp.getNombre());
+        verify(categoriaRepository).findOneById(5L);
+    }
+
+    @Test
+    void obtenerNoExistenteLanzaNotFound() {
+        when(categoriaRepository.findOneById(99L)).thenReturn(null);
+
+        assertThrows(NotFoundException.class, () -> categoriaService.obtener(99L));
+        verify(categoriaRepository).findOneById(99L);
     }
 }


### PR DESCRIPTION
## Summary
- expose `obtener` in CategoriaService and implementation using `findOneById`
- add `GET /api/v1/categorias/{id}` endpoint secured via JwtService and documented with OpenAPI
- expand unit tests for service and controller covering success and `NotFound` cases

## Testing
- `sh ./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68afb0879ac4832789f5d40153d727f5