### PR TITLE
feat: style social login buttons

### DIFF
--- a/frontend-baby/src/App.test.js
+++ b/frontend-baby/src/App.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import { GoogleOAuthProvider } from '@react-oauth/google';
+import SignInSide from './sign-in-side/SignInSide';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders sign in page', () => {
+  render(
+    <GoogleOAuthProvider clientId="test">
+      <SignInSide />
+    </GoogleOAuthProvider>
+  );
+  const heading = screen.getByText(/Acceder/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -15,8 +15,8 @@ import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../../context/AuthContext';
 import ForgotPassword from './ForgotPassword';
 import Button from '@mui/material/Button';
-import { SitemarkIcon } from './CustomIcons';
-import { GoogleLogin } from '@react-oauth/google';
+import { SitemarkIcon, GoogleIcon, FacebookIcon } from './CustomIcons';
+import { useGoogleLogin } from '@react-oauth/google';
 import FacebookLogin from '@greatsumini/react-facebook-login';
 
 const Card = styled(MuiCard)(({ theme }) => ({
@@ -45,6 +45,22 @@ export default function SignInCard() {
   const [open, setOpen] = React.useState(false);
   const { login } = React.useContext(AuthContext);
   const navigate = useNavigate();
+
+  const googleLogin = useGoogleLogin({
+    onSuccess: async (tokenResponse) => {
+      try {
+        const response = await axios.post('http://localhost:8080/api/v1/auth/google', {
+          token: tokenResponse.access_token,
+        });
+        const token = response.data.token;
+        login(token);
+        navigate('/dashboard');
+      } catch (error) {
+        console.error('Google login failed', error);
+      }
+    },
+    onError: () => console.error('Google login failed'),
+  });
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -182,21 +198,25 @@ export default function SignInCard() {
       </Box>
       <Divider>o</Divider>
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <GoogleLogin
-          onSuccess={async (credentialResponse) => {
-            try {
-              const response = await axios.post('http://localhost:8080/api/v1/auth/google', {
-                token: credentialResponse.credential,
-              });
-              const token = response.data.token;
-              login(token);
-              navigate('/dashboard');
-            } catch (error) {
-              console.error('Google login failed', error);
-            }
+        <Button
+          fullWidth
+          variant="outlined"
+          startIcon={<GoogleIcon />}
+          onClick={() => googleLogin()}
+          sx={{
+            justifyContent: 'flex-start',
+            textTransform: 'none',
+            bgcolor: 'grey.900',
+            color: 'grey.50',
+            borderColor: 'grey.700',
+            '&:hover': {
+              bgcolor: 'grey.800',
+              borderColor: 'grey.600',
+            },
           }}
-          onError={() => console.error('Google login failed')}
-        />
+        >
+          Acceder con Google
+        </Button>
         <FacebookLogin
           appId={process.env.REACT_APP_FACEBOOK_APP_ID}
           onSuccess={async (response) => {
@@ -212,6 +232,27 @@ export default function SignInCard() {
             }
           }}
           onFail={(error) => console.error('Facebook login failed', error)}
+          render={(renderProps) => (
+            <Button
+              fullWidth
+              variant="outlined"
+              startIcon={<FacebookIcon />}
+              onClick={renderProps.onClick}
+              sx={{
+                justifyContent: 'flex-start',
+                textTransform: 'none',
+                bgcolor: 'grey.900',
+                color: 'grey.50',
+                borderColor: 'grey.700',
+                '&:hover': {
+                  bgcolor: 'grey.800',
+                  borderColor: 'grey.600',
+                },
+              }}
+            >
+              Acceder con Facebook
+            </Button>
+          )}
         />
       </Box>
     </Card>


### PR DESCRIPTION
## Summary
- restyle Google and Facebook login buttons to match design
- add test for sign-in page

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use import statement outside a module in axios)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a732f0e88327817262cabea59348