### PR TITLE
feat: implement gastos dashboard page

### DIFF
--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -1,6 +1,278 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import IconButton from '@mui/material/IconButton';
+import MenuItem from '@mui/material/MenuItem';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { BarChart } from '@mui/x-charts/BarChart';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
+
+import {
+  listarPorBebe,
+  crearGasto,
+  actualizarGasto,
+  eliminarGasto,
+} from '../../services/gastosService';
+import GastoForm from '../components/GastoForm';
+
+const categoriaOptions = [
+  { id: 1, label: 'Alimentación' },
+  { id: 2, label: 'Ropa' },
+  { id: 3, label: 'Juguetes' },
+  { id: 4, label: 'Otros' },
+];
 
 export default function Gastos() {
-  return <Typography variant="h4">Gastos</Typography>;
+  const [gastos, setGastos] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [openForm, setOpenForm] = useState(false);
+  const [selectedGasto, setSelectedGasto] = useState(null);
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [monthFilter, setMonthFilter] = useState(dayjs().format('YYYY-MM'));
+  const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
+  const bebeId = 1;
+
+  const fetchGastos = () => {
+    listarPorBebe(bebeId)
+      .then((response) => {
+        setGastos(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching gastos:', error);
+      });
+  };
+
+  useEffect(() => {
+    fetchGastos();
+  }, [bebeId]);
+
+  const filteredGastos = useMemo(
+    () =>
+      gastos.filter((g) => {
+        const matchCategory = categoryFilter
+          ? Number(g.categoriaId) === Number(categoryFilter)
+          : true;
+        const matchMonth = monthFilter
+          ? dayjs(g.fecha).format('YYYY-MM') === monthFilter
+          : true;
+        return matchCategory && matchMonth;
+      }),
+    [gastos, categoryFilter, monthFilter]
+  );
+
+  const totalMes = useMemo(
+    () =>
+      filteredGastos.reduce(
+        (sum, g) => sum + Number(g.cantidad ?? 0),
+        0
+      ),
+    [filteredGastos]
+  );
+
+  useEffect(() => {
+    const stats = Array(7).fill(0);
+    filteredGastos.forEach((g) => {
+      const dayIndex = dayjs(g.fecha).day();
+      stats[(dayIndex + 6) % 7] += Number(g.cantidad ?? 0);
+    });
+    setWeeklyStats(stats);
+  }, [filteredGastos]);
+
+  const handleAdd = () => {
+    setSelectedGasto(null);
+    setOpenForm(true);
+  };
+
+  const handleEdit = (gasto) => {
+    setSelectedGasto(gasto);
+    setOpenForm(true);
+  };
+
+  const handleDelete = (id) => {
+    if (window.confirm('¿Eliminar gasto?')) {
+      eliminarGasto(id)
+        .then(() => fetchGastos())
+        .catch((error) => {
+          console.error('Error deleting gasto:', error);
+        });
+    }
+  };
+
+  const handleFormSubmit = (data) => {
+    const payload = { ...data, bebeId, usuarioId: 1 };
+    const request = selectedGasto
+      ? actualizarGasto(selectedGasto.id, payload)
+      : crearGasto(payload);
+
+    request
+      .then(() => {
+        setOpenForm(false);
+        setSelectedGasto(null);
+        fetchGastos();
+      })
+      .catch((error) => {
+        console.error('Error saving gasto:', error);
+      });
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="flex-start"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={2}
+        mb={2}
+      >
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          sx={{ alignSelf: 'flex-start' }}
+          onClick={handleAdd}
+        >
+          + Añadir gasto
+        </Button>
+        <TextField
+          select
+          label="Categoría"
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          sx={{ minWidth: 150 }}
+          InputLabelProps={{ shrink: true }}
+        >
+          <MenuItem value="">Todas</MenuItem>
+          {categoriaOptions.map((option) => (
+            <MenuItem key={option.id} value={option.id}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+        <TextField
+          label="Mes"
+          type="month"
+          value={monthFilter}
+          onChange={(e) => setMonthFilter(e.target.value)}
+          sx={{ minWidth: 150 }}
+          InputLabelProps={{ shrink: true }}
+        />
+      </Stack>
+
+      <Typography variant="h4" gutterBottom>
+        Gastos
+      </Typography>
+      <Typography variant="h6" gutterBottom>
+        Total del mes: {totalMes.toFixed(2)}
+      </Typography>
+
+      <TableContainer component={Paper} sx={{ mb: 4 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Fecha</TableCell>
+              <TableCell>Categoría</TableCell>
+              <TableCell>Descripción</TableCell>
+              <TableCell>Cantidad</TableCell>
+              <TableCell align="center">Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredGastos
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((gasto) => (
+                <TableRow key={gasto.id}>
+                  <TableCell>
+                    {dayjs(gasto.fecha).locale('es').format('DD/MM/YYYY')}
+                  </TableCell>
+                  <TableCell>
+                    {gasto.categoriaNombre ||
+                      categoriaOptions.find(
+                        (c) => Number(c.id) === Number(gasto.categoriaId)
+                      )?.label}
+                  </TableCell>
+                  <TableCell>{gasto.descripcion}</TableCell>
+                  <TableCell>{Number(gasto.cantidad).toFixed(2)}</TableCell>
+                  <TableCell align="center">
+                    <IconButton
+                      size="small"
+                      aria-label="edit"
+                      onClick={() => handleEdit(gasto)}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label="delete"
+                      onClick={() => handleDelete(gasto.id)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={filteredGastos.length}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </TableContainer>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Gastos por día de la semana
+          </Typography>
+          <BarChart
+            height={250}
+            xAxis={[
+              {
+                scaleType: 'band',
+                data: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
+              },
+            ]}
+            series={[{ data: weeklyStats }]}
+            margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+            grid={{ horizontal: true }}
+          />
+        </CardContent>
+      </Card>
+      <GastoForm
+        open={openForm}
+        onClose={() => setOpenForm(false)}
+        onSubmit={handleFormSubmit}
+        initialData={selectedGasto}
+      />
+    </Box>
+  );
 }
+


### PR DESCRIPTION
## Summary
- add full gastos dashboard page with category and date filters
- show monthly total and weekly chart for gastos
- support creating, updating and deleting gastos via service

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b4216ec8008327b3f54c451674c612