### PR TITLE
fix: adjust padding for multiline inputs

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/inputs.js
+++ b/frontend-baby/src/shared-theme/customizations/inputs.js
@@ -399,6 +399,12 @@ export const inputsCustomizations = {
             borderColor: gray[500],
           },
         }),
+        '&.MuiOutlinedInput-multiline': {
+          padding: 0,
+          '& textarea': {
+            padding: '8px 12px',
+          },
+        },
         variants: [
           {
             props: {


### PR DESCRIPTION
## Summary
- ensure multiline OutlinedInput has correct inner padding

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46a98692c8327982b837938ae97c5