### PR TITLE
feat(frontend-baby): add Facebook login support

### DIFF
--- a/frontend-baby/package-lock.json
+++ b/frontend-baby/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@greatsumini/react-facebook-login": "^3.4.0",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
         "@react-oauth/google": "^0.11.1",
@@ -2623,6 +2624,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@greatsumini/react-facebook-login": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@greatsumini/react-facebook-login/-/react-facebook-login-3.4.0.tgz",
+      "integrity": "sha512-NJYqTOcDghZ6zLppC+LJVLep7Xi3gfx9ssQFRd7EhDTU07lC15SG/eZ3ZyvUPsuPBkbhVl6E/Py0w4M5m7Lh9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/frontend-baby/package.json
+++ b/frontend-baby/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@greatsumini/react-facebook-login": "^3.4.0",
     "@mui/icons-material": "^7.3.1",
     "@mui/material": "^7.3.1",
     "@react-oauth/google": "^0.11.1",

--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -15,8 +15,9 @@ import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../context/AuthContext';
 import ForgotPassword from './ForgotPassword';
 import Button from '@mui/material/Button';
-import { FacebookIcon, SitemarkIcon } from './CustomIcons';
+import { SitemarkIcon } from './CustomIcons';
 import { GoogleLogin } from '@react-oauth/google';
+import FacebookLogin from '@greatsumini/react-facebook-login';
 
 const Card = styled(MuiCard)(({ theme }) => ({
   display: 'flex',
@@ -196,14 +197,22 @@ export default function SignInCard() {
           }}
           onError={() => console.error('Google login failed')}
         />
-        <Button
-          fullWidth
-          variant="outlined"
-          onClick={() => alert('Acceder con Facebook')}
-          startIcon={<FacebookIcon />}
-        >
-          Acceder con Facebook
-        </Button>
+        <FacebookLogin
+          appId={process.env.REACT_APP_FACEBOOK_APP_ID}
+          onSuccess={async (response) => {
+            try {
+              const res = await axios.post('http://localhost:8080/api/v1/auth/facebook', {
+                token: response.accessToken,
+              });
+              const token = res.data.token;
+              login(token);
+              navigate('/dashboard');
+            } catch (error) {
+              console.error('Facebook login failed', error);
+            }
+          }}
+          onFail={(error) => console.error('Facebook login failed', error)}
+        />
       </Box>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add @greatsumini/react-facebook-login dependency
- replace Facebook button with FacebookLogin component sending token to backend

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b2a0a431848327bfde99f738e1c125