### PR TITLE
Aplicar formato de fecha en tarjeta de cuidados recientes

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -5,6 +5,8 @@ import Typography from '@mui/material/Typography';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 import { listarRecientes } from '../../services/cuidadosService';
 
 export default function RecentCareCard() {
@@ -28,7 +30,7 @@ export default function RecentCareCard() {
             <ListItem key={item.id} disableGutters>
               <ListItemText
                 primary={item.tipoNombre}
-                secondary={item.inicio}
+                secondary={dayjs(item.inicio).locale('es').format('DD/MM/YYYY HH:mm')}
                 primaryTypographyProps={{ variant: 'body2' }}
                 secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
               />


### PR DESCRIPTION
## Summary
- Formatea las fechas de la tarjeta de cuidados recientes con dayjs para mostrarlas como `DD/MM/YYYY HH:mm`

## Testing
- `CI=true npm test` (falla: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b38feb0b388327bd693bbd39de5e97