### PR TITLE
feat: enable scrolling on signup

### DIFF
--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -40,8 +40,8 @@ const Card = styled(MuiCard)(({ theme }) => ({
 }));
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
-  height: 'calc((1 - var(--template-frame-height, 0)) * 100dvh)',
-  minHeight: '100%',
+  minHeight: '100vh',
+  overflowY: 'auto',
   padding: theme.spacing(2),
   [theme.breakpoints.up('sm')]: {
     padding: theme.spacing(4),

--- a/frontend-baby/src/sign-up/SignUp.tsx
+++ b/frontend-baby/src/sign-up/SignUp.tsx
@@ -37,8 +37,8 @@ const Card = styled(MuiCard)(({ theme }) => ({
 }));
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
-  height: 'calc((1 - var(--template-frame-height, 0)) * 100dvh)',
-  minHeight: '100%',
+  minHeight: '100vh',
+  overflowY: 'auto',
   padding: theme.spacing(2),
   [theme.breakpoints.up('sm')]: {
     padding: theme.spacing(4),


### PR DESCRIPTION
## Summary
- allow signup screen to scroll vertically by using `minHeight` and `overflowY`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b21ed41f648327bab6f83e01912af7