### PR TITLE
Fix multiline padding for OutlinedInput

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/inputs.js
+++ b/frontend-baby/src/shared-theme/customizations/inputs.js
@@ -377,9 +377,12 @@ export const inputsCustomizations = {
   },
   MuiOutlinedInput: {
     styleOverrides: {
-      input: ({ ownerState }) => ({
-        padding: ownerState.multiline ? '8px 12px' : 0,
-      }),
+      input: {
+        padding: 0,
+      },
+      inputMultiline: {
+        padding: '8px 12px',
+      },
       root: ({ theme, ownerState }) => ({
         padding: ownerState.multiline ? 0 : '8px 12px',
         color: (theme.vars || theme).palette.text.primary,
@@ -399,12 +402,6 @@ export const inputsCustomizations = {
             borderColor: gray[500],
           },
         }),
-        '&.MuiOutlinedInput-multiline': {
-          padding: 0,
-          '& textarea': {
-            padding: '8px 12px',
-          },
-        },
         variants: [
           {
             props: {


### PR DESCRIPTION
## Summary
- ensure multiline OutlinedInput uses consistent padding via `inputMultiline`
- retain root padding logic to avoid extra space on multiline fields

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4700b2ed4832784d95821b7586368