### PR TITLE
feat: limit care listings

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
@@ -79,11 +79,12 @@ public class CuidadoController {
 	// Listar por bebé
 	// ---------------------------------------------------------------------
 	@Operation(summary = "Listar cuidados de un bebé", description = "Lista todos los cuidados de un bebé del usuario autenticado")
-	@GetMapping("/bebe/{bebeId}")
-	public ResponseEntity<List<CuidadoResponse>> listarPorBebe(
-			@Parameter(description = "ID del bebé", example = "1") @PathVariable Long bebeId) {
-		return ResponseEntity.ok(service.listarPorBebe(bebeId));
-	}
+        @GetMapping("/bebe/{bebeId}")
+        public ResponseEntity<List<CuidadoResponse>> listarPorBebe(
+                        @Parameter(description = "ID del bebé", example = "1") @PathVariable Long bebeId,
+                        @RequestParam(value = "limit", required = false) Integer limit) {
+                return ResponseEntity.ok(service.listarPorBebe(bebeId, limit));
+        }
 
 	@Operation(summary = "Listar cuidados por bebé y tipo")
         @GetMapping("/bebe/{bebeId}/tipo/{tipoId}")

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
 
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 
 public interface CuidadoRepository extends JpaRepository<Cuidado, Long> {
     Optional<Cuidado> findByIdAndEliminadoFalse(Long id);
     List<Cuidado> findByBebeIdAndEliminadoFalseOrderByInicioDesc(Long bebeId);
+    List<Cuidado> findByBebeIdAndEliminadoFalse(Long bebeId, Pageable pageable);
     List<Cuidado> findByBebeIdAndTipo_IdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long tipoId);
     List<Cuidado> findByBebeIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
@@ -11,7 +11,7 @@ public interface CuidadoService {
     CuidadoResponse actualizar(Long id, CuidadoRequest request);
     void eliminar(Long id);
     CuidadoResponse obtener(Long id);
-    List<CuidadoResponse> listarPorBebe(Long bebeId);
+    List<CuidadoResponse> listarPorBebe(Long bebeId, Integer limit);
     List<CuidadoResponse> listarPorBebeYTipo(Long bebeId, Long tipoId);
     List<CuidadoResponse> listarPorRango(Long bebeId, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
@@ -64,8 +66,14 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
-    public List<CuidadoResponse> listarPorBebe(Long bebeId) {
-        List<Cuidado> list = repo.findByBebeIdAndEliminadoFalseOrderByInicioDesc(bebeId);
+    public List<CuidadoResponse> listarPorBebe(Long bebeId, Integer limit) {
+        List<Cuidado> list;
+        if (limit != null) {
+            list = repo.findByBebeIdAndEliminadoFalse(bebeId,
+                    PageRequest.of(0, limit, Sort.by("inicio").descending()));
+        } else {
+            list = repo.findByBebeIdAndEliminadoFalseOrderByInicioDesc(bebeId);
+        }
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));

--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -26,7 +26,7 @@ export default function RecentCareCard() {
           Cuidados Recientes
         </Typography>
         <List>
-          {recentCare.map((item) => (
+          {recentCare.slice(0, 5).map((item) => (
             <ListItem key={item.id} disableGutters>
               <ListItemText
                 primary={item.tipoNombre}


### PR DESCRIPTION
## Summary
- add optional `limit` parameter to list baby care records
- restrict recent care list on frontend to five items

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b394237fbc83279a41c45302b06c36