### PR TITLE
Add CRUD endpoints for appointment types

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/TipoCitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/TipoCitaController.java
@@ -1,0 +1,54 @@
+package com.babytrackmaster.api_citas.controller;
+
+import com.babytrackmaster.api_citas.dto.TipoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaUpdateDTO;
+import com.babytrackmaster.api_citas.service.TipoCitaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Tipos de Cita", description = "Gestión de tipos de cita")
+@RestController
+@RequestMapping("/api/v1/tipos-cita")
+@RequiredArgsConstructor
+public class TipoCitaController {
+
+    private final TipoCitaService service;
+
+    @Operation(summary = "Crear tipo de cita")
+    @PostMapping
+    public ResponseEntity<TipoCitaResponseDTO> crear(@Valid @RequestBody TipoCitaCreateDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(dto));
+    }
+
+    @Operation(summary = "Actualizar tipo de cita")
+    @PutMapping("/{id}")
+    public ResponseEntity<TipoCitaResponseDTO> actualizar(@PathVariable Long id, @Valid @RequestBody TipoCitaUpdateDTO dto) {
+        return ResponseEntity.ok(service.actualizar(id, dto));
+    }
+
+    @Operation(summary = "Eliminar tipo de cita")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Obtener tipo de cita por id")
+    @GetMapping("/{id}")
+    public ResponseEntity<TipoCitaResponseDTO> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtener(id));
+    }
+
+    @Operation(summary = "Listar todos los tipos de cita")
+    @GetMapping
+    public ResponseEntity<List<TipoCitaResponseDTO>> listarTodos() {
+        return ResponseEntity.ok(service.listarTodos());
+    }
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
@@ -13,7 +13,7 @@ public class CitaResponseDTO {
     private String hora;  // HH:mm
     private String ubicacion;
     private String medico;
-    private TipoCitaDTO tipo;
+    private TipoCitaResponseDTO tipo;
     private EstadoCita estado;
     private Integer recordatorioMinutos;
     private String creadoEn;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaCreateDTO.java
@@ -1,0 +1,17 @@
+package com.babytrackmaster.api_citas.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TipoCitaCreateDTO {
+
+    @Schema(example = "Pediatría")
+    @NotBlank
+    @Size(max = 100)
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaResponseDTO.java
@@ -1,14 +1,13 @@
 package com.babytrackmaster.api_citas.dto;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class TipoCitaDTO {
+public class TipoCitaResponseDTO {
     private Long id;
     private String nombre;
 }
-

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoCitaUpdateDTO.java
@@ -1,0 +1,13 @@
+package com.babytrackmaster.api_citas.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TipoCitaUpdateDTO {
+
+    @Size(max = 100)
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
@@ -49,10 +49,7 @@ public class CitaMapper {
         b.ubicacion(c.getUbicacion());
         b.medico(c.getMedico());
         if (c.getTipo() != null) {
-            b.tipo(TipoCitaDTO.builder()
-                    .id(c.getTipo().getId())
-                    .nombre(c.getTipo().getNombre())
-                    .build());
+            b.tipo(TipoCitaMapper.toDTO(c.getTipo()));
         }
         b.estado(c.getEstado());
         b.recordatorioMinutos(c.getRecordatorioMinutos());

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoCitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoCitaMapper.java
@@ -1,0 +1,31 @@
+package com.babytrackmaster.api_citas.mapper;
+
+import com.babytrackmaster.api_citas.dto.TipoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaUpdateDTO;
+import com.babytrackmaster.api_citas.entity.TipoCita;
+
+public class TipoCitaMapper {
+
+    private TipoCitaMapper() {}
+
+    public static TipoCita toEntity(TipoCitaCreateDTO dto) {
+        return TipoCita.builder()
+                .nombre(dto.getNombre())
+                .build();
+    }
+
+    public static void applyUpdate(TipoCita entity, TipoCitaUpdateDTO dto) {
+        if (dto.getNombre() != null) {
+            entity.setNombre(dto.getNombre());
+        }
+    }
+
+    public static TipoCitaResponseDTO toDTO(TipoCita entity) {
+        if (entity == null) return null;
+        return TipoCitaResponseDTO.builder()
+                .id(entity.getId())
+                .nombre(entity.getNombre())
+                .build();
+    }
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoCitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoCitaRepository.java
@@ -4,5 +4,6 @@ import com.babytrackmaster.api_citas.entity.TipoCita;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TipoCitaRepository extends JpaRepository<TipoCita, Long> {
+    boolean existsByNombreIgnoreCase(String nombre);
 }
 

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/TipoCitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/TipoCitaService.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_citas.service;
+
+import com.babytrackmaster.api_citas.dto.TipoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaUpdateDTO;
+import java.util.List;
+
+public interface TipoCitaService {
+    TipoCitaResponseDTO crear(TipoCitaCreateDTO dto);
+    TipoCitaResponseDTO actualizar(Long id, TipoCitaUpdateDTO dto);
+    void eliminar(Long id);
+    TipoCitaResponseDTO obtener(Long id);
+    List<TipoCitaResponseDTO> listarTodos();
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/TipoCitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/TipoCitaServiceImpl.java
@@ -1,0 +1,70 @@
+package com.babytrackmaster.api_citas.service.impl;
+
+import com.babytrackmaster.api_citas.dto.TipoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoCitaUpdateDTO;
+import com.babytrackmaster.api_citas.entity.TipoCita;
+import com.babytrackmaster.api_citas.exception.BadRequestException;
+import com.babytrackmaster.api_citas.exception.NotFoundException;
+import com.babytrackmaster.api_citas.mapper.TipoCitaMapper;
+import com.babytrackmaster.api_citas.repository.TipoCitaRepository;
+import com.babytrackmaster.api_citas.service.TipoCitaService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TipoCitaServiceImpl implements TipoCitaService {
+
+    private final TipoCitaRepository repo;
+
+    @Override
+    public TipoCitaResponseDTO crear(TipoCitaCreateDTO dto) {
+        if (repo.existsByNombreIgnoreCase(dto.getNombre())) {
+            throw new BadRequestException("Tipo de cita ya existe");
+        }
+        TipoCita tipo = TipoCitaMapper.toEntity(dto);
+        tipo = repo.save(tipo);
+        return TipoCitaMapper.toDTO(tipo);
+    }
+
+    @Override
+    public TipoCitaResponseDTO actualizar(Long id, TipoCitaUpdateDTO dto) {
+        TipoCita tipo = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de cita no encontrado"));
+        if (dto.getNombre() != null && repo.existsByNombreIgnoreCase(dto.getNombre())
+                && !dto.getNombre().equalsIgnoreCase(tipo.getNombre())) {
+            throw new BadRequestException("Tipo de cita ya existe");
+        }
+        TipoCitaMapper.applyUpdate(tipo, dto);
+        tipo = repo.save(tipo);
+        return TipoCitaMapper.toDTO(tipo);
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        TipoCita tipo = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de cita no encontrado"));
+        repo.delete(tipo);
+    }
+
+    @Override
+    public TipoCitaResponseDTO obtener(Long id) {
+        TipoCita tipo = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de cita no encontrado"));
+        return TipoCitaMapper.toDTO(tipo);
+    }
+
+    @Override
+    public List<TipoCitaResponseDTO> listarTodos() {
+        List<TipoCita> list = repo.findAll();
+        List<TipoCitaResponseDTO> res = new ArrayList<>();
+        int i;
+        for (i = 0; i < list.size(); i++) {
+            res.add(TipoCitaMapper.toDTO(list.get(i)));
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
## Summary
- add create, update, response DTOs for appointment types
- implement TipoCita service, mapper, repository, and REST controller
- wire appointment types into existing appointment mapping

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b061be83c483278c12b549700004a0