### PR TITLE
Fix SignIn page import path

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import signInSide from "./sign-in-side";
+import SignInSide from "./sign-in-side/SignInSide";
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<signInSide />} />
+        <Route path="/" element={<SignInSide />} />
       </Routes>
     </Router>
   );

--- a/frontend-baby/src/sign-in-side/SignInSide.js
+++ b/frontend-baby/src/sign-in-side/SignInSide.js
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import Stack from '@mui/material/Stack';
-import AppTheme from './shared-theme/AppTheme';
-import ColorModeSelect from './shared-theme/ColorModeSelect';
+import AppTheme from '../shared-theme/AppTheme';
+import ColorModeSelect from '../shared-theme/ColorModeSelect';
 import SignInCard from './components/SignInCard';
 import Content from './components/Content';
 


### PR DESCRIPTION
## Summary
- use `SignInSide` component in App router
- fix SignInSide shared-theme imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0fcc346848327bd74a31bcd3e6d90