### PR TITLE
Remove color mode selector from sign pages

### DIFF
--- a/frontend-baby/src/pages/SignInSide.js
+++ b/frontend-baby/src/pages/SignInSide.js
@@ -11,7 +11,6 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { styled } from '@mui/material/styles';
 import AppTheme from '../theme/AppTheme';
-import ColorModeSelect from '../theme/ColorModeSelect';
 
 const SignInCard = styled(Box)(({ theme }) => ({
   display: 'flex',
@@ -59,7 +58,6 @@ export default function SignInSide(props) {
           square
           sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <ColorModeSelect sx={{ position: 'fixed', top: '1rem', right: '1rem' }} />
           <SignInCard component="form" onSubmit={handleSubmit}>
             <Typography component="h1" variant="h5">
               Sign in

--- a/frontend-baby/src/sign-in-side/SignInSide.js
+++ b/frontend-baby/src/sign-in-side/SignInSide.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import Stack from '@mui/material/Stack';
 import AppTheme from '../shared-theme/AppTheme';
-import ColorModeSelect from '../shared-theme/ColorModeSelect';
 import SignInCard from '../sign-in-side/components/SignInCard';
 import Content from '../sign-in-side/components/Content';
 
@@ -10,7 +9,6 @@ export default function SignInSide(props) {
   return (
     <AppTheme {...props}>
       <CssBaseline enableColorScheme />
-      <ColorModeSelect sx={{ position: 'fixed', top: '1rem', right: '1rem' }} />
         <Stack
           direction="column"
           component="main"

--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -16,7 +16,6 @@ import { styled } from '@mui/material/styles';
 import axios from 'axios';
 import AppTheme from '../shared-theme/AppTheme';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import ColorModeSelect from '../shared-theme/ColorModeSelect';
 import API_BASE_URL from '../config';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from '../sign-up/components/CustomIcons';
 
@@ -135,7 +134,6 @@ export default function SignUp(props) {
   return (
     <AppTheme {...props}>
       <CssBaseline enableColorScheme />
-      <ColorModeSelect sx={{ position: 'fixed', top: '1rem', right: '1rem' }} />
       <SignUpContainer direction="column" justifyContent="space-between">
         <Card variant="outlined">
           <SitemarkIcon />


### PR DESCRIPTION
## Summary
- remove ColorModeSelect component and import from sign-in-side screen
- remove ColorModeSelect from SignIn page
- drop ColorModeSelect from SignUp page

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b2dddcd1a88327b7578fc6da61030b