### PR TITLE
style: add label spacing to care form inputs

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -56,7 +56,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="inicio"
             value={formData.inicio}
             onChange={handleChange}
-            InputLabelProps={{ shrink: true }}
+            InputLabelProps={{ shrink: true, sx: { mb: 1 } }}
           />
           <TextField
             select
@@ -64,7 +64,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="tipoId"
             value={formData.tipoId}
             onChange={handleChange}
-            InputLabelProps={{ shrink: true }}
+            InputLabelProps={{ shrink: true, sx: { mb: 1 } }}
           >
             {tipoOptions.map((option) => (
               <MenuItem key={option.id} value={option.id}>
@@ -78,7 +78,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="cantidadMl"
             value={formData.cantidadMl}
             onChange={handleChange}
-            InputLabelProps={{ shrink: true }}
+            InputLabelProps={{ shrink: true, sx: { mb: 1 } }}
           />
           <TextField
             label="Observaciones"
@@ -87,7 +87,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             name="observaciones"
             value={formData.observaciones}
             onChange={handleChange}
-            InputLabelProps={{ shrink: true }}
+            InputLabelProps={{ shrink: true, sx: { mb: 1 } }}
           />
         </Stack>
       </DialogContent>


### PR DESCRIPTION
## Summary
- add vertical spacing between labels and inputs for CuidadoForm text fields

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b464975418832783d0a5c786b8dfab