### PR TITLE
feat: add dashboard routes and navigation links

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -2,7 +2,17 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import SignInSide from "./sign-in-side/SignInSide";
 import SignUp from "./sign-up/SignUp";
-import Dashboard from "./pages/Dashboard";
+import DashboardLayout from "./dashboard/Dashboard";
+import MainGrid from "./dashboard/components/MainGrid";
+import Cuidados from "./dashboard/pages/Cuidados";
+import Gastos from "./dashboard/pages/Gastos";
+import Diario from "./dashboard/pages/Diario";
+import Citas from "./dashboard/pages/Citas";
+import Rutinas from "./dashboard/pages/Rutinas";
+import Perfil from "./dashboard/pages/Perfil";
+import Configuracion from "./dashboard/pages/Configuracion";
+import Acerca from "./dashboard/pages/Acerca";
+import Ayuda from "./dashboard/pages/Ayuda";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
@@ -15,13 +25,24 @@ function App() {
           <Route path="/signup" element={<SignUp />} />
           <Route path="/signin" element={<SignInSide />} />
           <Route
-            path="/dashboard"
+            path="/dashboard/*"
             element={
               <ProtectedRoute>
-                <Dashboard />
+                <DashboardLayout />
               </ProtectedRoute>
             }
-          />
+          >
+            <Route index element={<MainGrid />} />
+            <Route path="cuidados" element={<Cuidados />} />
+            <Route path="gastos" element={<Gastos />} />
+            <Route path="diario" element={<Diario />} />
+            <Route path="citas" element={<Citas />} />
+            <Route path="rutinas" element={<Rutinas />} />
+            <Route path="perfil" element={<Perfil />} />
+            <Route path="configuracion" element={<Configuracion />} />
+            <Route path="acerca" element={<Acerca />} />
+            <Route path="ayuda" element={<Ayuda />} />
+          </Route>
         </Routes>
       </Router>
     </AuthProvider>

--- a/frontend-baby/src/dashboard/Dashboard.js
+++ b/frontend-baby/src/dashboard/Dashboard.js
@@ -6,8 +6,8 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import AppNavbar from './components/AppNavbar';
 import Header from './components/Header';
-import MainGrid from './components/MainGrid';
 import SideMenu from './components/SideMenu';
+import { Outlet } from 'react-router-dom';
 import AppTheme from '../shared-theme/AppTheme';
 import {
   chartsCustomizations,
@@ -51,7 +51,7 @@ export default function Dashboard(props) {
             }}
           >
             <Header />
-            <MainGrid />
+            <Outlet />
           </Stack>
         </Box>
       </Box>

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -39,20 +39,34 @@ export default function MenuContent() {
       <List dense>
         {mainListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-            <ListItemButton component={Link} to={item.to} selected={index === 0}>
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
+            <NavLink
+              to={item.to}
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              {({ isActive }) => (
+                <ListItemButton selected={isActive}>
+                  <ListItemIcon>{item.icon}</ListItemIcon>
+                  <ListItemText primary={item.text} />
+                </ListItemButton>
+              )}
+            </NavLink>
           </ListItem>
         ))}
       </List>
       <List dense>
         {secondaryListItems.map((item, index) => (
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
-            <ListItemButton component={Link} to={item.to}>
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
+            <NavLink
+              to={item.to}
+              style={{ textDecoration: 'none', color: 'inherit' }}
+            >
+              {({ isActive }) => (
+                <ListItemButton selected={isActive}>
+                  <ListItemIcon>{item.icon}</ListItemIcon>
+                  <ListItemText primary={item.text} />
+                </ListItemButton>
+              )}
+            </NavLink>
           </ListItem>
         ))}
       </List>

--- a/frontend-baby/src/dashboard/pages/Acerca.js
+++ b/frontend-baby/src/dashboard/pages/Acerca.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Acerca() {
+  return <Typography variant="h4">Acerca de</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Ayuda.js
+++ b/frontend-baby/src/dashboard/pages/Ayuda.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Ayuda() {
+  return <Typography variant="h4">Ayuda</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Citas() {
+  return <Typography variant="h4">Citas</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Configuracion.js
+++ b/frontend-baby/src/dashboard/pages/Configuracion.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Configuracion() {
+  return <Typography variant="h4">Configuración</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Cuidados() {
+  return <Typography variant="h4">Cuidados</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Diario.js
+++ b/frontend-baby/src/dashboard/pages/Diario.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Diario() {
+  return <Typography variant="h4">Diario</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Gastos() {
+  return <Typography variant="h4">Gastos</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Perfil.js
+++ b/frontend-baby/src/dashboard/pages/Perfil.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Perfil() {
+  return <Typography variant="h4">Perfil</Typography>;
+}

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Rutinas() {
+  return <Typography variant="h4">Rutinas</Typography>;
+}


### PR DESCRIPTION
## Summary
- wrap dashboard menu buttons with NavLink for routing
- add protected routes for each dashboard section
- render nested routes in dashboard layout with Outlet

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b32148a7008327b7ed8ee3d1ffee68