### PR TITLE
Fix dashboard link highlighting with exact match

### DIFF
--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -39,6 +39,7 @@ export default function MenuContent() {
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
             <NavLink
               to={item.to}
+              {...(item.to === '/dashboard' ? { end: true } : {})}
               style={{ textDecoration: 'none', color: 'inherit' }}
             >
               {({ isActive }) => (
@@ -56,6 +57,7 @@ export default function MenuContent() {
           <ListItem key={index} disablePadding sx={{ display: 'block' }}>
             <NavLink
               to={item.to}
+              {...(item.to === '/dashboard' ? { end: true } : {})}
               style={{ textDecoration: 'none', color: 'inherit' }}
             >
               {({ isActive }) => (


### PR DESCRIPTION
## Summary
- ensure dashboard NavLink uses `end` to avoid partial matches

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b37d675380832789a8092f876e2816