### PR TITLE
feat: listar categorias

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/CategoriaController.java
@@ -1,7 +1,10 @@
 package com.babytrackmaster.api_gastos.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +28,17 @@ public class CategoriaController {
 
     private final CategoriaService categoriaService;
     private final JwtService jwtService;
+
+    @Operation(summary = "Listar categorías", description = "Obtiene la lista de categorías ordenadas por nombre")
+    @GetMapping
+    public ResponseEntity<List<CategoriaResponse>> listar() {
+        Long userId = jwtService.resolveUserId();
+        if (userId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        List<CategoriaResponse> resp = categoriaService.listar();
+        return ResponseEntity.ok(resp);
+    }
 
     @Operation(summary = "Crear una categoría", description = "Crea una nueva categoría de gasto")
     @PostMapping

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/CategoriaService.java
@@ -1,8 +1,11 @@
 package com.babytrackmaster.api_gastos.service;
 
+import java.util.List;
+
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
 
 public interface CategoriaService {
     CategoriaResponse crear(CategoriaCreateRequest req);
+    List<CategoriaResponse> listar();
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/CategoriaServiceImpl.java
@@ -1,5 +1,9 @@
 package com.babytrackmaster.api_gastos.service.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,5 +29,18 @@ public class CategoriaServiceImpl implements CategoriaService {
         c.setNombre(req.getNombre());
         c = categoriaRepository.save(c);
         return CategoriaMapper.toResponse(c);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CategoriaResponse> listar() {
+        List<CategoriaGasto> categorias = categoriaRepository.findAll(Sort.by("nombre"));
+        List<CategoriaResponse> dtos = new ArrayList<CategoriaResponse>();
+        int i = 0;
+        while (i < categorias.size()) {
+            dtos.add(CategoriaMapper.toResponse(categorias.get(i)));
+            i++;
+        }
+        return dtos;
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -1,7 +1,10 @@
 package com.babytrackmaster.api_gastos.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,5 +44,30 @@ class CategoriaControllerTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").value(1L))
             .andExpect(jsonPath("$.nombre").value("Ropa"));
+    }
+
+    @Test
+    void listarRetornaListaOrdenada() throws Exception {
+        CategoriaResponse c1 = new CategoriaResponse();
+        c1.setId(1L);
+        c1.setNombre("Agua");
+        CategoriaResponse c2 = new CategoriaResponse();
+        c2.setId(2L);
+        c2.setNombre("Comida");
+        Mockito.when(jwtService.resolveUserId()).thenReturn(1L);
+        Mockito.when(categoriaService.listar()).thenReturn(Arrays.asList(c1, c2));
+
+        mockMvc.perform(get("/api/v1/categorias"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].nombre").value("Agua"))
+            .andExpect(jsonPath("$[1].nombre").value("Comida"));
+    }
+
+    @Test
+    void listarSinAutenticacionRetorna401() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(null);
+
+        mockMvc.perform(get("/api/v1/categorias"))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/service/CategoriaServiceTest.java
@@ -3,9 +3,14 @@ package com.babytrackmaster.api_gastos.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Sort;
 
 import com.babytrackmaster.api_gastos.dto.CategoriaCreateRequest;
 import com.babytrackmaster.api_gastos.dto.CategoriaResponse;
@@ -40,5 +45,33 @@ class CategoriaServiceTest {
         assertEquals(10L, resp.getId());
         assertEquals("Lactancia", resp.getNombre());
         verify(categoriaRepository).save(any(CategoriaGasto.class));
+    }
+
+    @Test
+    void listarCategoriasOrdenadas() {
+        CategoriaGasto c1 = new CategoriaGasto();
+        c1.setId(1L);
+        c1.setNombre("Bebidas");
+        CategoriaGasto c2 = new CategoriaGasto();
+        c2.setId(2L);
+        c2.setNombre("Alimentos");
+
+        when(categoriaRepository.findAll(any(Sort.class))).thenAnswer(invocation -> {
+            List<CategoriaGasto> list = new ArrayList<CategoriaGasto>();
+            list.add(c1);
+            list.add(c2);
+            list.sort((a, b) -> a.getNombre().compareTo(b.getNombre()));
+            return list;
+        });
+
+        List<CategoriaResponse> resp = categoriaService.listar();
+
+        assertEquals(2, resp.size());
+        assertEquals("Alimentos", resp.get(0).getNombre());
+        assertEquals("Bebidas", resp.get(1).getNombre());
+
+        ArgumentCaptor<Sort> captor = ArgumentCaptor.forClass(Sort.class);
+        verify(categoriaRepository).findAll(captor.capture());
+        assertEquals("nombre", captor.getValue().iterator().next().getProperty());
     }
 }


### PR DESCRIPTION
## Summary
- add listar to CategoriaService and implement sorted retrieval in service impl
- expose authenticated GET endpoint to list categories
- cover category listing and auth with unit tests

## Testing
- `sh ./mvnw -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afb08aebc88327ba91481b15865e47