### PR TITLE
feat(frontend): support microservice-specific API URLs

### DIFF
--- a/frontend-baby/src/config.js
+++ b/frontend-baby/src/config.js
@@ -1,3 +1,25 @@
-const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:8082';
+const API_USUARIOS_URL =
+  process.env.REACT_APP_API_USUARIOS_URL || 'http://localhost:8080';
+const API_CUIDADOS_URL =
+  process.env.REACT_APP_API_CUIDADOS_URL || 'http://localhost:8081';
+const API_GASTOS_URL =
+  process.env.REACT_APP_API_GASTOS_URL || 'http://localhost:8082';
+const API_HITOS_URL =
+  process.env.REACT_APP_API_HITOS_URL || 'http://localhost:8083';
+const API_CITAS_URL =
+  process.env.REACT_APP_API_CITAS_URL || 'http://localhost:8084';
+const API_DIARIO_URL =
+  process.env.REACT_APP_API_DIARIO_URL || 'http://localhost:8085';
+const API_RUTINAS_URL =
+  process.env.REACT_APP_API_RUTINAS_URL || 'http://localhost:8086';
 
-export default API_BASE_URL;
+export {
+  API_USUARIOS_URL,
+  API_CUIDADOS_URL,
+  API_GASTOS_URL,
+  API_HITOS_URL,
+  API_CITAS_URL,
+  API_DIARIO_URL,
+  API_RUTINAS_URL,
+};
+

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -1,30 +1,30 @@
 import axios from 'axios';
-import API_BASE_URL from '../config';
+import { API_CUIDADOS_URL } from '../config';
 
-const API_CUIDADOS_URL = `${API_BASE_URL}/api/v1/cuidados`;
+const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
 
 export const listarPorBebe = (bebeId, page, size) => {
   const params = {};
   if (page !== undefined) params.page = page;
   if (size !== undefined) params.size = size;
-  return axios.get(`${API_CUIDADOS_URL}/bebe/${bebeId}`, { params });
+  return axios.get(`${API_CUIDADOS_ENDPOINT}/bebe/${bebeId}`, { params });
 };
 
 export const listarRecientes = (bebeId, limit = 5) => {
-  return axios.get(`${API_CUIDADOS_URL}/bebe/${bebeId}`, {
+  return axios.get(`${API_CUIDADOS_ENDPOINT}/bebe/${bebeId}`, {
     params: { limit },
   });
 };
 
 export const crearCuidado = (data) => {
-  return axios.post(`${API_CUIDADOS_URL}`, data);
+  return axios.post(`${API_CUIDADOS_ENDPOINT}`, data);
 };
 
 export const actualizarCuidado = (id, data) => {
-  return axios.put(`${API_CUIDADOS_URL}/${id}`, data);
+  return axios.put(`${API_CUIDADOS_ENDPOINT}/${id}`, data);
 };
 
 export const eliminarCuidado = (id) => {
-  return axios.delete(`${API_CUIDADOS_URL}/${id}`);
+  return axios.delete(`${API_CUIDADOS_ENDPOINT}/${id}`);
 };
 

--- a/frontend-baby/src/services/gastosService.js
+++ b/frontend-baby/src/services/gastosService.js
@@ -1,35 +1,35 @@
 import axios from 'axios';
-import API_BASE_URL from '../config';
+import { API_GASTOS_URL } from '../config';
 
-const API_GASTOS_URL = `${API_BASE_URL}/api/v1/gastos`;
-const API_CATEGORIAS_URL = `${API_BASE_URL}/api/v1/categorias`;
+const API_GASTOS_ENDPOINT = `${API_GASTOS_URL}/api/v1/gastos`;
+const API_CATEGORIAS_ENDPOINT = `${API_GASTOS_URL}/api/v1/categorias`;
 
 export const listarPorBebe = (bebeId, page, size) => {
   const params = {};
   if (page !== undefined) params.page = page;
   if (size !== undefined) params.size = size;
-  return axios.get(`${API_GASTOS_URL}/bebe/${bebeId}`, { params });
+  return axios.get(`${API_GASTOS_ENDPOINT}/bebe/${bebeId}`, { params });
 };
 
 export const listarRecientes = (bebeId, limit = 5) => {
-  return axios.get(`${API_GASTOS_URL}/bebe/${bebeId}`, {
+  return axios.get(`${API_GASTOS_ENDPOINT}/bebe/${bebeId}`, {
     params: { limit },
   });
 };
 
 export const crearGasto = (data) => {
-  return axios.post(`${API_GASTOS_URL}`, data);
+  return axios.post(`${API_GASTOS_ENDPOINT}`, data);
 };
 
 export const actualizarGasto = (id, data) => {
-  return axios.put(`${API_GASTOS_URL}/${id}`, data);
+  return axios.put(`${API_GASTOS_ENDPOINT}/${id}`, data);
 };
 
 export const eliminarGasto = (id) => {
-  return axios.delete(`${API_GASTOS_URL}/${id}`);
+  return axios.delete(`${API_GASTOS_ENDPOINT}/${id}`);
 };
 
 export const listarCategorias = () => {
-  return axios.get(API_CATEGORIAS_URL);
+  return axios.get(API_CATEGORIAS_ENDPOINT);
 };
 

--- a/frontend-baby/src/sign-up/SignUp.js
+++ b/frontend-baby/src/sign-up/SignUp.js
@@ -16,7 +16,7 @@ import { styled } from '@mui/material/styles';
 import axios from 'axios';
 import AppTheme from '../shared-theme/AppTheme';
 import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import API_BASE_URL from '../config';
+import { API_USUARIOS_URL } from '../config';
 import { GoogleIcon, FacebookIcon, SitemarkIcon } from '../sign-up/components/CustomIcons';
 
 const Card = styled(MuiCard)(({ theme }) => ({
@@ -117,7 +117,7 @@ export default function SignUp(props) {
     setApiErrorMessage('');
     const data = new FormData(event.currentTarget);
     try {
-      await axios.post(`${API_BASE_URL}/api/v1/auth/register`, {
+      await axios.post(`${API_USUARIOS_URL}/api/v1/auth/register`, {
         nombre: data.get('name'),
         apellidos: data.get('apellidos'),
         email: data.get('email'),


### PR DESCRIPTION
## Summary
- define dedicated base URLs for usuarios, cuidados, gastos, hitos, citas, diario and rutinas services
- use usuarios service URL for sign up requests
- route cuidados and gastos services through their respective endpoints

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b457a8b6b4832796ae7aaf2ff1bc38