### PR TITLE
Remove profile feature and references

### DIFF
--- a/frontend-baby/README.md
+++ b/frontend-baby/README.md
@@ -3,7 +3,7 @@
 Aplicación **React** (SPA) para la interfaz de usuario.
 
 ## Descripción
-Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas, rutinas y perfil. Rutas protegidas con JWT y consumo de APIs vía Axios.
+Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas y rutinas. Rutas protegidas con JWT y consumo de APIs vía Axios.
 
 ## Tecnologías usadas
 - **React**

--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -9,7 +9,6 @@ import Gastos from "./dashboard/pages/Gastos";
 import Diario from "./dashboard/pages/Diario";
 import Citas from "./dashboard/pages/Citas";
 import Rutinas from "./dashboard/pages/Rutinas";
-import Profile from "./pages/Profile";
 import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
 import Ayuda from "./dashboard/pages/Ayuda";
@@ -38,7 +37,6 @@ function App() {
             <Route path="diario" element={<Diario />} />
             <Route path="citas" element={<Citas />} />
             <Route path="rutinas" element={<Rutinas />} />
-            <Route path="profile" element={<Profile />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
             <Route path="ayuda" element={<Ayuda />} />

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -12,7 +12,6 @@ import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
-import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
@@ -27,7 +26,6 @@ const mainListItems = [
 ];
 
 const secondaryListItems = [
-  { text: 'Perfil', icon: <AccountCircleIcon />, to: '/dashboard/profile' },
   { text: 'Configuración', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion' },
   { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
   { text: 'Ayuda', icon: <HelpRoundedIcon />, to: '/dashboard/ayuda' },

--- a/frontend-baby/src/dashboard/components/OptionsMenu.js
+++ b/frontend-baby/src/dashboard/components/OptionsMenu.js
@@ -53,7 +53,6 @@ export default function OptionsMenu() {
           },
         }}
       >
-        <MenuItem onClick={handleClose}>Perfil</MenuItem>
         <MenuItem onClick={handleClose}>Mi cuenta</MenuItem>
         <Divider />
         <MenuItem onClick={handleClose}>Agregar otra cuenta</MenuItem>

--- a/frontend-baby/src/dashboard/components/OptionsMenu.tsx
+++ b/frontend-baby/src/dashboard/components/OptionsMenu.tsx
@@ -53,7 +53,6 @@ export default function OptionsMenu() {
           },
         }}
       >
-        <MenuItem onClick={handleClose}>Perfil</MenuItem>
         <MenuItem onClick={handleClose}>Mi cuenta</MenuItem>
         <Divider />
         <MenuItem onClick={handleClose}>Agregar otra cuenta</MenuItem>

--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -6,7 +6,6 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { NavLink } from 'react-router-dom';
 import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
@@ -66,8 +65,6 @@ export default function SideMenu() {
         }}
       >
         <Box
-          component={NavLink}
-          to="/dashboard/profile"
           sx={{
             display: 'flex',
             alignItems: 'center',

--- a/frontend-baby/src/dashboard/internals/data/gridData.js
+++ b/frontend-baby/src/dashboard/internals/data/gridData.js
@@ -170,7 +170,7 @@ export const rows = [
   },
   {
     id: 4,
-    pageTitle: 'User Profile Dashboard',
+    pageTitle: 'User Dashboard',
     status: 'Online',
     eventCount: 112543,
     users: 96240,
@@ -499,7 +499,7 @@ export const rows = [
   },
   {
     id: 27,
-    pageTitle: 'Profiles - Team Members',
+    pageTitle: 'Team Members',
     status: 'Offline',
     eventCount: 5634,
     users: 23423,

--- a/frontend-baby/src/dashboard/internals/data/gridData.tsx
+++ b/frontend-baby/src/dashboard/internals/data/gridData.tsx
@@ -174,7 +174,7 @@ export const rows: GridRowsProp = [
   },
   {
     id: 4,
-    pageTitle: 'User Profile Dashboard',
+    pageTitle: 'User Dashboard',
     status: 'Online',
     eventCount: 112543,
     users: 96240,
@@ -503,7 +503,7 @@ export const rows: GridRowsProp = [
   },
   {
     id: 27,
-    pageTitle: 'Profiles - Team Members',
+    pageTitle: 'Team Members',
     status: 'Offline',
     eventCount: 5634,
     users: 23423,

--- a/frontend-baby/src/dashboard/pages/Perfil.js
+++ b/frontend-baby/src/dashboard/pages/Perfil.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Typography from '@mui/material/Typography';
-
-export default function Perfil() {
-  return <Typography variant="h4">Perfil</Typography>;
-}

--- a/frontend-baby/src/pages/Profile.js
+++ b/frontend-baby/src/pages/Profile.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Typography from '@mui/material/Typography';
-
-export default function Profile() {
-  return <Typography variant="h4">Perfil</Typography>;
-}


### PR DESCRIPTION
## Summary
- delete legacy profile pages and routing
- clean up navigation menus and options related to profile
- remove profile strings from sample grid data and documentation

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b32c5fbe608327874ede6aee1e5e10