### PR TITLE
feat(frontend): scale background gradient

### DIFF
--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -1,6 +1,10 @@
-html, body, #root { height: 100%; }
+html, body, #root {
+  height: 100%;
+  min-height: 100vh;
+}
 body {
   margin: 0;
   font-family: Inter, Roboto, -apple-system, Segoe UI, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', Arial, sans-serif;
-  background: radial-gradient(1000px 600px at 20% 10%, #ff7aa8 0%, #c5456f 35%, #9b2a4f 65%, #641d37 100%) fixed;
+  background: radial-gradient(circle at 20% 10%, #ff7aa8 0%, #c5456f 35%, #9b2a4f 65%, #641d37 100%);
+  background-size: cover;
 }


### PR DESCRIPTION
## Summary
- ensure root elements cover viewport height
- make landing background gradient scale with screen

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b223c8724083278de88544fd249357