### PR TITLE
Implement logical user deletion and secure endpoint

### DIFF
--- a/api-usuarios/src/main/java/controller/UserController.java
+++ b/api-usuarios/src/main/java/controller/UserController.java
@@ -1,10 +1,9 @@
 package controller;
 
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import entity.Usuario;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,5 +24,11 @@ public class UserController {
     public Usuario me(Authentication auth) {
         // auth.getName() = email (por UserDetailsService)
         return usuarioService.buscarPorEmail(auth.getName());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        usuarioService.eliminarLogicamente(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/api-usuarios/src/main/java/entity/Usuario.java
+++ b/api-usuarios/src/main/java/entity/Usuario.java
@@ -44,4 +44,7 @@ public class Usuario {
 
     @Column(nullable = false)
     private LocalDateTime fechaAlta;
+
+    @Column(name = "fecha_baja")
+    private LocalDateTime fechaBaja;
 }

--- a/api-usuarios/src/main/java/repository/UsuarioRepository.java
+++ b/api-usuarios/src/main/java/repository/UsuarioRepository.java
@@ -8,10 +8,11 @@ import entity.Usuario;
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     Usuario findByEmail(String email);
+    Usuario findByEmailAndHabilitadoTrue(String email);
     boolean existsByEmail(String email);
     Usuario findFirstByEmail(String email);
     Usuario findFirstByNombre(String nombre);
-    
- // Útil cuando no sabes si viene email o nombre:
+
+    // Útil cuando no sabes si viene email o nombre:
     Usuario findFirstByEmailOrNombre(String email, String nombre);
 }

--- a/api-usuarios/src/main/java/security/CustomUserDetailsService.java
+++ b/api-usuarios/src/main/java/security/CustomUserDetailsService.java
@@ -21,7 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private UsuarioRepository usuarioRepository;
 
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Usuario u = usuarioRepository.findByEmail(username);
+        Usuario u = usuarioRepository.findByEmailAndHabilitadoTrue(username);
         if (u == null) {
             throw new UsernameNotFoundException("Usuario no encontrado: " + username);
         }

--- a/api-usuarios/src/main/java/service/UsuarioService.java
+++ b/api-usuarios/src/main/java/service/UsuarioService.java
@@ -54,4 +54,13 @@ public class UsuarioService {
     public Usuario buscarPorEmail(String email) {
         return usuarioRepository.findByEmail(email);
     }
+
+    @Transactional
+    public void eliminarLogicamente(Long id) {
+        Usuario u = usuarioRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario no encontrado: " + id));
+        u.setHabilitado(false);
+        u.setFechaBaja(LocalDateTime.now());
+        usuarioRepository.save(u);
+    }
 }

--- a/api-usuarios/src/test/java/com/babytrackmaster/api_usuarios/service/AuthServiceTest.java
+++ b/api-usuarios/src/test/java/com/babytrackmaster/api_usuarios/service/AuthServiceTest.java
@@ -43,7 +43,7 @@ public class AuthServiceTest {
 	}
 
 	@Test
-	public void login_correcto_invocaJwtServiceYDevuelveToken() {
+        public void login_correcto_invocaJwtServiceYDevuelveToken() {
 		LoginDTO dto = new LoginDTO();
 		dto.setEmail("david@test.com");
 		dto.setPassword("12345678");
@@ -63,6 +63,21 @@ public class AuthServiceTest {
 
 		Mockito.verify(usuarioRepository).findByEmail("david@test.com");
 		Mockito.verify(passwordEncoder, Mockito.atLeastOnce()).matches(Mockito.anyString(), Mockito.anyString());
-		Mockito.verify(jwtService).generarToken("david@test.com");
-	}
+                Mockito.verify(jwtService).generarToken("david@test.com");
+        }
+
+        @Test
+        public void login_usuarioDeshabilitado_lanzaExcepcion() {
+                LoginDTO dto = new LoginDTO();
+                dto.setEmail("david@test.com");
+                dto.setPassword("12345678");
+
+                usuario.setHabilitado(false);
+                Mockito.when(usuarioRepository.findByEmail("david@test.com")).thenReturn(usuario);
+
+                org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class,
+                        () -> authService.login(dto));
+
+                Mockito.verify(usuarioRepository).findByEmail("david@test.com");
+        }
 }

--- a/api-usuarios/src/test/java/com/babytrackmaster/api_usuarios/service/UsuarioServiceTest.java
+++ b/api-usuarios/src/test/java/com/babytrackmaster/api_usuarios/service/UsuarioServiceTest.java
@@ -1,0 +1,41 @@
+package com.babytrackmaster.api_usuarios.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import entity.Usuario;
+import repository.UsuarioRepository;
+import service.UsuarioService;
+
+public class UsuarioServiceTest {
+
+    private UsuarioRepository usuarioRepository;
+    private UsuarioService usuarioService;
+
+    @BeforeEach
+    public void setUp() {
+        usuarioRepository = mock(UsuarioRepository.class);
+        usuarioService = new UsuarioService(usuarioRepository, null, null);
+    }
+
+    @Test
+    public void eliminarLogicamente_desactivaUsuarioYRegistraFecha() {
+        Usuario usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setHabilitado(true);
+
+        when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuario));
+        when(usuarioRepository.save(any(Usuario.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        usuarioService.eliminarLogicamente(1L);
+
+        org.junit.jupiter.api.Assertions.assertFalse(usuario.isHabilitado());
+        org.junit.jupiter.api.Assertions.assertNotNull(usuario.getFechaBaja());
+        verify(usuarioRepository).save(usuario);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional `fechaBaja` to `Usuario` entity
- implement service and controller logic for logical deletion
- update repository and security to exclude disabled users
- add unit tests for deletion and authentication of disabled users

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b039987a788327955ab1c28074261c