### PR TITLE
Update copyright notice to BabyTrackMaster 2025

### DIFF
--- a/frontend-baby/src/dashboard/internals/components/Copyright.js
+++ b/frontend-baby/src/dashboard/internals/components/Copyright.js
@@ -16,11 +16,10 @@ export default function Copyright(props) {
       ]}
     >
       {'Copyright © '}
-      <Link color="inherit" href="https://mui.com/">
-        Sitemark
+      <Link color="inherit" href="https://babytrackmaster.com/">
+        BabyTrackMaster
       </Link>{' '}
-      {new Date().getFullYear()}
-      {'.'}
+      {'2025.'}
     </Typography>
   );
 }

--- a/frontend-baby/src/dashboard/internals/components/Copyright.tsx
+++ b/frontend-baby/src/dashboard/internals/components/Copyright.tsx
@@ -16,11 +16,10 @@ export default function Copyright(props: any) {
       ]}
     >
       {'Copyright © '}
-      <Link color="inherit" href="https://mui.com/">
-        Sitemark
+      <Link color="inherit" href="https://babytrackmaster.com/">
+        BabyTrackMaster
       </Link>{' '}
-      {new Date().getFullYear()}
-      {'.'}
+      {'2025.'}
     </Typography>
   );
 }


### PR DESCRIPTION
## Summary
- personalize frontend copyright notice to BabyTrackMaster for 2025

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b4944c40a08327b5cb1b45d643b978