### PR TITLE
fix: ensure labels stay visible in Cuidado form

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -64,6 +64,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="tipoId"
             value={formData.tipoId}
             onChange={handleChange}
+            InputLabelProps={{ shrink: true }}
           >
             {tipoOptions.map((option) => (
               <MenuItem key={option.id} value={option.id}>
@@ -77,6 +78,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="cantidadMl"
             value={formData.cantidadMl}
             onChange={handleChange}
+            InputLabelProps={{ shrink: true }}
           />
           <TextField
             label="Observaciones"
@@ -85,6 +87,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="observaciones"
             value={formData.observaciones}
             onChange={handleChange}
+            InputLabelProps={{ shrink: true }}
           />
         </Stack>
       </DialogContent>


### PR DESCRIPTION
## Summary
- ensure all Cuidado form TextFields have shrinking labels to remain readable

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b3806dcc748327a7bcf8500709845e