### PR TITLE
feat: translate dashboard menu items to Spanish

### DIFF
--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -6,24 +7,30 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
 import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
-import AnalyticsRoundedIcon from '@mui/icons-material/AnalyticsRounded';
-import PeopleRoundedIcon from '@mui/icons-material/PeopleRounded';
-import AssignmentRoundedIcon from '@mui/icons-material/AssignmentRounded';
+import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
+import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded';
+import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
+import EventRoundedIcon from '@mui/icons-material/EventRounded';
+import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
+import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
 
 const mainListItems = [
-  { text: 'Home', icon: <HomeRoundedIcon /> },
-  { text: 'Analytics', icon: <AnalyticsRoundedIcon /> },
-  { text: 'Clients', icon: <PeopleRoundedIcon /> },
-  { text: 'Tasks', icon: <AssignmentRoundedIcon /> },
+  { text: 'Inicio', icon: <HomeRoundedIcon />, to: '/dashboard' },
+  { text: 'Cuidados', icon: <FavoriteRoundedIcon />, to: '/dashboard/cuidados' },
+  { text: 'Gastos', icon: <MonetizationOnRoundedIcon />, to: '/dashboard/gastos' },
+  { text: 'Diario', icon: <MenuBookRoundedIcon />, to: '/dashboard/diario' },
+  { text: 'Citas', icon: <EventRoundedIcon />, to: '/dashboard/citas' },
+  { text: 'Rutinas', icon: <ScheduleRoundedIcon />, to: '/dashboard/rutinas' },
 ];
 
 const secondaryListItems = [
-  { text: 'Settings', icon: <SettingsRoundedIcon /> },
-  { text: 'About', icon: <InfoRoundedIcon /> },
-  { text: 'Feedback', icon: <HelpRoundedIcon /> },
+  { text: 'Perfil', icon: <PersonRoundedIcon />, to: '/dashboard/perfil' },
+  { text: 'Configuración', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion' },
+  { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
+  { text: 'Ayuda', icon: <HelpRoundedIcon />, to: '/dashboard/ayuda' },
 ];
 
 export default function MenuContent() {
@@ -32,7 +39,7 @@ export default function MenuContent() {
       <List dense>
         {mainListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-            <ListItemButton selected={index === 0}>
+            <ListItemButton component={Link} to={item.to} selected={index === 0}>
               <ListItemIcon>{item.icon}</ListItemIcon>
               <ListItemText primary={item.text} />
             </ListItemButton>
@@ -42,7 +49,7 @@ export default function MenuContent() {
       <List dense>
         {secondaryListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-            <ListItemButton>
+            <ListItemButton component={Link} to={item.to}>
               <ListItemIcon>{item.icon}</ListItemIcon>
               <ListItemText primary={item.text} />
             </ListItemButton>


### PR DESCRIPTION
## Summary
- localize dashboard menu labels in Spanish and add MUI icons
- wire menu entries to React Router routes

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b31bcff2f083279de4cf15fc65f73d