### PR TITLE
build(api-usuarios): actualiza restfb a 2024.1.0

### DIFF
--- a/api-usuarios/pom.xml
+++ b/api-usuarios/pom.xml
@@ -115,7 +115,7 @@
       <dependency>
          <groupId>com.restfb</groupId>
          <artifactId>restfb</artifactId>
-         <version>2023.5.1</version>
+         <version>2024.1.0</version>
       </dependency>
       <!-- Tests -->
       <dependency>


### PR DESCRIPTION
## Summary
- Actualiza la dependencia `restfb` a la versión 2024.1.0 para la verificación del token de Facebook OAuth.

## Testing
- `mvn -pl api-usuarios clean package` *(falló: Could not find the selected project in the reactor)*
- `mvn -f api-usuarios/pom.xml clean package` *(falló: Non-resolvable parent POM debido a `Network is unreachable`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a555638c83279abc3f7ef011994b