### PR TITLE
feat: display BabyTrackMaster logo in dashboard navbar

### DIFF
--- a/frontend-baby/src/dashboard/components/AppNavbar.js
+++ b/frontend-baby/src/dashboard/components/AppNavbar.js
@@ -7,7 +7,6 @@ import MuiToolbar from '@mui/material/Toolbar';
 import { tabsClasses } from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
-import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
 import SideMenuMobile from './SideMenuMobile';
 import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
@@ -82,24 +81,10 @@ export default function AppNavbar() {
 export function CustomIcon() {
   return (
     <Box
-      sx={{
-        width: '1.5rem',
-        height: '1.5rem',
-        bgcolor: 'black',
-        borderRadius: '999px',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        alignSelf: 'center',
-        backgroundImage:
-          'linear-gradient(135deg, hsl(210, 98%, 60%) 0%, hsl(210, 100%, 35%) 100%)',
-        color: 'hsla(210, 100%, 95%, 0.9)',
-        border: '1px solid',
-        borderColor: 'hsl(210, 100%, 55%)',
-        boxShadow: 'inset 0 2px 5px rgba(255, 255, 255, 0.3)',
-      }}
-    >
-      <DashboardRoundedIcon color="inherit" sx={{ fontSize: '1rem' }} />
-    </Box>
+      component="img"
+      src="/baby-logo.png"
+      alt="BabyTrackMaster"
+      sx={{ width: '1.5rem', height: '1.5rem' }}
+    />
   );
 }

--- a/frontend-baby/src/dashboard/components/AppNavbar.tsx
+++ b/frontend-baby/src/dashboard/components/AppNavbar.tsx
@@ -7,7 +7,6 @@ import MuiToolbar from '@mui/material/Toolbar';
 import { tabsClasses } from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
-import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
 import SideMenuMobile from './SideMenuMobile';
 import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
@@ -82,24 +81,10 @@ export default function AppNavbar() {
 export function CustomIcon() {
   return (
     <Box
-      sx={{
-        width: '1.5rem',
-        height: '1.5rem',
-        bgcolor: 'black',
-        borderRadius: '999px',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        alignSelf: 'center',
-        backgroundImage:
-          'linear-gradient(135deg, hsl(210, 98%, 60%) 0%, hsl(210, 100%, 35%) 100%)',
-        color: 'hsla(210, 100%, 95%, 0.9)',
-        border: '1px solid',
-        borderColor: 'hsl(210, 100%, 55%)',
-        boxShadow: 'inset 0 2px 5px rgba(255, 255, 255, 0.3)',
-      }}
-    >
-      <DashboardRoundedIcon color="inherit" sx={{ fontSize: '1rem' }} />
-    </Box>
+      component="img"
+      src="/baby-logo.png"
+      alt="BabyTrackMaster"
+      sx={{ width: '1.5rem', height: '1.5rem' }}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- show BabyTrackMaster logo in mobile dashboard navbar by replacing placeholder icon

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*
- `npm start` *(fails to compile: Can't resolve 'dayjs')*

------
https://chatgpt.com/codex/tasks/task_e_68b332b147088327a790ac9c1fc960f4