### PR TITLE
Add SignInSide page with updated theme imports

### DIFF
--- a/frontend-baby/src/pages/SignInSide.js
+++ b/frontend-baby/src/pages/SignInSide.js
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import CssBaseline from '@mui/material/CssBaseline';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import { styled } from '@mui/material/styles';
+import AppTheme from '../theme/AppTheme';
+import ColorModeSelect from '../theme/ColorModeSelect';
+
+const SignInCard = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: theme.spacing(2),
+  padding: theme.spacing(4),
+  width: '100%',
+  maxWidth: 360,
+}));
+
+const Content = styled(Grid)(({ theme }) => ({
+  backgroundImage: 'url(https://source.unsplash.com/random?baby)',
+  backgroundRepeat: 'no-repeat',
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+  backgroundColor:
+    theme.palette.mode === 'light'
+      ? theme.palette.grey[50]
+      : theme.palette.grey[900],
+}));
+
+export default function SignInSide(props) {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+  };
+
+  return (
+    <AppTheme {...props}>
+      <CssBaseline enableColorScheme />
+      <Grid container component="main" sx={{ height: '100vh' }}>
+        <Content item xs={false} sm={4} md={7} />
+        <Grid
+          item
+          xs={12}
+          sm={8}
+          md={5}
+          component={Paper}
+          elevation={6}
+          square
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <ColorModeSelect sx={{ position: 'fixed', top: '1rem', right: '1rem' }} />
+          <SignInCard component="form" onSubmit={handleSubmit}>
+            <Typography component="h1" variant="h5">
+              Sign in
+            </Typography>
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              autoFocus
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              name="password"
+              label="Password"
+              type="password"
+              id="password"
+              autoComplete="current-password"
+            />
+            <FormControlLabel
+              control={<Checkbox value="remember" color="primary" />}
+              label="Remember me"
+            />
+            <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+              Sign In
+            </Button>
+            <Grid container>
+              <Grid item xs>
+                <Link href="#" variant="body2">
+                  Forgot password?
+                </Link>
+              </Grid>
+              <Grid item>
+                <Link href="#" variant="body2">
+                  {"Don't have an account? Sign Up"}
+                </Link>
+              </Grid>
+            </Grid>
+          </SignInCard>
+        </Grid>
+      </Grid>
+    </AppTheme>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create SignInSide page with internal SignInCard and Content components
- use theme-based AppTheme and ColorModeSelect imports

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' in tests)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0f234baf083279599a73fcf6c9808