### PR TITLE
fix: adjust padding for multiline inputs

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/inputs.js
+++ b/frontend-baby/src/shared-theme/customizations/inputs.js
@@ -377,11 +377,11 @@ export const inputsCustomizations = {
   },
   MuiOutlinedInput: {
     styleOverrides: {
-      input: {
-        padding: 0,
-      },
-      root: ({ theme }) => ({
-        padding: '8px 12px',
+      input: ({ ownerState }) => ({
+        padding: ownerState.multiline ? '8px 12px' : 0,
+      }),
+      root: ({ theme, ownerState }) => ({
+        padding: ownerState.multiline ? 0 : '8px 12px',
         color: (theme.vars || theme).palette.text.primary,
         borderRadius: (theme.vars || theme).shape.borderRadius,
         border: `1px solid ${(theme.vars || theme).palette.divider}`,


### PR DESCRIPTION
## Summary
- ensure multiline OutlinedInput uses conditional padding via ownerState

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46a98692c8327982b837938ae97c5