### PR TITLE
Replace 'Ayuda' option with 'Acerca de'

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -11,7 +11,6 @@ import Citas from "./dashboard/pages/Citas";
 import Rutinas from "./dashboard/pages/Rutinas";
 import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
-import Ayuda from "./dashboard/pages/Ayuda";
 import AnadirBebe from "./dashboard/pages/AnadirBebe";
 import ConfiguracionBebe from "./dashboard/pages/ConfiguracionBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
@@ -43,7 +42,6 @@ function App() {
             <Route path="configuracion-bebe" element={<ConfiguracionBebe />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
-            <Route path="ayuda" element={<Ayuda />} />
           </Route>
         </Routes>
       </Router>

--- a/frontend-baby/src/dashboard/components/CustomizedTreeView.js
+++ b/frontend-baby/src/dashboard/components/CustomizedTreeView.js
@@ -60,7 +60,7 @@ const ITEMS = [
     ],
   },
   { id: '4', label: 'Contacto', color: 'blue' },
-  { id: '5', label: 'Ayuda', color: 'blue' },
+  { id: '5', label: 'Acerca de', color: 'blue' },
 ];
 
 function DotIcon({ color }) {

--- a/frontend-baby/src/dashboard/components/CustomizedTreeView.tsx
+++ b/frontend-baby/src/dashboard/components/CustomizedTreeView.tsx
@@ -67,7 +67,7 @@ const ITEMS: TreeViewBaseItem<ExtendedTreeItemProps>[] = [
     ],
   },
   { id: '4', label: 'Contacto', color: 'blue' },
-  { id: '5', label: 'Ayuda', color: 'blue' },
+  { id: '5', label: 'Acerca de', color: 'blue' },
 ];
 
 function DotIcon({ color }: { color: string }) {

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -14,7 +14,7 @@ import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
-import HelpRoundedIcon from '@mui/icons-material/HelpRounded';
+import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 
 const mainListItems = [
   { text: 'Inicio', icon: <HomeRoundedIcon />, to: '/dashboard' },
@@ -28,7 +28,7 @@ const mainListItems = [
 const secondaryListItems = [
   { text: 'Añadir bebe', icon: <AddCircleRoundedIcon />, to: '/dashboard/anadir-bebe' },
   { text: 'Configuración bebe', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion-bebe' },
-  { text: 'Ayuda', icon: <HelpRoundedIcon />, to: '/dashboard/ayuda' },
+  { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
 ];
 
 export default function MenuContent() {

--- a/frontend-baby/src/dashboard/pages/Ayuda.js
+++ b/frontend-baby/src/dashboard/pages/Ayuda.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Typography from '@mui/material/Typography';
-
-export default function Ayuda() {
-  return <Typography variant="h4">Ayuda</Typography>;
-}


### PR DESCRIPTION
## Summary
- switch sidebar help menu entry to "Acerca de"
- update tree view labels accordingly
- remove unused Ayuda page and route

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b491ef599483279cf8a36e5e444674