### PR TITLE
Update API base URL for frontend

### DIFF
--- a/frontend-baby/src/config.js
+++ b/frontend-baby/src/config.js
@@ -1,3 +1,3 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8081';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8082';
 
 export default API_BASE_URL;


### PR DESCRIPTION
## Summary
- update default API base URL to localhost:8082 for the React frontend

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b45849729083279d38572997c41d13