### PR TITLE
feat: use CssVarsProvider for theming

### DIFF
--- a/frontend-baby/src/shared-theme/AppTheme.js
+++ b/frontend-baby/src/shared-theme/AppTheme.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CssVarsProvider, createTheme } from '@mui/material/styles';
 
 import { inputsCustomizations } from './customizations/inputs';
 import { dataDisplayCustomizations } from './customizations/dataDisplay';
@@ -38,9 +38,9 @@ function AppTheme(props) {
     return <React.Fragment>{children}</React.Fragment>;
   }
   return (
-    <ThemeProvider theme={theme} disableTransitionOnChange>
+    <CssVarsProvider theme={theme} defaultMode="system" disableTransitionOnChange>
       {children}
-    </ThemeProvider>
+    </CssVarsProvider>
   );
 }
 

--- a/frontend-baby/src/shared-theme/AppTheme.tsx
+++ b/frontend-baby/src/shared-theme/AppTheme.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CssVarsProvider, createTheme } from '@mui/material/styles';
 import type { ThemeOptions } from '@mui/material/styles';
 import { inputsCustomizations } from './customizations/inputs';
 import { dataDisplayCustomizations } from './customizations/dataDisplay';
@@ -46,8 +46,8 @@ export default function AppTheme(props: AppThemeProps) {
     return <React.Fragment>{children}</React.Fragment>;
   }
   return (
-    <ThemeProvider theme={theme} disableTransitionOnChange>
+    <CssVarsProvider theme={theme} defaultMode="system" disableTransitionOnChange>
       {children}
-    </ThemeProvider>
+    </CssVarsProvider>
   );
 }


### PR DESCRIPTION
## Summary
- replace `ThemeProvider` with `CssVarsProvider` in shared theme
- apply same update to TypeScript variant

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b22ada04888327a7ed80980e4a0d2d