### PR TITLE
Handle async auth token loading and protected routes

### DIFF
--- a/frontend-baby/src/components/ProtectedRoute.js
+++ b/frontend-baby/src/components/ProtectedRoute.js
@@ -3,7 +3,10 @@ import { Navigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 
 export default function ProtectedRoute({ children }) {
-  const { token } = useContext(AuthContext);
+  const { token, loading } = useContext(AuthContext);
+  if (loading) {
+    return null;
+  }
   if (!token) {
     return <Navigate to="/" replace />;
   }

--- a/frontend-baby/src/context/AuthContext.js
+++ b/frontend-baby/src/context/AuthContext.js
@@ -4,15 +4,15 @@ import axios from 'axios';
 export const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  const [token, setToken] = useState(null);
+  const [token, setToken] = useState(() => localStorage.getItem('jwt'));
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const storedToken = localStorage.getItem('jwt');
-    if (storedToken) {
-      setToken(storedToken);
-      axios.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
+    if (token) {
+      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
     }
-  }, []);
+    setLoading(false);
+  }, [token]);
 
   const login = (newToken) => {
     setToken(newToken);
@@ -31,7 +31,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, login, loginWithGoogle, logout }}>
+    <AuthContext.Provider value={{ token, loading, login, loginWithGoogle, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- initialize auth token from localStorage and expose loading state
- defer axios header setup until token is available
- avoid redirecting protected routes while auth token is loading

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*
- `NODE_OPTIONS=--experimental-vm-modules npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b476ec54848327ab6db756eb92c238