### PR TITLE
feat: add paginated gastos by bebé

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/GastoController.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/controller/GastoController.java
@@ -96,17 +96,30 @@ public class GastoController {
 	}
 
 	@Operation(summary = "Listar gastos por categoría", description = "Lista paginada de gastos del usuario filtrando por categoría, ordenada por fecha descendente.")
-	@GetMapping("/categoria/{categoriaId}")
-	public ResponseEntity<Page<GastoResponse>> listarPorCategoria(@PathVariable Long categoriaId,
-			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-		Long userId = jwtService.resolveUserId();
-		if (userId == null) {
-			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-		}
-		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("fecha")));
-		Page<GastoResponse> resp = gastoService.listarPorCategoria(userId, categoriaId, pageable);
-		return ResponseEntity.ok(resp);
-	}
+        @GetMapping("/categoria/{categoriaId}")
+        public ResponseEntity<Page<GastoResponse>> listarPorCategoria(@PathVariable Long categoriaId,
+                        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+                Long userId = jwtService.resolveUserId();
+                if (userId == null) {
+                        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                }
+                Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("fecha")));
+                Page<GastoResponse> resp = gastoService.listarPorCategoria(userId, categoriaId, pageable);
+                return ResponseEntity.ok(resp);
+        }
+
+        @Operation(summary = "Listar gastos por bebé", description = "Lista paginada de gastos del usuario filtrando por bebé, ordenada por fecha descendente.")
+        @GetMapping("/bebe/{bebeId}")
+        public ResponseEntity<Page<GastoResponse>> listarPorBebe(@PathVariable Long bebeId,
+                        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+                Long userId = jwtService.resolveUserId();
+                if (userId == null) {
+                        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+                }
+                Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("fecha")));
+                Page<GastoResponse> resp = gastoService.listarPorBebe(userId, bebeId, pageable);
+                return ResponseEntity.ok(resp);
+        }
 
 	@Operation(
 	        summary = "Obtener resumen mensual",

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/repository/GastoRepository.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/repository/GastoRepository.java
@@ -44,4 +44,8 @@ public interface GastoRepository extends JpaRepository<Gasto, Long> {
             LocalDate desde,
             LocalDate hasta,
             Pageable pageable);
+
+    Page<Gasto> findByUsuarioIdAndBebeIdAndEliminadoFalse(Long usuarioId,
+            Long bebeId,
+            Pageable pageable);
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/GastoService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/GastoService.java
@@ -16,6 +16,7 @@ public interface GastoService {
 
     Page<GastoResponse> listarPorMes(Long usuarioIdDelToken, int anio, int mes, Pageable pageable);
     Page<GastoResponse> listarPorCategoria(Long usuarioIdDelToken, Long categoriaId, Pageable pageable);
+    Page<GastoResponse> listarPorBebe(Long usuarioIdDelToken, Long bebeId, Pageable pageable);
 
     ResumenMensualResponse resumenMensual(Long usuarioIdDelToken, int anio, int mes);
 }

--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/GastoServiceImpl.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/service/impl/GastoServiceImpl.java
@@ -122,6 +122,20 @@ public class GastoServiceImpl implements GastoService {
     }
 
     @Transactional(readOnly = true)
+    public Page<GastoResponse> listarPorBebe(Long usuarioId, Long bebeId, Pageable pageable) {
+        Page<Gasto> page = gastoRepository.findByUsuarioIdAndBebeIdAndEliminadoFalse(usuarioId, bebeId, pageable);
+
+        List<GastoResponse> dtos = new ArrayList<GastoResponse>();
+        List<Gasto> content = page.getContent();
+        int i = 0;
+        while (i < content.size()) {
+            dtos.add(GastoMapper.toResponse(content.get(i)));
+            i++;
+        }
+        return new PageImpl<GastoResponse>(dtos, pageable, page.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
     public Page<GastoResponse> listarPorCategoria(Long usuarioId, Long categoriaId, Pageable pageable) {
         Page<Gasto> page = gastoRepository.findByUsuarioAndCategoria(usuarioId, categoriaId, pageable);
 

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -45,9 +45,9 @@ export default function Gastos() {
   const bebeId = 1;
 
   const fetchGastos = () => {
-    listarPorBebe(bebeId)
+    listarPorBebe(bebeId, page, rowsPerPage)
       .then((response) => {
-        setGastos(response.data);
+        setGastos(response.data.content ?? response.data);
       })
       .catch((error) => {
         console.error('Error fetching gastos:', error);

--- a/frontend-baby/src/services/gastosService.js
+++ b/frontend-baby/src/services/gastosService.js
@@ -4,11 +4,10 @@ import { API_GASTOS_URL } from '../config';
 const API_GASTOS_ENDPOINT = `${API_GASTOS_URL}/api/v1/gastos`;
 const API_CATEGORIAS_ENDPOINT = `${API_GASTOS_URL}/api/v1/categorias`;
 
-export const listarPorBebe = (bebeId, page, size) => {
-  const params = {};
-  if (page !== undefined) params.page = page;
-  if (size !== undefined) params.size = size;
-  return axios.get(`${API_GASTOS_ENDPOINT}/bebe/${bebeId}`, { params });
+export const listarPorBebe = (bebeId, page = 0, size = 10) => {
+  return axios.get(`${API_GASTOS_ENDPOINT}/bebe/${bebeId}`, {
+    params: { page, size },
+  });
 };
 
 export const listarRecientes = (bebeId, limit = 5) => {


### PR DESCRIPTION
## Summary
- support listing gastos by bebé with pagination in API
- update frontend to request paginated gastos and preserve pagination after adding

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM - Network is unreachable)*
- `npm test -- --watchAll=false` *(failed: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b45e104ab08327869c2cbb5b3a1cc9