### PR TITLE
Add dayjs to frontend dependencies

### DIFF
--- a/frontend-baby/package-lock.json
+++ b/frontend-baby/package-lock.json
@@ -23,6 +23,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.11.0",
+        "dayjs": "^1.11.10",
         "jwt-decode": "^4.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -7441,6 +7442,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/frontend-baby/package.json
+++ b/frontend-baby/package.json
@@ -18,6 +18,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.11.0",
+    "dayjs": "^1.11.10",
     "jwt-decode": "^4.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",


### PR DESCRIPTION
## Summary
- include dayjs in frontend dependencies
- install new package

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b324b210f48327849c56263c37ac80