### PR TITLE
feat: add TipoCuidado management

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/TipoCuidadoController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/TipoCuidadoController.java
@@ -1,0 +1,70 @@
+package com.babytrackmaster.api_cuidados.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoResponse;
+import com.babytrackmaster.api_cuidados.service.TipoCuidadoService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/tipos-cuidado")
+@Tag(name = "Tipos de cuidado", description = "Gestión de tipos de cuidado")
+public class TipoCuidadoController {
+
+    private final TipoCuidadoService service;
+
+    public TipoCuidadoController(TipoCuidadoService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Crear un tipo de cuidado")
+    @PostMapping
+    public ResponseEntity<TipoCuidadoResponse> crear(
+            @Valid @RequestBody TipoCuidadoRequest req) {
+        return new ResponseEntity<TipoCuidadoResponse>(service.crear(req), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Actualizar un tipo de cuidado")
+    @PutMapping("/{id}")
+    public ResponseEntity<TipoCuidadoResponse> actualizar(
+            @Parameter(description = "ID del tipo de cuidado", example = "1") @PathVariable Long id,
+            @Valid @RequestBody TipoCuidadoRequest req) {
+        return ResponseEntity.ok(service.actualizar(id, req));
+    }
+
+    @Operation(summary = "Eliminar un tipo de cuidado")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(
+            @Parameter(description = "ID del tipo de cuidado", example = "1") @PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Obtener un tipo de cuidado")
+    @GetMapping("/{id}")
+    public ResponseEntity<TipoCuidadoResponse> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtener(id));
+    }
+
+    @Operation(summary = "Listar tipos de cuidado")
+    @GetMapping
+    public ResponseEntity<List<TipoCuidadoResponse>> listar() {
+        return ResponseEntity.ok(service.listar());
+    }
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoCuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoCuidadoRequest.java
@@ -1,0 +1,15 @@
+package com.babytrackmaster.api_cuidados.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Schema(name = "TipoCuidadoRequest", description = "Datos para crear/actualizar un tipo de cuidado")
+public class TipoCuidadoRequest {
+    @NotBlank
+    @Size(min = 1, max = 60)
+    @Schema(example = "Alimentación", description = "Nombre del tipo de cuidado")
+    private String nombre;
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoCuidadoResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoCuidadoResponse.java
@@ -1,0 +1,19 @@
+package com.babytrackmaster.api_cuidados.dto;
+
+import java.util.Date;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(name = "TipoCuidadoResponse", description = "Representación de un tipo de cuidado")
+public class TipoCuidadoResponse {
+    @Schema(example = "1")
+    private Long id;
+
+    @Schema(example = "Alimentación")
+    private String nombre;
+
+    private Date createdAt;
+    private Date updatedAt;
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/TipoCuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/TipoCuidadoMapper.java
@@ -1,0 +1,33 @@
+package com.babytrackmaster.api_cuidados.mapper;
+
+import java.util.Date;
+
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoResponse;
+import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+
+public class TipoCuidadoMapper {
+
+    public static TipoCuidado toEntity(TipoCuidadoRequest req) {
+        TipoCuidado t = new TipoCuidado();
+        t.setNombre(req.getNombre());
+        Date now = new Date();
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return t;
+    }
+
+    public static void copyToEntity(TipoCuidadoRequest req, TipoCuidado t) {
+        t.setNombre(req.getNombre());
+        t.setUpdatedAt(new Date());
+    }
+
+    public static TipoCuidadoResponse toResponse(TipoCuidado t) {
+        TipoCuidadoResponse r = new TipoCuidadoResponse();
+        r.setId(t.getId());
+        r.setNombre(t.getNombre());
+        r.setCreatedAt(t.getCreatedAt());
+        r.setUpdatedAt(t.getUpdatedAt());
+        return r;
+    }
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/TipoCuidadoService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/TipoCuidadoService.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_cuidados.service;
+
+import java.util.List;
+
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoResponse;
+
+public interface TipoCuidadoService {
+    TipoCuidadoResponse crear(TipoCuidadoRequest request);
+    TipoCuidadoResponse actualizar(Long id, TipoCuidadoRequest request);
+    void eliminar(Long id);
+    TipoCuidadoResponse obtener(Long id);
+    List<TipoCuidadoResponse> listar();
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/TipoCuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/TipoCuidadoServiceImpl.java
@@ -1,0 +1,69 @@
+package com.babytrackmaster.api_cuidados.service.iml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoCuidadoResponse;
+import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.mapper.TipoCuidadoMapper;
+import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.service.TipoCuidadoService;
+
+@Service
+@Transactional
+public class TipoCuidadoServiceImpl implements TipoCuidadoService {
+
+    private final TipoCuidadoRepository repo;
+
+    public TipoCuidadoServiceImpl(TipoCuidadoRepository repo) {
+        this.repo = repo;
+    }
+
+    public TipoCuidadoResponse crear(TipoCuidadoRequest request) {
+        TipoCuidado t = TipoCuidadoMapper.toEntity(request);
+        t = repo.save(t);
+        return TipoCuidadoMapper.toResponse(t);
+    }
+
+    public TipoCuidadoResponse actualizar(Long id, TipoCuidadoRequest request) {
+        TipoCuidado t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de cuidado no encontrado: " + id);
+        }
+        TipoCuidadoMapper.copyToEntity(request, t);
+        t = repo.save(t);
+        return TipoCuidadoMapper.toResponse(t);
+    }
+
+    public void eliminar(Long id) {
+        TipoCuidado t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de cuidado no encontrado: " + id);
+        }
+        repo.delete(t);
+    }
+
+    @Transactional(readOnly = true)
+    public TipoCuidadoResponse obtener(Long id) {
+        TipoCuidado t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de cuidado no encontrado: " + id);
+        }
+        return TipoCuidadoMapper.toResponse(t);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TipoCuidadoResponse> listar() {
+        List<TipoCuidado> list = repo.findAll(Sort.by("nombre"));
+        List<TipoCuidadoResponse> resp = new ArrayList<TipoCuidadoResponse>();
+        for (int i = 0; i < list.size(); i++) {
+            resp.add(TipoCuidadoMapper.toResponse(list.get(i)));
+        }
+        return resp;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs for TipoCuidado with validation and response fields
- implement mapper, service and controller for TipoCuidado CRUD

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b04c45ae908327bd59e87cde76b8c0