### PR TITLE
feat(frontend): add theme modules and fix SignIn imports

### DIFF
--- a/frontend-baby/src/pages/SignIn.js
+++ b/frontend-baby/src/pages/SignIn.js
@@ -14,8 +14,8 @@ import Stack from '@mui/material/Stack';
 import MuiCard from '@mui/material/Card';
 import { styled } from '@mui/material/styles';
 import ForgotPassword from '../components/ForgotPassword';
-import AppTheme from '../shared-theme/AppTheme';
-import ColorModeSelect from '../shared-theme/ColorModeSelect';
+import AppTheme from '../theme/AppTheme';
+import ColorModeSelect from '../theme/ColorModeSelect';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from '../components/CustomIcons';
 
 const Card = styled(MuiCard)(({ theme }) => ({

--- a/frontend-baby/src/pages/SignIn.tsx
+++ b/frontend-baby/src/pages/SignIn.tsx
@@ -13,14 +13,10 @@ import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import MuiCard from '@mui/material/Card';
 import { styled } from '@mui/material/styles';
-import ForgotPassword from './components/ForgotPassword';
-// import AppTheme from '../shared-theme/AppTheme';
-// Update the path below to the correct location of AppTheme if needed:
+import ForgotPassword from '../components/ForgotPassword';
 import AppTheme from '../theme/AppTheme';
-import ColorModeSelect from '../shared-theme/ColorModeSelect';
-// Update the import path if the file exists elsewhere, for example:
+import ColorModeSelect from '../theme/ColorModeSelect';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from '../components/CustomIcons';
-// Or create './components/CustomIcons.tsx' and export the icons if missing.
 
 const Card = styled(MuiCard)(({ theme }) => ({
   display: 'flex',

--- a/frontend-baby/src/theme/AppTheme.js
+++ b/frontend-baby/src/theme/AppTheme.js
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export const ColorModeContext = React.createContext({ toggleColorMode: () => {} });
+
+export default function AppTheme({ children, disableCustomTheme }) {
+  const [mode, setMode] = React.useState('light');
+
+  const colorMode = React.useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode((prevMode) => (prevMode === 'light' ? 'dark' : 'light'));
+      },
+    }),
+    [],
+  );
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+        },
+      }),
+    [mode],
+  );
+
+  if (disableCustomTheme) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </ColorModeContext.Provider>
+  );
+}
+
+AppTheme.propTypes = {
+  children: PropTypes.node,
+  disableCustomTheme: PropTypes.bool,
+};

--- a/frontend-baby/src/theme/ColorModeSelect.js
+++ b/frontend-baby/src/theme/ColorModeSelect.js
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import { useTheme } from '@mui/material/styles';
+import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
+import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
+import { ColorModeContext } from './AppTheme';
+
+export default function ColorModeSelect(props) {
+  const theme = useTheme();
+  const colorMode = React.useContext(ColorModeContext);
+
+  return (
+    <Tooltip title="Toggle light/dark mode">
+      <IconButton color="inherit" onClick={colorMode.toggleColorMode} {...props}>
+        {theme.palette.mode === 'dark' ? <LightModeOutlined /> : <DarkModeOutlined />}
+      </IconButton>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable AppTheme and ColorModeSelect components
- fix SignIn imports to use new theme modules
- align TypeScript version of SignIn

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b0ed8f00d483278c77481db183d1a4