### PR TITLE
feat: mostrar perfil de usuario

### DIFF
--- a/frontend-baby/src/context/AuthContext.js
+++ b/frontend-baby/src/context/AuthContext.js
@@ -1,17 +1,50 @@
 import React, { createContext, useEffect, useState } from 'react';
 import axios from 'axios';
+import jwtDecode from 'jwt-decode';
+import { getCurrentUser } from '../services/usuarioService';
 
 export const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
   const [token, setToken] = useState(() => localStorage.getItem('jwt'));
   const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState(null);
 
   useEffect(() => {
-    if (token) {
-      axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-    }
-    setLoading(false);
+    const fetchUser = async () => {
+      if (token) {
+        axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+        try {
+          const response = await getCurrentUser();
+          const data = response.data || {};
+          const nombreCompleto = `${data.nombre || ''} ${
+            data.apellidos?.split(' ')[0] || ''
+          }`.trim();
+
+          let email;
+          try {
+            const decoded = jwtDecode(token);
+            email = decoded?.email;
+          } catch (e) {
+            email = undefined;
+          }
+
+          setUser({
+            ...data,
+            nombreCompleto,
+            email: email || data.email || '',
+          });
+        } catch (error) {
+          setUser(null);
+        }
+      } else {
+        delete axios.defaults.headers.common['Authorization'];
+        setUser(null);
+      }
+      setLoading(false);
+    };
+
+    fetchUser();
   }, [token]);
 
   const login = (newToken) => {
@@ -26,12 +59,13 @@ export function AuthProvider({ children }) {
 
   const logout = () => {
     setToken(null);
+    setUser(null);
     localStorage.removeItem('jwt');
     delete axios.defaults.headers.common['Authorization'];
   };
 
   return (
-    <AuthContext.Provider value={{ token, loading, login, loginWithGoogle, logout }}>
+    <AuthContext.Provider value={{ token, user, loading, login, loginWithGoogle, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
+import { AuthContext } from '../../context/AuthContext';
 
 const drawerWidth = 240;
 
@@ -24,6 +25,7 @@ const Drawer = styled(MuiDrawer)({
 });
 
 export default function SideMenu() {
+  const { user } = React.useContext(AuthContext);
   return (
     <Drawer
       variant="permanent"
@@ -76,16 +78,16 @@ export default function SideMenu() {
         >
           <Avatar
             sizes="small"
-            alt="Riley Carter"
+            alt={user?.nombreCompleto || ''}
             src="/static/images/avatar/7.jpg"
             sx={{ width: 36, height: 36 }}
           />
           <Box>
             <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: '16px' }}>
-              Riley Carter
+              {user?.nombreCompleto || ''}
             </Typography>
             <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-              riley@email.com
+              {user?.email || ''}
             </Typography>
           </Box>
         </Box>

--- a/frontend-baby/src/dashboard/components/SideMenu.tsx
+++ b/frontend-baby/src/dashboard/components/SideMenu.tsx
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
+import { AuthContext } from '../../context/AuthContext';
 
 const drawerWidth = 240;
 
@@ -24,6 +25,7 @@ const Drawer = styled(MuiDrawer)({
 });
 
 export default function SideMenu() {
+  const { user } = React.useContext(AuthContext as any);
   return (
     <Drawer
       variant="permanent"
@@ -66,16 +68,16 @@ export default function SideMenu() {
       >
         <Avatar
           sizes="small"
-          alt="Riley Carter"
+          alt={user?.nombreCompleto || ''}
           src="/static/images/avatar/7.jpg"
           sx={{ width: 36, height: 36 }}
         />
         <Box sx={{ mr: 'auto' }}>
           <Typography variant="body2" sx={{ fontWeight: 500, lineHeight: '16px' }}>
-            Riley Carter
+            {user?.nombreCompleto || ''}
           </Typography>
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
-            riley@email.com
+            {user?.email || ''}
           </Typography>
         </Box>
         <OptionsMenu />

--- a/frontend-baby/src/dashboard/components/SideMenuMobile.js
+++ b/frontend-baby/src/dashboard/components/SideMenuMobile.js
@@ -14,7 +14,7 @@ import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 
 function SideMenuMobile({ open, toggleDrawer }) {
-  const { logout } = useContext(AuthContext);
+  const { logout, user } = useContext(AuthContext);
   const navigate = useNavigate();
   const handleLogout = () => {
     logout();
@@ -47,12 +47,12 @@ function SideMenuMobile({ open, toggleDrawer }) {
           >
             <Avatar
               sizes="small"
-              alt="Riley Carter"
+              alt={user?.nombreCompleto || ''}
               src="/static/images/avatar/7.jpg"
               sx={{ width: 24, height: 24 }}
             />
             <Typography component="p" variant="h6">
-              Riley Carter
+              {user?.nombreCompleto || ''}
             </Typography>
           </Stack>
           <MenuButton showBadge>

--- a/frontend-baby/src/dashboard/components/SideMenuMobile.tsx
+++ b/frontend-baby/src/dashboard/components/SideMenuMobile.tsx
@@ -18,7 +18,7 @@ interface SideMenuMobileProps {
 }
 
 export default function SideMenuMobile({ open, toggleDrawer }: SideMenuMobileProps) {
-  const { logout } = useContext(AuthContext as any);
+  const { logout, user } = useContext(AuthContext as any);
   const navigate = useNavigate();
   const handleLogout = () => {
     logout();
@@ -51,12 +51,12 @@ export default function SideMenuMobile({ open, toggleDrawer }: SideMenuMobilePro
           >
             <Avatar
               sizes="small"
-              alt="Riley Carter"
+              alt={user?.nombreCompleto || ''}
               src="/static/images/avatar/7.jpg"
               sx={{ width: 24, height: 24 }}
             />
             <Typography component="p" variant="h6">
-              Riley Carter
+              {user?.nombreCompleto || ''}
             </Typography>
           </Stack>
           <MenuButton showBadge>

--- a/frontend-baby/src/services/usuarioService.js
+++ b/frontend-baby/src/services/usuarioService.js
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { API_USUARIOS_URL } from '../config';
+
+const API_USUARIOS_ENDPOINT = `${API_USUARIOS_URL}/api/v1/usuarios`;
+
+export const getCurrentUser = () => {
+  return axios.get(`${API_USUARIOS_ENDPOINT}/me`);
+};
+


### PR DESCRIPTION
## Summary
- fetch current user profile from API
- expose user data via AuthContext
- render user name and email in side menus

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.js')

------
https://chatgpt.com/codex/tasks/task_e_68b4dfdf06c083278646e15fb6c5d7e9