### PR TITLE
feat: add dashboard summary cards

### DIFF
--- a/frontend-baby/src/dashboard/components/DailyRoutinesCard.js
+++ b/frontend-baby/src/dashboard/components/DailyRoutinesCard.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+
+const routines = [
+  { time: '08:00', activity: 'Desayuno' },
+  { time: '10:00', activity: 'Siesta' },
+  { time: '12:30', activity: 'Almuerzo' },
+  { time: '15:00', activity: 'Paseo' },
+];
+
+export default function DailyRoutinesCard() {
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Rutinas Diarias
+        </Typography>
+        <List>
+          {routines.map((item, index) => (
+            <ListItem key={index} disableGutters>
+              <ListItemText
+                primary={item.activity}
+                secondary={item.time}
+                primaryTypographyProps={{ variant: 'body2' }}
+                secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -1,90 +1,27 @@
 import * as React from 'react';
-import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
 import Copyright from '../internals/components/Copyright';
-import ChartUserByCountry from './ChartUserByCountry';
-import CustomizedTreeView from './CustomizedTreeView';
-import CustomizedDataGrid from './CustomizedDataGrid';
-import HighlightedCard from './HighlightedCard';
-import PageViewsBarChart from './PageViewsBarChart';
-import SessionsChart from './SessionsChart';
-import StatCard from './StatCard';
-
-const data = [
-  {
-    title: 'Users',
-    value: '14k',
-    interval: 'Last 30 days',
-    trend: 'up',
-    data: [
-      200, 24, 220, 260, 240, 380, 100, 240, 280, 240, 300, 340, 320, 360, 340, 380,
-      360, 400, 380, 420, 400, 640, 340, 460, 440, 480, 460, 600, 880, 920,
-    ],
-  },
-  {
-    title: 'Conversions',
-    value: '325',
-    interval: 'Last 30 days',
-    trend: 'down',
-    data: [
-      1640, 1250, 970, 1130, 1050, 900, 720, 1080, 900, 450, 920, 820, 840, 600, 820,
-      780, 800, 760, 380, 740, 660, 620, 840, 500, 520, 480, 400, 360, 300, 220,
-    ],
-  },
-  {
-    title: 'Event count',
-    value: '200k',
-    interval: 'Last 30 days',
-    trend: 'neutral',
-    data: [
-      500, 400, 510, 530, 520, 600, 530, 520, 510, 730, 520, 510, 530, 620, 510, 530,
-      520, 410, 530, 520, 610, 530, 520, 610, 530, 420, 510, 430, 520, 510,
-    ],
-  },
-];
+import DailyRoutinesCard from './DailyRoutinesCard';
+import UpcomingAppointmentsCard from './UpcomingAppointmentsCard';
+import RecentCareCard from './RecentCareCard';
+import QuickStatsCard from './QuickStatsCard';
 
 export default function MainGrid() {
   return (
     <Box sx={{ width: '100%', maxWidth: { sm: '100%', md: '1700px' } }}>
-      {/* cards */}
-      <Typography component="h2" variant="h6" sx={{ mb: 2 }}>
-        Overview
-      </Typography>
-      <Grid
-        container
-        spacing={2}
-        columns={12}
-        sx={{ mb: (theme) => theme.spacing(2) }}
-      >
-        {data.map((card, index) => (
-          <Grid key={index} size={{ xs: 12, sm: 6, lg: 3 }}>
-            <StatCard {...card} />
-          </Grid>
-        ))}
-        <Grid size={{ xs: 12, sm: 6, lg: 3 }}>
-          <HighlightedCard />
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <DailyRoutinesCard />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <SessionsChart />
+          <UpcomingAppointmentsCard />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <PageViewsBarChart />
+          <RecentCareCard />
         </Grid>
-      </Grid>
-      <Typography component="h2" variant="h6" sx={{ mb: 2 }}>
-        Details
-      </Typography>
-      <Grid container spacing={2} columns={12}>
-        <Grid size={{ xs: 12, lg: 9 }}>
-          <CustomizedDataGrid />
-        </Grid>
-        <Grid size={{ xs: 12, lg: 3 }}>
-          <Stack gap={2} direction={{ xs: 'column', sm: 'row', lg: 'column' }}>
-            <CustomizedTreeView />
-            <ChartUserByCountry />
-          </Stack>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <QuickStatsCard />
         </Grid>
       </Grid>
       <Copyright sx={{ my: 4 }} />

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+
+const stats = [
+  { label: 'Horas de sueño', value: '8h' },
+  { label: 'Pañales', value: '5' },
+  { label: 'Tomas', value: '6' },
+  { label: 'Baños', value: '1' },
+];
+
+export default function QuickStatsCard() {
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Estadísticas Rápidas
+        </Typography>
+        <Grid container spacing={2}>
+          {stats.map((stat, index) => (
+            <Grid item xs={6} key={index}>
+              <Typography variant="h5" component="p">
+                {stat.value}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {stat.label}
+              </Typography>
+            </Grid>
+          ))}
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+
+const careEntries = [
+  { time: '08:30', action: 'Biberón 120ml' },
+  { time: '09:15', action: 'Cambio de pañal' },
+  { time: '11:00', action: 'Siesta' },
+];
+
+export default function RecentCareCard() {
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Cuidados Recientes
+        </Typography>
+        <List>
+          {careEntries.map((item, index) => (
+            <ListItem key={index} disableGutters>
+              <ListItemText
+                primary={item.action}
+                secondary={item.time}
+                primaryTypographyProps={{ variant: 'body2' }}
+                secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
+              />
+            </ListItem>
+          ))}
+        </List>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+
+const appointments = [
+  { date: '20 Feb', time: '09:00', doctor: 'Pediatra' },
+  { date: '05 Mar', time: '11:30', doctor: 'Vacuna' },
+];
+
+export default function UpcomingAppointmentsCard() {
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Próximas Citas
+        </Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Fecha</TableCell>
+              <TableCell>Hora</TableCell>
+              <TableCell>Médico</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {appointments.map((row, index) => (
+              <TableRow key={index}>
+                <TableCell>{row.date}</TableCell>
+                <TableCell>{row.time}</TableCell>
+                <TableCell>{row.doctor}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add DailyRoutinesCard, UpcomingAppointmentsCard, RecentCareCard and QuickStatsCard components
- simplify MainGrid layout to use new summary cards

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b31dc436808327b7dbda9e809ee92c