### PR TITLE
Scope cuidados to authenticated user

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
 import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
 import com.babytrackmaster.api_cuidados.service.CuidadoService;
+import com.babytrackmaster.api_cuidados.security.JwtService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,52 +29,58 @@ import jakarta.validation.Valid;
 @Tag(name = "Cuidados", description = "Gestión de cuidados del bebé")
 public class CuidadoController {
 
-	private final CuidadoService service;
+        private final CuidadoService service;
+        private final JwtService jwtService;
 
-	public CuidadoController(CuidadoService service) {
-		this.service = service;
-	}
+        public CuidadoController(CuidadoService service, JwtService jwtService) {
+                this.service = service;
+                this.jwtService = jwtService;
+        }
 
 	// ---------------------------------------------------------------------
 	// Crear
 	// ---------------------------------------------------------------------
 	@Operation(summary = "Crear un cuidado", description = "Crea un cuidado para el usuario autenticado")
 	@PostMapping
-	public ResponseEntity<CuidadoResponse> crear(
-			@Valid @org.springframework.web.bind.annotation.RequestBody CuidadoRequest req) {
-		return new ResponseEntity<CuidadoResponse>(service.crear(req), HttpStatus.CREATED);
-	}
+        public ResponseEntity<CuidadoResponse> crear(
+                        @Valid @org.springframework.web.bind.annotation.RequestBody CuidadoRequest req) {
+                Long usuarioId = jwtService.resolveUserId();
+                return new ResponseEntity<CuidadoResponse>(service.crear(usuarioId, req), HttpStatus.CREATED);
+        }
 
 	// ---------------------------------------------------------------------
 	// Actualizar
 	// ---------------------------------------------------------------------
 	@Operation(summary = "Actualizar un cuidado", description = "Actualiza los datos de un cuidado propio")
 	@PutMapping("/{id}")
-	public ResponseEntity<CuidadoResponse> actualizar(
-			@Parameter(description = "ID del cuidado", example = "101") @PathVariable Long id,
-			@Valid @org.springframework.web.bind.annotation.RequestBody CuidadoRequest req) {
-		return ResponseEntity.ok(service.actualizar(id, req));
-	}
+        public ResponseEntity<CuidadoResponse> actualizar(
+                        @Parameter(description = "ID del cuidado", example = "101") @PathVariable Long id,
+                        @Valid @org.springframework.web.bind.annotation.RequestBody CuidadoRequest req) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.actualizar(usuarioId, id, req));
+        }
 
 	// ---------------------------------------------------------------------
 	// Eliminar
 	// ---------------------------------------------------------------------
 	@Operation(summary = "Eliminar un cuidado", description = "Elimina un cuidado propio")
 	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> eliminar(
-			@Parameter(description = "ID del cuidado", example = "101") @PathVariable Long id) {
-		service.eliminar(id);
-		return ResponseEntity.noContent().build();
-	}
+        public ResponseEntity<Void> eliminar(
+                        @Parameter(description = "ID del cuidado", example = "101") @PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
+                service.eliminar(usuarioId, id);
+                return ResponseEntity.noContent().build();
+        }
 
 	// ---------------------------------------------------------------------
 	// Obtener por ID
 	// ---------------------------------------------------------------------
 	@Operation(summary = "Obtener un cuidado", description = "Devuelve un cuidado propio por su ID")
 	@GetMapping("/{id}")
-	public ResponseEntity<CuidadoResponse> obtener(@PathVariable Long id) {
-		return ResponseEntity.ok(service.obtener(id));
-	}
+        public ResponseEntity<CuidadoResponse> obtener(@PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.obtener(usuarioId, id));
+        }
 
 	// ---------------------------------------------------------------------
 	// Listar por bebé
@@ -83,20 +90,23 @@ public class CuidadoController {
         public ResponseEntity<List<CuidadoResponse>> listarPorBebe(
                         @Parameter(description = "ID del bebé", example = "1") @PathVariable Long bebeId,
                         @RequestParam(value = "limit", required = false) Integer limit) {
-                return ResponseEntity.ok(service.listarPorBebe(bebeId, limit));
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorBebe(usuarioId, bebeId, limit));
         }
 
 	@Operation(summary = "Listar cuidados por bebé y tipo")
         @GetMapping("/bebe/{bebeId}/tipo/{tipoId}")
         public ResponseEntity<List<CuidadoResponse>> listarPorBebeYTipo(@PathVariable Long bebeId,
                         @PathVariable Long tipoId) {
-                return ResponseEntity.ok(service.listarPorBebeYTipo(bebeId, tipoId));
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorBebeYTipo(usuarioId, bebeId, tipoId));
         }
 
 	@Operation(summary = "Listar cuidados por rango de fechas")
 	@GetMapping("/bebe/{bebeId}/rango")
