### PR TITLE
Add authentication context and protected routes

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -2,15 +2,28 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import SignInSide from "./sign-in-side/SignInSide";
 import SignUp from "./sign-up/SignUp";
+import Dashboard from "./pages/Dashboard";
+import ProtectedRoute from "./components/ProtectedRoute";
+import { AuthProvider } from "./context/AuthContext";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<SignInSide />} />
-        <Route path="/" element={<SignUp />} />
-      </Routes>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<SignInSide />} />
+          <Route path="/signup" element={<SignUp />} />
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/frontend-baby/src/components/ProtectedRoute.js
+++ b/frontend-baby/src/components/ProtectedRoute.js
@@ -1,0 +1,11 @@
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+export default function ProtectedRoute({ children }) {
+  const { token } = useContext(AuthContext);
+  if (!token) {
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}

--- a/frontend-baby/src/context/AuthContext.js
+++ b/frontend-baby/src/context/AuthContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useEffect, useState } from 'react';
+import axios from 'axios';
+
+export const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(null);
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('jwt');
+    if (storedToken) {
+      setToken(storedToken);
+      axios.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
+    }
+  }, []);
+
+  const login = (newToken) => {
+    setToken(newToken);
+    localStorage.setItem('jwt', newToken);
+    axios.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+  };
+
+  const logout = () => {
+    setToken(null);
+    localStorage.removeItem('jwt');
+    delete axios.defaults.headers.common['Authorization'];
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/frontend-baby/src/pages/Dashboard.js
+++ b/frontend-baby/src/pages/Dashboard.js
@@ -1,0 +1,12 @@
+import React, { useContext } from 'react';
+import { AuthContext } from '../context/AuthContext';
+
+export default function Dashboard() {
+  const { logout } = useContext(AuthContext);
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}

--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -11,6 +11,9 @@ import Link from '@mui/material/Link';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/AuthContext';
 import ForgotPassword from './ForgotPassword';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from './CustomIcons';
 
@@ -38,6 +41,8 @@ export default function SignInCard() {
   const [passwordError, setPasswordError] = React.useState(false);
   const [passwordErrorMessage, setPasswordErrorMessage] = React.useState('');
   const [open, setOpen] = React.useState(false);
+  const { login } = React.useContext(AuthContext);
+  const navigate = useNavigate();
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -47,16 +52,23 @@ export default function SignInCard() {
     setOpen(false);
   };
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
+    event.preventDefault();
     if (emailError || passwordError) {
-      event.preventDefault();
       return;
     }
     const data = new FormData(event.currentTarget);
-    console.log({
-      email: data.get('email'),
-      password: data.get('password'),
-    });
+    try {
+      const response = await axios.post('http://localhost:8080/api/v1/auth/login', {
+        email: data.get('email'),
+        password: data.get('password'),
+      });
+      const token = response.data.token;
+      login(token);
+      navigate('/dashboard');
+    } catch (error) {
+      console.error('Login failed', error);
+    }
   };
 
   const validateInputs = () => {


### PR DESCRIPTION
## Summary
- Replace sign-in form console logging with Axios login request
- Introduce auth context to persist JWT and set Axios Authorization header
- Add protected routing and simple dashboard with logout

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b187eeba7c83278a5b53a0169ab610