### PR TITLE
fix: adjust jwt decode import

### DIFF
--- a/frontend-baby/src/context/AuthContext.js
+++ b/frontend-baby/src/context/AuthContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useEffect, useState } from 'react';
 import axios from 'axios';
-import jwtDecode from 'jwt-decode';
+import { jwtDecode } from 'jwt-decode';
 import { getCurrentUser } from '../services/usuarioService';
 
 export const AuthContext = createContext(null);


### PR DESCRIPTION
## Summary
- switch jwt-decode to named import

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4e16a70508327bacb47a61aa050ff