### PR TITLE
feat(frontend): add Google OAuth env variable

### DIFF
--- a/frontend-baby/.env
+++ b/frontend-baby/.env
@@ -1,0 +1,1 @@
+REACT_APP_GOOGLE_CLIENT_ID=<tu client ID de Google OAuth>

--- a/frontend-baby/README.md
+++ b/frontend-baby/README.md
@@ -13,3 +13,11 @@ Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas, 
 - **jwt-decode**
 - Gestión de estado con Context / useReducer
 - Herramientas: Create React App (o Vite), ESLint/Prettier (opcional)
+
+## Configuración
+
+Crea un archivo `.env` en `frontend-baby/` con tu Client ID de Google OAuth:
+
+```
+REACT_APP_GOOGLE_CLIENT_ID=<tu client ID de Google OAuth>
+```


### PR DESCRIPTION
## Summary
- add `REACT_APP_GOOGLE_CLIENT_ID` to `.env`
- document Google OAuth env variable setup in frontend README

## Testing
- `npm start`
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b2aa243f948327b52bde78828fa3c7