### PR TITLE
feat: add pagination to cuidados table

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -16,6 +16,7 @@ import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TablePagination from '@mui/material/TablePagination';
 import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -37,6 +38,8 @@ import CuidadoForm from '../components/CuidadoForm';
 export default function Cuidados() {
   const [tab, setTab] = useState(0);
   const [cuidados, setCuidados] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedCuidado, setSelectedCuidado] = useState(null);
   const bebeId = 1;
@@ -94,6 +97,15 @@ export default function Cuidados() {
       .catch((error) => {
         console.error('Error saving cuidado:', error);
       });
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
   };
 
   return (
@@ -158,7 +170,9 @@ export default function Cuidados() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {cuidados.map((cuidado) => (
+            {cuidados
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((cuidado) => (
               <TableRow key={cuidado.id}>
                 <TableCell>
                   {dayjs(cuidado.inicio).locale('es').format('DD/MM/YYYY HH:mm')}
@@ -183,9 +197,17 @@ export default function Cuidados() {
                   </IconButton>
                 </TableCell>
               </TableRow>
-            ))}
+              ))}
           </TableBody>
         </Table>
+        <TablePagination
+          component="div"
+          count={cuidados.length}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
       </TableContainer>
 
       <Card variant="outlined">

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -3,8 +3,11 @@ import API_BASE_URL from '../config';
 
 const API_CUIDADOS_URL = `${API_BASE_URL}/api/v1/cuidados`;
 
-export const listarPorBebe = (bebeId) => {
-  return axios.get(`${API_CUIDADOS_URL}/bebe/${bebeId}`);
+export const listarPorBebe = (bebeId, page, size) => {
+  const params = {};
+  if (page !== undefined) params.page = page;
+  if (size !== undefined) params.size = size;
+  return axios.get(`${API_CUIDADOS_URL}/bebe/${bebeId}`, { params });
 };
 
 export const listarRecientes = (bebeId, limit = 5) => {


### PR DESCRIPTION
## Summary
- add client-side pagination to cuidados table
- allow `listarPorBebe` service to send optional page and size params

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b39241651c8327b55c6e33501e9dbe