### PR TITLE
Format cuidado hour with dayjs

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -19,6 +19,8 @@ import TableRow from '@mui/material/TableRow';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -158,7 +160,9 @@ export default function Cuidados() {
           <TableBody>
             {cuidados.map((cuidado) => (
               <TableRow key={cuidado.id}>
-                <TableCell>{cuidado.inicio}</TableCell>
+                <TableCell>
+                  {dayjs(cuidado.inicio).locale('es').format('DD/MM/YYYY HH:mm')}
+                </TableCell>
                 <TableCell>{cuidado.tipoNombre}</TableCell>
                 <TableCell>{cuidado.cantidadMl ?? '-'}</TableCell>
                 <TableCell>{cuidado.observaciones}</TableCell>


### PR DESCRIPTION
## Summary
- format `cuidado.inicio` using dayjs and Spanish locale for Hora column

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*
- `npm start` (Starting the development server...)


------
https://chatgpt.com/codex/tasks/task_e_68b38cf11cb483278ff575112a975998