### PR TITLE
Filtrar cuidados por tab y reiniciar paginación

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -35,6 +35,8 @@ import {
 } from '../../services/cuidadosService';
 import CuidadoForm from '../components/CuidadoForm';
 
+const tipos = ['Biberón', 'Pañal', 'Sueño', 'Baño'];
+
 export default function Cuidados() {
   const [tab, setTab] = useState(0);
   const [cuidados, setCuidados] = useState([]);
@@ -44,8 +46,13 @@ export default function Cuidados() {
   const [selectedCuidado, setSelectedCuidado] = useState(null);
   const bebeId = 1;
 
+  const filteredCuidados = cuidados.filter(
+    (c) => c.tipoNombre === tipos[tab]
+  );
+
   const handleTabChange = (event, newValue) => {
     setTab(newValue);
+    setPage(0);
   };
 
   const fetchCuidados = () => {
@@ -170,7 +177,7 @@ export default function Cuidados() {
             </TableRow>
           </TableHead>
           <TableBody>
-            {cuidados
+            {filteredCuidados
               .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               .map((cuidado) => (
               <TableRow key={cuidado.id}>
@@ -202,7 +209,7 @@ export default function Cuidados() {
         </Table>
         <TablePagination
           component="div"
-          count={cuidados.length}
+          count={filteredCuidados.length}
           page={page}
           onPageChange={handleChangePage}
           rowsPerPage={rowsPerPage}


### PR DESCRIPTION
## Summary
- Declara arreglo de tipos de cuidados
- Filtra los cuidados por pestaña seleccionada y reinicia la paginación al cambiar de tab
- Usa los cuidados filtrados para mostrar datos y contar filas

## Testing
- `npm test -- --watchAll=false` *(falla: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b39bd1b2508327a71d2b11bfc625c0