### PR TITLE
Add CORS configuration for api-cuidados service

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/CorsConfig.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.babytrackmaster.api_cuidados.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated CorsConfig with explicit allowed origins, methods, and headers
- ensure security chain enables CORS using the custom configuration
- verify frontend makes requests without Access-Control-Allow-Origin header

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `rg -n "Access-Control-Allow-Origin" frontend-baby/src --stats`

------
https://chatgpt.com/codex/tasks/task_e_68b38829cfc0832793ae276f92135466