### PR TITLE
Add baby management menu entries and pages

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -12,6 +12,8 @@ import Rutinas from "./dashboard/pages/Rutinas";
 import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
 import Ayuda from "./dashboard/pages/Ayuda";
+import AnadirBebe from "./dashboard/pages/AnadirBebe";
+import ConfiguracionBebe from "./dashboard/pages/ConfiguracionBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
@@ -37,6 +39,8 @@ function App() {
             <Route path="diario" element={<Diario />} />
             <Route path="citas" element={<Citas />} />
             <Route path="rutinas" element={<Rutinas />} />
+            <Route path="anadir-bebe" element={<AnadirBebe />} />
+            <Route path="configuracion-bebe" element={<ConfiguracionBebe />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
             <Route path="ayuda" element={<Ayuda />} />

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -12,8 +12,8 @@ import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
-import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
 
 const mainListItems = [
@@ -26,8 +26,8 @@ const mainListItems = [
 ];
 
 const secondaryListItems = [
-  { text: 'Configuración', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion' },
-  { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
+  { text: 'Añadir bebe', icon: <AddCircleRoundedIcon />, to: '/dashboard/anadir-bebe' },
+  { text: 'Configuración bebe', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion-bebe' },
   { text: 'Ayuda', icon: <HelpRoundedIcon />, to: '/dashboard/ayuda' },
 ];
 

--- a/frontend-baby/src/dashboard/components/MenuContent.tsx
+++ b/frontend-baby/src/dashboard/components/MenuContent.tsx
@@ -9,8 +9,8 @@ import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import AnalyticsRoundedIcon from '@mui/icons-material/AnalyticsRounded';
 import PeopleRoundedIcon from '@mui/icons-material/PeopleRounded';
 import AssignmentRoundedIcon from '@mui/icons-material/AssignmentRounded';
+import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
-import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
 
 const mainListItems = [
@@ -21,8 +21,8 @@ const mainListItems = [
 ];
 
 const secondaryListItems = [
-  { text: 'Configuración', icon: <SettingsRoundedIcon /> },
-  { text: 'Acerca de', icon: <InfoRoundedIcon /> },
+  { text: 'Añadir bebe', icon: <AddCircleRoundedIcon /> },
+  { text: 'Configuración bebe', icon: <SettingsRoundedIcon /> },
   { text: 'Comentarios', icon: <HelpRoundedIcon /> },
 ];
 

--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function AnadirBebe() {
+  return <Typography variant="h4">Añadir bebe</Typography>;
+}
+

--- a/frontend-baby/src/dashboard/pages/ConfiguracionBebe.js
+++ b/frontend-baby/src/dashboard/pages/ConfiguracionBebe.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+export default function ConfiguracionBebe() {
+  return <Typography variant="h4">Configuración bebe</Typography>;
+}
+


### PR DESCRIPTION
## Summary
- Add "Añadir bebe" and "Configuración bebe" options to dashboard menu
- Create simple pages for adding and configuring baby
- Wire new pages into application routing

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b48f7b48bc8327a1c4decc8f9340c0