### PR TITLE
feat: cargar categorias dinamicamente

### DIFF
--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -8,12 +8,7 @@ import TextField from '@mui/material/TextField';
 import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 
-const categoriaOptions = [
-  { id: 1, label: 'Alimentación' },
-  { id: 2, label: 'Ropa' },
-  { id: 3, label: 'Juguetes' },
-  { id: 4, label: 'Otros' },
-];
+import { listarCategorias } from '../../services/gastosService';
 
 export default function GastoForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -22,6 +17,7 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
     descripcion: '',
     cantidad: '',
   });
+  const [categorias, setCategorias] = useState([]);
 
   useEffect(() => {
     if (initialData) {
@@ -35,6 +31,16 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
       setFormData({ fecha: '', categoriaId: '', descripcion: '', cantidad: '' });
     }
   }, [initialData, open]);
+
+  useEffect(() => {
+    listarCategorias()
+      .then((response) => {
+        setCategorias(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching categorias:', error);
+      });
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -66,9 +72,9 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
             onChange={handleChange}
             InputLabelProps={{ shrink: true }}
           >
-            {categoriaOptions.map((option) => (
+            {categorias.map((option) => (
               <MenuItem key={option.id} value={option.id}>
-                {option.label}
+                {option.nombre}
               </MenuItem>
             ))}
           </TextField>

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -28,15 +28,9 @@ import {
   crearGasto,
   actualizarGasto,
   eliminarGasto,
+  listarCategorias,
 } from '../../services/gastosService';
 import GastoForm from '../components/GastoForm';
-
-const categoriaOptions = [
-  { id: 1, label: 'Alimentación' },
-  { id: 2, label: 'Ropa' },
-  { id: 3, label: 'Juguetes' },
-  { id: 4, label: 'Otros' },
-];
 
 export default function Gastos() {
   const [gastos, setGastos] = useState([]);
@@ -45,6 +39,7 @@ export default function Gastos() {
   const [openForm, setOpenForm] = useState(false);
   const [selectedGasto, setSelectedGasto] = useState(null);
   const [categoryFilter, setCategoryFilter] = useState('');
+  const [categorias, setCategorias] = useState([]);
   const [monthFilter, setMonthFilter] = useState(dayjs().format('YYYY-MM'));
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
   const bebeId = 1;
@@ -61,6 +56,13 @@ export default function Gastos() {
 
   useEffect(() => {
     fetchGastos();
+    listarCategorias()
+      .then((response) => {
+        setCategorias(response.data);
+      })
+      .catch((error) => {
+        console.error('Error fetching categorias:', error);
+      });
   }, [bebeId]);
 
   const filteredGastos = useMemo(
@@ -167,9 +169,9 @@ export default function Gastos() {
           InputLabelProps={{ shrink: true }}
         >
           <MenuItem value="">Todas</MenuItem>
-          {categoriaOptions.map((option) => (
+          {categorias.map((option) => (
             <MenuItem key={option.id} value={option.id}>
-              {option.label}
+              {option.nombre}
             </MenuItem>
           ))}
         </TextField>
@@ -211,9 +213,9 @@ export default function Gastos() {
                   </TableCell>
                   <TableCell>
                     {gasto.categoriaNombre ||
-                      categoriaOptions.find(
+                      categorias.find(
                         (c) => Number(c.id) === Number(gasto.categoriaId)
-                      )?.label}
+                      )?.nombre}
                   </TableCell>
                   <TableCell>{gasto.descripcion}</TableCell>
                   <TableCell>{Number(gasto.cantidad).toFixed(2)}</TableCell>

--- a/frontend-baby/src/services/gastosService.js
+++ b/frontend-baby/src/services/gastosService.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import API_BASE_URL from '../config';
 
 const API_GASTOS_URL = `${API_BASE_URL}/api/v1/gastos`;
+const API_CATEGORIAS_URL = `${API_BASE_URL}/api/v1/categorias`;
 
 export const listarPorBebe = (bebeId, page, size) => {
   const params = {};
@@ -26,5 +27,9 @@ export const actualizarGasto = (id, data) => {
 
 export const eliminarGasto = (id) => {
   return axios.delete(`${API_GASTOS_URL}/${id}`);
+};
+
+export const listarCategorias = () => {
+  return axios.get(API_CATEGORIAS_URL);
 };
 


### PR DESCRIPTION
## Summary
- agrega servicio para listar categorias de gastos
- carga categorias dinamicamente en la pagina de gastos
- carga categorias dinamicamente en el formulario de gasto

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b4257297348327881ceb5599d8cef8