### PR TITLE
feat: center sign-up header

### DIFF
--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -142,7 +142,7 @@ export default function SignUp(props) {
           <Typography
             component="h1"
             variant="h4"
-            sx={{ width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)' }}
+            sx={{ width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)', textAlign: 'center' }}
           >
             Registro
           </Typography>


### PR DESCRIPTION
## Summary
- center Registro header text on sign-up screen

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b24e23546c832782275958595b7a6e