### PR TITLE
Remove duplicate plus from add expense button

### DIFF
--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -156,7 +156,7 @@ export default function Gastos() {
           sx={{ alignSelf: 'flex-start' }}
           onClick={handleAdd}
         >
-          + Añadir gasto
+          Añadir gasto
         </Button>
         <TextField
           select


### PR DESCRIPTION
## Summary
- remove extra '+' from "Añadir gasto" button to avoid two plus icons

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')


------
https://chatgpt.com/codex/tasks/task_e_68b423077bb08327801ff6ca3b560b43