### PR TITLE
feat: add EstadoCita service and controller

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/EstadoCitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/EstadoCitaController.java
@@ -1,0 +1,55 @@
+package com.babytrackmaster.api_citas.controller;
+
+import com.babytrackmaster.api_citas.dto.EstadoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaUpdateDTO;
+import com.babytrackmaster.api_citas.service.EstadoCitaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Estados de Cita", description = "Gestión de estados de cita")
+@RestController
+@RequestMapping("/api/v1/estados-cita")
+@RequiredArgsConstructor
+public class EstadoCitaController {
+
+    private final EstadoCitaService service;
+
+    @Operation(summary = "Crear estado de cita")
+    @PostMapping
+    public ResponseEntity<EstadoCitaResponseDTO> crear(@Valid @RequestBody EstadoCitaCreateDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(dto));
+    }
+
+    @Operation(summary = "Actualizar estado de cita")
+    @PutMapping("/{id}")
+    public ResponseEntity<EstadoCitaResponseDTO> actualizar(@PathVariable Long id, @Valid @RequestBody EstadoCitaUpdateDTO dto) {
+        return ResponseEntity.ok(service.actualizar(id, dto));
+    }
+
+    @Operation(summary = "Eliminar estado de cita")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Obtener estado de cita por id")
+    @GetMapping("/{id}")
+    public ResponseEntity<EstadoCitaResponseDTO> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtener(id));
+    }
+
+    @Operation(summary = "Listar todos los estados de cita")
+    @GetMapping
+    public ResponseEntity<List<EstadoCitaResponseDTO>> listarTodos() {
+        return ResponseEntity.ok(service.listarTodos());
+    }
+}
+

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/EstadoCitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/EstadoCitaService.java
@@ -1,0 +1,15 @@
+package com.babytrackmaster.api_citas.service;
+
+import com.babytrackmaster.api_citas.dto.EstadoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaUpdateDTO;
+import java.util.List;
+
+public interface EstadoCitaService {
+    EstadoCitaResponseDTO crear(EstadoCitaCreateDTO dto);
+    EstadoCitaResponseDTO actualizar(Long id, EstadoCitaUpdateDTO dto);
+    void eliminar(Long id);
+    EstadoCitaResponseDTO obtener(Long id);
+    List<EstadoCitaResponseDTO> listarTodos();
+}
+

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/EstadoCitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/EstadoCitaServiceImpl.java
@@ -1,0 +1,70 @@
+package com.babytrackmaster.api_citas.service.impl;
+
+import com.babytrackmaster.api_citas.dto.EstadoCitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.EstadoCitaUpdateDTO;
+import com.babytrackmaster.api_citas.entity.EstadoCita;
+import com.babytrackmaster.api_citas.exception.BadRequestException;
+import com.babytrackmaster.api_citas.exception.NotFoundException;
+import com.babytrackmaster.api_citas.mapper.EstadoCitaMapper;
+import com.babytrackmaster.api_citas.repository.EstadoCitaRepository;
+import com.babytrackmaster.api_citas.service.EstadoCitaService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EstadoCitaServiceImpl implements EstadoCitaService {
+
+    private final EstadoCitaRepository repo;
+
+    @Override
+    public EstadoCitaResponseDTO crear(EstadoCitaCreateDTO dto) {
+        if (repo.existsByNombreIgnoreCase(dto.getNombre())) {
+            throw new BadRequestException("Estado de cita ya existe");
+        }
+        EstadoCita estado = EstadoCitaMapper.toEntity(dto);
+        estado = repo.save(estado);
+        return EstadoCitaMapper.toDTO(estado);
+    }
+
+    @Override
+    public EstadoCitaResponseDTO actualizar(Long id, EstadoCitaUpdateDTO dto) {
+        EstadoCita estado = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Estado de cita no encontrado"));
+        if (dto.getNombre() != null && repo.existsByNombreIgnoreCase(dto.getNombre())
+                && !dto.getNombre().equalsIgnoreCase(estado.getNombre())) {
+            throw new BadRequestException("Estado de cita ya existe");
+        }
+        EstadoCitaMapper.applyUpdate(estado, dto);
+        estado = repo.save(estado);
+        return EstadoCitaMapper.toDTO(estado);
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        EstadoCita estado = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Estado de cita no encontrado"));
+        repo.delete(estado);
+    }
+
+    @Override
+    public EstadoCitaResponseDTO obtener(Long id) {
+        EstadoCita estado = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Estado de cita no encontrado"));
+        return EstadoCitaMapper.toDTO(estado);
+    }
+
+    @Override
+    public List<EstadoCitaResponseDTO> listarTodos() {
+        List<EstadoCita> list = repo.findAll();
+        List<EstadoCitaResponseDTO> res = new ArrayList<>();
+        for (EstadoCita estado : list) {
+            res.add(EstadoCitaMapper.toDTO(estado));
+        }
+        return res;
+    }
+}
+

--- a/api-citas/src/test/java/com/babytrackmaster/api_citas/dto/EstadoCitaDtoSerializationTest.java
+++ b/api-citas/src/test/java/com/babytrackmaster/api_citas/dto/EstadoCitaDtoSerializationTest.java
@@ -1,0 +1,22 @@
+package com.babytrackmaster.api_citas.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+public class EstadoCitaDtoSerializationTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializaResponse() throws Exception {
+        EstadoCitaResponseDTO dto = EstadoCitaResponseDTO.builder()
+                .id(1L)
+                .nombre("Pendiente")
+                .build();
+        String json = mapper.writeValueAsString(dto);
+        assertThat(json).contains("\"id\":1", "\"nombre\":\"Pendiente\"");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add service interface and implementation for `EstadoCita` with unique name validation
- expose new REST controller for managing appointment status
- add serialization test for `EstadoCitaResponseDTO`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.babytrackmaster:api-citas)*

------
https://chatgpt.com/codex/tasks/task_e_68b0659598308327a71159a9db777169