### PR TITLE
chore: update cuidados api port

### DIFF
--- a/frontend-baby/src/config.js
+++ b/frontend-baby/src/config.js
@@ -1,3 +1,3 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081';
 
 export default API_BASE_URL;


### PR DESCRIPTION
## Summary
- point frontend to api-cuidados on port 8081

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b3817fa9908327944d159fae3dc53b