### PR TITLE
fix: adjust sign-in layout container styles

### DIFF
--- a/frontend-baby/src/sign-in-side/SignInSide.js
+++ b/frontend-baby/src/sign-in-side/SignInSide.js
@@ -11,16 +11,15 @@ export default function SignInSide(props) {
     <AppTheme {...props}>
       <CssBaseline enableColorScheme />
       <ColorModeSelect sx={{ position: 'fixed', top: '1rem', right: '1rem' }} />
-      <Stack
-        direction="column"
-        component="main"
-        sx={[
-          {
-            justifyContent: 'center',
-            height: 'calc((1 - var(--template-frame-height, 0)) * 100%)',
-            marginTop: 'max(40px - var(--template-frame-height, 0px), 0px)',
-            minHeight: '100%',
-          },
+        <Stack
+          direction="column"
+          component="main"
+          sx={[
+            {
+              justifyContent: 'center',
+              position: 'relative',
+              minHeight: '100vh',
+            },
           (theme) => ({
             '&::before': {
               content: '""',

--- a/frontend-baby/src/sign-in-side/SignInSide.tsx
+++ b/frontend-baby/src/sign-in-side/SignInSide.tsx
@@ -17,9 +17,8 @@ export default function SignInSide(props: { disableCustomTheme?: boolean }) {
         sx={[
           {
             justifyContent: 'center',
-            height: 'calc((1 - var(--template-frame-height, 0)) * 100%)',
-            marginTop: 'max(40px - var(--template-frame-height, 0px), 0px)',
-            minHeight: '100%',
+            position: 'relative',
+            minHeight: '100vh',
           },
           (theme) => ({
             '&::before': {


### PR DESCRIPTION
## Summary
- ensure SignIn page container uses `minHeight: 100vh` and is positioned relatively for background pseudo-element
- mirror style changes in TypeScript version

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b22308dcfc8327b52b4b5f56a37965