### PR TITLE
Centrar título de login

### DIFF
--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -106,7 +106,7 @@ export default function SignInCard() {
       <Typography
         component="h1"
         variant="h4"
-        sx={{ width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)' }}
+        sx={{ width: '100%', fontSize: 'clamp(2rem, 10vw, 2.15rem)', textAlign: 'center' }}
       >
         Acceder
       </Typography>


### PR DESCRIPTION
## Summary
- Centrar palabra "Acceder" en el encabezado del formulario de login para mejorar la presentación

## Testing
- `npm test -- --watchAll=false` *(falla: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b252088e5483278bf0217e2fc50faa