### PR TITLE
feat: center and enlarge login logo

### DIFF
--- a/frontend-baby/src/sign-in-side/components/Content.js
+++ b/frontend-baby/src/sign-in-side/components/Content.js
@@ -42,7 +42,7 @@ export default function Content() {
     <Stack
       sx={{ flexDirection: 'column', alignSelf: 'center', gap: 4, maxWidth: 450 }}
     >
-      <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: 'center', width: '100%' }}>
         <SitemarkIcon />
       </Box>
       {items.map((item, index) => (

--- a/frontend-baby/src/sign-in-side/components/Content.tsx
+++ b/frontend-baby/src/sign-in-side/components/Content.tsx
@@ -40,7 +40,7 @@ export default function Content() {
     <Stack
       sx={{ flexDirection: 'column', alignSelf: 'center', gap: 4, maxWidth: 450 }}
     >
-      <Box sx={{ display: { xs: 'none', md: 'flex' } }}>
+      <Box sx={{ display: { xs: 'none', md: 'flex' }, justifyContent: 'center', width: '100%' }}>
         <SitemarkIcon />
       </Box>
       {items.map((item, index) => (

--- a/frontend-baby/src/sign-in-side/components/CustomIcons.js
+++ b/frontend-baby/src/sign-in-side/components/CustomIcons.js
@@ -8,7 +8,7 @@ export function SitemarkIcon() {
       component="img"
       src="/baby-logo.png"
       alt="Baby logo"
-      sx={{ height: 48, width: 48, alignSelf: 'center' }}
+      sx={{ height: 120, width: 120, alignSelf: 'center' }}
     />
   );
 }

--- a/frontend-baby/src/sign-in-side/components/CustomIcons.tsx
+++ b/frontend-baby/src/sign-in-side/components/CustomIcons.tsx
@@ -8,7 +8,7 @@ export function SitemarkIcon() {
       component="img"
       src="/baby-logo.png"
       alt="Baby logo"
-      sx={{ height: 48, width: 48, alignSelf: 'center' }}
+      sx={{ height: 120, width: 120, alignSelf: 'center' }}
     />
   );
 }


### PR DESCRIPTION
## Summary
- center the sign-in logo and give it width to be centered
- enlarge logo dimensions for clearer branding

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b2531f576483279bf33fb11ddc5c39