### PR TITLE
refactor: redesign add baby page layout

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -12,6 +12,8 @@ import Radio from '@mui/material/Radio';
 import Switch from '@mui/material/Switch';
 import Avatar from '@mui/material/Avatar';
 import Stack from '@mui/material/Stack';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -78,120 +80,155 @@ export default function AnadirBebe() {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
       <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
+        <Typography variant="h4" sx={{ mb: 2 }}>
+          Añadir bebé
+        </Typography>
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              required
-              label="Nombre del bebé"
-              name="nombre"
-              fullWidth
-              value={formData.nombre}
-              onChange={handleChange}
-            />
+          <Grid item xs={12} md={8}>
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Datos básicos
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    required
+                    label="Nombre del bebé"
+                    name="nombre"
+                    fullWidth
+                    value={formData.nombre}
+                    onChange={handleChange}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <DatePicker
+                    label="Fecha de nacimiento"
+                    value={formData.fechaNacimiento}
+                    onChange={handleDateChange}
+                    slotProps={{ textField: { fullWidth: true } }}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <FormControl>
+                    <FormLabel>Sexo</FormLabel>
+                    <RadioGroup
+                      row
+                      name="sexo"
+                      value={formData.sexo}
+                      onChange={handleChange}
+                    >
+                      <FormControlLabel value="M" control={<Radio />} label="M" />
+                      <FormControlLabel value="F" control={<Radio />} label="F" />
+                      <FormControlLabel value="ND" control={<Radio />} label="ND" />
+                    </RadioGroup>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={formData.activo}
+                        onChange={handleChange}
+                        name="activo"
+                      />
+                    }
+                    label="Bebé activo"
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Datos de nacimiento
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Peso al nacer (kg)"
+                    name="pesoNacimiento"
+                    type="number"
+                    fullWidth
+                    value={formData.pesoNacimiento}
+                    onChange={handleChange}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Talla al nacer (cm)"
+                    name="tallaNacimiento"
+                    type="number"
+                    fullWidth
+                    value={formData.tallaNacimiento}
+                    onChange={handleChange}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Semanas de gestación"
+                    name="semanasGestacion"
+                    type="number"
+                    fullWidth
+                    value={formData.semanasGestacion}
+                    onChange={handleChange}
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Preferencias
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Color"
+                    name="color"
+                    type="color"
+                    fullWidth
+                    value={formData.color}
+                    onChange={handleChange}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Emoji"
+                    name="emoji"
+                    fullWidth
+                    value={formData.emoji}
+                    onChange={handleChange}
+                  />
+                </Grid>
+              </Grid>
+            </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
-            <DatePicker
-              label="Fecha de nacimiento"
-              value={formData.fechaNacimiento}
-              onChange={handleDateChange}
-              slotProps={{ textField: { fullWidth: true } }}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl>
-              <FormLabel>Sexo</FormLabel>
-              <RadioGroup
-                row
-                name="sexo"
-                value={formData.sexo}
-                onChange={handleChange}
-              >
-                <FormControlLabel value="M" control={<Radio />} label="M" />
-                <FormControlLabel value="F" control={<Radio />} label="F" />
-                <FormControlLabel value="ND" control={<Radio />} label="ND" />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControlLabel
-              control={
-                <Switch
-                  checked={formData.activo}
-                  onChange={handleChange}
-                  name="activo"
+
+          <Grid item xs={12} md={4}>
+            <Box component={Paper} sx={{ p: 2, textAlign: 'center' }}>
+              <Typography variant="h6" gutterBottom>
+                Foto/Identidad
+              </Typography>
+              <Stack spacing={2} alignItems="center">
+                <Avatar src={preview} sx={{ width: 120, height: 120 }} />
+                <input
+                  type="file"
+                  accept="image/*"
+                  ref={fileInputRef}
+                  style={{ display: 'none' }}
+                  onChange={handlePhotoChange}
                 />
-              }
-              label="Bebé activo"
-            />
+                <Button
+                  variant="contained"
+                  onClick={() => fileInputRef.current && fileInputRef.current.click()}
+                >
+                  Subir foto
+                </Button>
+              </Stack>
+            </Box>
           </Grid>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              label="Peso al nacer (kg)"
-              name="pesoNacimiento"
-              type="number"
-              fullWidth
-              value={formData.pesoNacimiento}
-              onChange={handleChange}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              label="Talla al nacer (cm)"
-              name="tallaNacimiento"
-              type="number"
-              fullWidth
-              value={formData.tallaNacimiento}
-              onChange={handleChange}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              label="Semanas de gestación"
-              name="semanasGestacion"
-              type="number"
-              fullWidth
-              value={formData.semanasGestacion}
-              onChange={handleChange}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              label="Color"
-              name="color"
-              type="color"
-              fullWidth
-              value={formData.color}
-              onChange={handleChange}
-              InputLabelProps={{ shrink: true }}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <TextField
-              label="Emoji"
-              name="emoji"
-              fullWidth
-              value={formData.emoji}
-              onChange={handleChange}
-            />
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <Stack direction="row" spacing={2} alignItems="center">
-              <Avatar src={preview} sx={{ width: 56, height: 56 }} />
-              <input
-                type="file"
-                accept="image/*"
-                ref={fileInputRef}
-                style={{ display: 'none' }}
-                onChange={handlePhotoChange}
-              />
-              <Button
-                variant="contained"
-                onClick={() => fileInputRef.current && fileInputRef.current.click()}
-              >
-                Subir foto
-              </Button>
-            </Stack>
-          </Grid>
+
           <Grid item xs={12}>
             <Stack direction="row" spacing={2} justifyContent="flex-end">
               <Button onClick={() => navigate(-1)}>Cancelar</Button>


### PR DESCRIPTION
## Summary
- add main header and restructure form into two-column grid
- group form fields into "Datos básicos", "Datos de nacimiento" and "Preferencias"
- add dedicated photo section and move action buttons to footer

## Testing
- `cd frontend-baby && CI=true npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b4a188cc108327a4d8f9e7ba6758a0