### PR TITLE
fix: enforce 8-char password rule

### DIFF
--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -88,7 +88,7 @@ export default function SignUp(props) {
       setEmailErrorMessage('');
     }
 
-    if (!password.value || password.value.length < 6) {
+    if (!password.value || password.value.length < 8) {
       setPasswordError(true);
       setPasswordErrorMessage('La contraseña debe tener como minimo 8 caracteres.');
       isValid = false;

--- a/frontend-baby/src/sign-up/SignUp.tsx
+++ b/frontend-baby/src/sign-up/SignUp.tsx
@@ -83,9 +83,9 @@ export default function SignUp(props: { disableCustomTheme?: boolean }) {
       setEmailErrorMessage('');
     }
 
-    if (!password.value || password.value.length < 6) {
+    if (!password.value || password.value.length < 8) {
       setPasswordError(true);
-      setPasswordErrorMessage('Password must be at least 6 characters long.');
+      setPasswordErrorMessage('Password must be at least 8 characters long.');
       isValid = false;
     } else {
       setPasswordError(false);


### PR DESCRIPTION
## Summary
- ensure password validation requires at least 8 characters across SignUp forms

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b21f9062948327b469be9efe748740