### PR TITLE
feat: add logout handling to mobile side menu

### DIFF
--- a/frontend-baby/src/dashboard/components/SideMenuMobile.js
+++ b/frontend-baby/src/dashboard/components/SideMenuMobile.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';
@@ -8,10 +8,19 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/AuthContext';
 import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 
 function SideMenuMobile({ open, toggleDrawer }) {
+  const { logout } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const handleLogout = () => {
+    logout();
+    toggleDrawer(false)();
+    navigate('/signin');
+  };
   return (
     <Drawer
       anchor="right"
@@ -56,7 +65,12 @@ function SideMenuMobile({ open, toggleDrawer }) {
           <Divider />
         </Stack>
         <Stack sx={{ p: 2 }}>
-          <Button variant="outlined" fullWidth startIcon={<LogoutRoundedIcon />}>
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<LogoutRoundedIcon />}
+            onClick={handleLogout}
+          >
             Cerrar sesión
           </Button>
         </Stack>

--- a/frontend-baby/src/dashboard/components/SideMenuMobile.tsx
+++ b/frontend-baby/src/dashboard/components/SideMenuMobile.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import Avatar from '@mui/material/Avatar';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
@@ -7,6 +7,8 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/AuthContext';
 import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 
@@ -16,6 +18,13 @@ interface SideMenuMobileProps {
 }
 
 export default function SideMenuMobile({ open, toggleDrawer }: SideMenuMobileProps) {
+  const { logout } = useContext(AuthContext as any);
+  const navigate = useNavigate();
+  const handleLogout = () => {
+    logout();
+    toggleDrawer(false)();
+    navigate('/signin');
+  };
   return (
     <Drawer
       anchor="right"
@@ -60,7 +69,12 @@ export default function SideMenuMobile({ open, toggleDrawer }: SideMenuMobilePro
           <Divider />
         </Stack>
         <Stack sx={{ p: 2 }}>
-          <Button variant="outlined" fullWidth startIcon={<LogoutRoundedIcon />}>
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<LogoutRoundedIcon />}
+            onClick={handleLogout}
+          >
             Cerrar sesión
           </Button>
         </Stack>


### PR DESCRIPTION
## Summary
- enable logout button in SideMenuMobile with navigation to sign in
- mirror logout logic for TypeScript version

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b474dd12d083278933e6dac94d3d31