### PR TITLE
feat: add profile page and link in side menu

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -9,7 +9,7 @@ import Gastos from "./dashboard/pages/Gastos";
 import Diario from "./dashboard/pages/Diario";
 import Citas from "./dashboard/pages/Citas";
 import Rutinas from "./dashboard/pages/Rutinas";
-import Perfil from "./dashboard/pages/Perfil";
+import Profile from "./pages/Profile";
 import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
 import Ayuda from "./dashboard/pages/Ayuda";
@@ -38,7 +38,7 @@ function App() {
             <Route path="diario" element={<Diario />} />
             <Route path="citas" element={<Citas />} />
             <Route path="rutinas" element={<Rutinas />} />
-            <Route path="perfil" element={<Perfil />} />
+            <Route path="profile" element={<Profile />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
             <Route path="ayuda" element={<Ayuda />} />

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -12,7 +12,7 @@ import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
-import PersonRoundedIcon from '@mui/icons-material/PersonRounded';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
@@ -27,7 +27,7 @@ const mainListItems = [
 ];
 
 const secondaryListItems = [
-  { text: 'Perfil', icon: <PersonRoundedIcon />, to: '/dashboard/perfil' },
+  { text: 'Perfil', icon: <AccountCircleIcon />, to: '/dashboard/profile' },
   { text: 'Configuración', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion' },
   { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
   { text: 'Ayuda', icon: <HelpRoundedIcon />, to: '/dashboard/ayuda' },

--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { NavLink } from 'react-router-dom';
 import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import CardAlert from './CardAlert';
@@ -66,19 +67,32 @@ export default function SideMenu() {
           borderColor: 'divider',
         }}
       >
-        <Avatar
-          sizes="small"
-          alt="Riley Carter"
-          src="/static/images/avatar/7.jpg"
-          sx={{ width: 36, height: 36 }}
-        />
-        <Box sx={{ mr: 'auto' }}>
-          <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: '16px' }}>
-            Riley Carter
-          </Typography>
-          <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            riley@email.com
-          </Typography>
+        <Box
+          component={NavLink}
+          to="/dashboard/profile"
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            textDecoration: 'none',
+            color: 'inherit',
+            mr: 'auto',
+          }}
+        >
+          <Avatar
+            sizes="small"
+            alt="Riley Carter"
+            src="/static/images/avatar/7.jpg"
+            sx={{ width: 36, height: 36 }}
+          />
+          <Box>
+            <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: '16px' }}>
+              Riley Carter
+            </Typography>
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              riley@email.com
+            </Typography>
+          </Box>
         </Box>
         <OptionsMenu />
       </Stack>

--- a/frontend-baby/src/pages/Profile.js
+++ b/frontend-baby/src/pages/Profile.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function Profile() {
+  return <Typography variant="h4">Perfil</Typography>;
+}


### PR DESCRIPTION
## Summary
- add profile entry with account icon to dashboard menu
- link footer avatar to profile page
- add basic profile page and route

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b32282ed708327a4189997538d653b