### PR TITLE
feat: ensure SignUp container covers viewport

### DIFF
--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -40,6 +40,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 }));
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
+  position: 'relative',
   minHeight: '100vh',
   overflowY: 'auto',
   padding: theme.spacing(2),

--- a/frontend-baby/src/sign-up/SignUp.tsx
+++ b/frontend-baby/src/sign-up/SignUp.tsx
@@ -37,6 +37,7 @@ const Card = styled(MuiCard)(({ theme }) => ({
 }));
 
 const SignUpContainer = styled(Stack)(({ theme }) => ({
+  position: 'relative',
   minHeight: '100vh',
   overflowY: 'auto',
   padding: theme.spacing(2),


### PR DESCRIPTION
## Summary
- ensure sign up container positions relative for background overlay
- keep ::before pseudo element covering full container

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b224a241dc83279806c415bf7723a8