### PR TITLE
refactor: replace tipo cita enum with entity

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
@@ -65,13 +65,13 @@ public class CitaController {
 		return ResponseEntity.ok(service.listarPorEstado(usuarioId, estado, page, size));
 	}
 
-	@Operation(summary = "Listar por tipo")
-	@GetMapping("/tipo/{tipo}")
-	public ResponseEntity<Page<CitaResponseDTO>> listarPorTipo(@PathVariable String tipo,
-			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-		Long usuarioId = jwtService.resolveUserId();
-		return ResponseEntity.ok(service.listarPorTipo(usuarioId, tipo, page, size));
-	}
+        @Operation(summary = "Listar por tipo")
+        @GetMapping("/tipo/{tipoId}")
+        public ResponseEntity<Page<CitaResponseDTO>> listarPorTipo(@PathVariable Long tipoId,
+                        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorTipo(usuarioId, tipoId, page, size));
+        }
 
 	@Operation(summary = "Listar por médico")
 	@GetMapping("/medico")

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
@@ -1,6 +1,5 @@
 package com.babytrackmaster.api_citas.dto;
 
-import com.babytrackmaster.api_citas.enums.TipoCita;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -37,9 +36,9 @@ public class CitaCreateDTO {
     @Size(max = 120)
     private String medico;
 
-    @Schema(example = "PEDIATRIA")
+    @Schema(example = "1")
     @NotNull
-    private TipoCita tipo;
+    private Long tipoId;
 
     @Schema(example = "30")
     private Integer recordatorioMinutos;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
@@ -1,6 +1,6 @@
 package com.babytrackmaster.api_citas.dto;
 
-import com.babytrackmaster.api_citas.enums.*;
+import com.babytrackmaster.api_citas.enums.EstadoCita;
 import lombok.*;
 
 @Getter @Setter @Builder
@@ -13,7 +13,7 @@ public class CitaResponseDTO {
     private String hora;  // HH:mm
     private String ubicacion;
     private String medico;
-    private TipoCita tipo;
+    private TipoCitaDTO tipo;
     private EstadoCita estado;
     private Integer recordatorioMinutos;
     private String creadoEn;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
@@ -1,7 +1,6 @@
 package com.babytrackmaster.api_citas.dto;
 
 import com.babytrackmaster.api_citas.enums.EstadoCita;
-import com.babytrackmaster.api_citas.enums.TipoCita;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
@@ -29,7 +28,7 @@ public class CitaUpdateDTO {
     @Size(max = 120)
     private String medico;
 
-    private TipoCita tipo;
+    private Long tipoId;
 
     private Integer recordatorioMinutos;
 

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaDTO.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_citas.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TipoCitaDTO {
+    private Long id;
+    private String nombre;
+}
+

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
@@ -5,19 +5,20 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import com.babytrackmaster.api_citas.enums.EstadoCita;
-import com.babytrackmaster.api_citas.enums.TipoCita;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -58,8 +59,8 @@ public class Cita {
     @Column(length = 120)
     private String medico;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @ManyToOne
+    @JoinColumn(name = "tipo", nullable = false)
     private TipoCita tipo;
 
     @Enumerated(EnumType.STRING)

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
@@ -1,0 +1,22 @@
+package com.babytrackmaster.api_citas.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "tipo_cita")
+public class TipoCita {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 100)
+    private String nombre;
+}
+

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/enums/TipoCita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/enums/TipoCita.java
@@ -1,5 +1,0 @@
-package com.babytrackmaster.api_citas.enums;
-
-public enum TipoCita {
-    PEDIATRIA, VACUNA, REVISION, PRUEBA, URGENCIA, OTRO
-}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
@@ -2,14 +2,15 @@ package com.babytrackmaster.api_citas.mapper;
 
 import com.babytrackmaster.api_citas.dto.*;
 import com.babytrackmaster.api_citas.entity.Cita;
-import com.babytrackmaster.api_citas.enums.*;
+import com.babytrackmaster.api_citas.entity.TipoCita;
+import com.babytrackmaster.api_citas.enums.EstadoCita;
 import java.time.*;
 
 public class CitaMapper {
 
     private CitaMapper() {}
 
-    public static Cita toEntity(CitaCreateDTO dto, Long usuarioId) {
+    public static Cita toEntity(CitaCreateDTO dto, Long usuarioId, TipoCita tipo) {
         Cita c = new Cita();
         c.setUsuarioId(usuarioId);
         c.setTitulo(dto.getTitulo());
@@ -18,21 +19,21 @@ public class CitaMapper {
         c.setHora(LocalTime.parse(dto.getHora()));
         c.setUbicacion(dto.getUbicacion());
         c.setMedico(dto.getMedico());
-        c.setTipo(dto.getTipo());
+        c.setTipo(tipo);
         c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
         c.setEstado(EstadoCita.PENDIENTE);
         c.setEliminado(Boolean.FALSE);
         return c;
     }
 
-    public static void applyUpdate(Cita c, CitaUpdateDTO dto) {
+    public static void applyUpdate(Cita c, CitaUpdateDTO dto, TipoCita tipo) {
         if (dto.getTitulo() != null) c.setTitulo(dto.getTitulo());
         if (dto.getDescripcion() != null) c.setDescripcion(dto.getDescripcion());
         if (dto.getFecha() != null) c.setFecha(LocalDate.parse(dto.getFecha()));
         if (dto.getHora() != null) c.setHora(LocalTime.parse(dto.getHora()));
         if (dto.getUbicacion() != null) c.setUbicacion(dto.getUbicacion());
         if (dto.getMedico() != null) c.setMedico(dto.getMedico());
-        if (dto.getTipo() != null) c.setTipo(dto.getTipo());
+        if (tipo != null) c.setTipo(tipo);
         if (dto.getRecordatorioMinutos() != null) c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
         if (dto.getEstado() != null) c.setEstado(dto.getEstado());
     }
@@ -47,7 +48,12 @@ public class CitaMapper {
         b.hora(c.getHora() != null ? c.getHora().toString() : null);
         b.ubicacion(c.getUbicacion());
         b.medico(c.getMedico());
-        b.tipo(c.getTipo());
+        if (c.getTipo() != null) {
+            b.tipo(TipoCitaDTO.builder()
+                    .id(c.getTipo().getId())
+                    .nombre(c.getTipo().getNombre())
+                    .build());
+        }
         b.estado(c.getEstado());
         b.recordatorioMinutos(c.getRecordatorioMinutos());
         return b.build();

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
@@ -2,7 +2,6 @@ package com.babytrackmaster.api_citas.repository;
 
 import com.babytrackmaster.api_citas.entity.Cita;
 import com.babytrackmaster.api_citas.enums.EstadoCita;
-import com.babytrackmaster.api_citas.enums.TipoCita;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
@@ -30,10 +29,10 @@ public interface CitaRepository extends JpaRepository<Cita, Long> {
                                @Param("estado") EstadoCita estado,
                                Pageable pageable);
 
-    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and c.tipo = :tipo " +
+    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and c.tipo.id = :tipoId " +
            "order by c.fecha asc, c.hora asc")
     Page<Cita> listarPorTipo(@Param("usuarioId") Long usuarioId,
-                             @Param("tipo") TipoCita tipo,
+                             @Param("tipoId") Long tipoId,
                              Pageable pageable);
 
     @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and c.medico = :medico " +

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoCitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoCitaRepository.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_citas.repository;
+
+import com.babytrackmaster.api_citas.entity.TipoCita;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipoCitaRepository extends JpaRepository<TipoCita, Long> {
+}
+

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
@@ -10,6 +10,6 @@ public interface CitaService {
     CitaResponseDTO obtener(Long id, Long usuarioId);
     Page<CitaResponseDTO> listarRango(Long usuarioId, String desde, String hasta, int page, int size);
     Page<CitaResponseDTO> listarPorEstado(Long usuarioId, String estado, int page, int size);
-    Page<CitaResponseDTO> listarPorTipo(Long usuarioId, String tipo, int page, int size);
+    Page<CitaResponseDTO> listarPorTipo(Long usuarioId, Long tipoId, int page, int size);
     Page<CitaResponseDTO> listarPorMedico(Long usuarioId, String medico, int page, int size);
 }


### PR DESCRIPTION
## Summary
- add `TipoCita` entity and repository
- relate `Cita` to `TipoCita` via `@ManyToOne`
- update DTOs, mapper, service, controller and queries to use entity ids

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b06066081c8327bb00dbc39d024af2