-	public ResponseEntity<List<CuidadoResponse>> listarPorRango(@PathVariable Long bebeId,
-			@RequestParam("desde") Long desdeMillis, @RequestParam("hasta") Long hastaMillis) {
-		return ResponseEntity.ok(service.listarPorRango(bebeId, new Date(desdeMillis), new Date(hastaMillis)));
-	}
+        public ResponseEntity<List<CuidadoResponse>> listarPorRango(@PathVariable Long bebeId,
+                        @RequestParam("desde") Long desdeMillis, @RequestParam("hasta") Long hastaMillis) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorRango(usuarioId, bebeId, new Date(desdeMillis), new Date(hastaMillis)));
+        }
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
@@ -9,9 +9,8 @@ import lombok.Data;
 @Data
 @Schema(name = "CuidadoRequest", description = "Datos para crear/actualizar un cuidado")
 public class CuidadoRequest {
-        @Schema(example = "1", description = "ID del bebé al que pertenece el cuidado")
+    @Schema(example = "1", description = "ID del bebé al que pertenece el cuidado")
     @NotNull private Long bebeId;
-    @NotNull private Long usuarioId;
     @Schema(example = "1", description = "ID del tipo de cuidado")
     @NotNull private Long tipoId;
     @NotNull private Date inicio;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -10,10 +10,10 @@ import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
 
 public class CuidadoMapper {
 
-        public static Cuidado toEntity(CuidadoRequest req, TipoCuidadoRepository tipoRepo) {
+    public static Cuidado toEntity(CuidadoRequest req, Long usuarioId, TipoCuidadoRepository tipoRepo) {
         Cuidado c = new Cuidado();
         c.setBebeId(req.getBebeId());
-        c.setUsuarioId(req.getUsuarioId());
+        c.setUsuarioId(usuarioId);
         TipoCuidado tipo = tipoRepo.findById(req.getTipoId())
                 .orElseThrow(() -> new IllegalArgumentException("Tipo de cuidado no encontrado: " + req.getTipoId()));
         c.setTipo(tipo);
@@ -32,9 +32,9 @@ public class CuidadoMapper {
         return c;
     }
 
-    public static void copyToEntity(CuidadoRequest req, Cuidado c, TipoCuidadoRepository tipoRepo) {
+    public static void copyToEntity(CuidadoRequest req, Cuidado c, Long usuarioId, TipoCuidadoRepository tipoRepo) {
         c.setBebeId(req.getBebeId());
-        c.setUsuarioId(req.getUsuarioId());
+        c.setUsuarioId(usuarioId);
         TipoCuidado tipo = tipoRepo.findById(req.getTipoId())
                 .orElseThrow(() -> new IllegalArgumentException("Tipo de cuidado no encontrado: " + req.getTipoId()));
         c.setTipo(tipo);

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.domain.Pageable;
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 
 public interface CuidadoRepository extends JpaRepository<Cuidado, Long> {
-    Optional<Cuidado> findByIdAndEliminadoFalse(Long id);
-    List<Cuidado> findByBebeIdAndEliminadoFalseOrderByInicioDesc(Long bebeId);
-    List<Cuidado> findByBebeIdAndEliminadoFalse(Long bebeId, Pageable pageable);
-    List<Cuidado> findByBebeIdAndTipo_IdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long tipoId);
-    List<Cuidado> findByBebeIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Date desde, Date hasta);
+    Optional<Cuidado> findByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
+    List<Cuidado> findByBebeIdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long usuarioId);
+    List<Cuidado> findByBebeIdAndUsuarioIdAndEliminadoFalse(Long bebeId, Long usuarioId, Pageable pageable);
+    List<Cuidado> findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long tipoId, Long usuarioId);
+    List<Cuidado> findByBebeIdAndUsuarioIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long usuarioId, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
@@ -7,11 +7,11 @@ import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
 import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
 
 public interface CuidadoService {
-    CuidadoResponse crear(CuidadoRequest request);
-    CuidadoResponse actualizar(Long id, CuidadoRequest request);
-    void eliminar(Long id);
-    CuidadoResponse obtener(Long id);
-    List<CuidadoResponse> listarPorBebe(Long bebeId, Integer limit);
-    List<CuidadoResponse> listarPorBebeYTipo(Long bebeId, Long tipoId);
-    List<CuidadoResponse> listarPorRango(Long bebeId, Date desde, Date hasta);
+    CuidadoResponse crear(Long usuarioId, CuidadoRequest request);
+    CuidadoResponse actualizar(Long usuarioId, Long id, CuidadoRequest request);
+    void eliminar(Long usuarioId, Long id);
+    CuidadoResponse obtener(Long usuarioId, Long id);
+    List<CuidadoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit);
+    List<CuidadoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId);
+    List<CuidadoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -30,24 +30,24 @@ public class CuidadoServiceImpl implements CuidadoService {
         this.tipoRepo = tipoRepo;
     }
 
-    public CuidadoResponse crear(CuidadoRequest request) {
-        Cuidado c = CuidadoMapper.toEntity(request, tipoRepo);
+    public CuidadoResponse crear(Long usuarioId, CuidadoRequest request) {
+        Cuidado c = CuidadoMapper.toEntity(request, usuarioId, tipoRepo);
         c = repo.save(c);
         return CuidadoMapper.toResponse(c);
     }
 
-    public CuidadoResponse actualizar(Long id, CuidadoRequest request) {
-        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
+    public CuidadoResponse actualizar(Long usuarioId, Long id, CuidadoRequest request) {
+        Cuidado c = repo.findByIdAndUsuarioIdAndEliminadoFalse(id, usuarioId).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
-        CuidadoMapper.copyToEntity(request, c, tipoRepo);
+        CuidadoMapper.copyToEntity(request, c, usuarioId, tipoRepo);
         c = repo.save(c);
         return CuidadoMapper.toResponse(c);
     }
 
-    public void eliminar(Long id) {
-        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
+    public void eliminar(Long usuarioId, Long id) {
+        Cuidado c = repo.findByIdAndUsuarioIdAndEliminadoFalse(id, usuarioId).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
@@ -57,8 +57,8 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
-    public CuidadoResponse obtener(Long id) {
-        Cuidado c = repo.findByIdAndEliminadoFalse(id).orElse(null);
+    public CuidadoResponse obtener(Long usuarioId, Long id) {
+        Cuidado c = repo.findByIdAndUsuarioIdAndEliminadoFalse(id, usuarioId).orElse(null);
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
@@ -66,13 +66,13 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
-    public List<CuidadoResponse> listarPorBebe(Long bebeId, Integer limit) {
+    public List<CuidadoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit) {
         List<Cuidado> list;
         if (limit != null) {
-            list = repo.findByBebeIdAndEliminadoFalse(bebeId,
+            list = repo.findByBebeIdAndUsuarioIdAndEliminadoFalse(bebeId, usuarioId,
                     PageRequest.of(0, limit, Sort.by("inicio").descending()));
         } else {
-            list = repo.findByBebeIdAndEliminadoFalseOrderByInicioDesc(bebeId);
+            list = repo.findByBebeIdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(bebeId, usuarioId);
         }
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
@@ -82,8 +82,8 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
-    public List<CuidadoResponse> listarPorBebeYTipo(Long bebeId, Long tipoId) {
-        List<Cuidado> list = repo.findByBebeIdAndTipo_IdAndEliminadoFalseOrderByInicioDesc(bebeId, tipoId);
+    public List<CuidadoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId) {
+        List<Cuidado> list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(bebeId, tipoId, usuarioId);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));
@@ -92,8 +92,8 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
-    public List<CuidadoResponse> listarPorRango(Long bebeId, Date desde, Date hasta) {
-        List<Cuidado> list = repo.findByBebeIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(bebeId, desde, hasta);
+    public List<CuidadoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta) {
+        List<Cuidado> list = repo.findByBebeIdAndUsuarioIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(bebeId, usuarioId, desde, hasta);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();
         for (int i = 0; i < list.size(); i++) {
             resp.add(CuidadoMapper.toResponse(list.get(i)));


### PR DESCRIPTION
## Summary
- inject JwtService into CuidadoController and propagate resolved user ID to services
- add usuarioId parameter across CuidadoService and implementation, persisting and filtering by user
- adjust repository queries and DTO/mapper to remove client-supplied usuarioId

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3977091b48327b3b3a5133f84d03f