### PR TITLE
Usar RouterLink hacia /signup en SignInCard

### DIFF
--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -12,7 +12,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../context/AuthContext';
 import ForgotPassword from './ForgotPassword';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from './CustomIcons';
@@ -172,11 +172,7 @@ export default function SignInCard() {
         <Typography sx={{ textAlign: 'center' }}>
           ¿No tienes cuenta?{' '}
           <span>
-            <Link
-              href="/material-ui/getting-started/templates/sign-in/"
-              variant="body2"
-              sx={{ alignSelf: 'center' }}
-            >
+            <Link component={RouterLink} to="/signup" variant="body2" sx={{ alignSelf: 'center' }}>
               Registrate
             </Link>
           </span>


### PR DESCRIPTION
## Summary
- Importa `Link as RouterLink` desde `react-router-dom`
- Utiliza `RouterLink` para el enlace de registro en `SignInCard`

## Testing
- `npm test -- --watchAll=false` *(falla: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b18b1d51788327b21639ac34ae56ca