### PR TITLE
feat: validate additional data form before closing

### DIFF
--- a/frontend-baby/src/dashboard/components/DatosAdicionalesForm.js
+++ b/frontend-baby/src/dashboard/components/DatosAdicionalesForm.js
@@ -10,6 +10,19 @@ import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 
 export default function DatosAdicionalesForm({ open, onClose, formData, onChange }) {
+  const handleSave = () => {
+    const hasEmptyFields = Object.values(formData).some(
+      (value) => value === undefined || value === null || String(value).trim() === ''
+    );
+
+    if (hasEmptyFields) {
+      alert('Por favor, completa todos los campos.');
+      return;
+    }
+
+    onClose();
+  };
+
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>Datos adicionales</DialogTitle>
@@ -89,7 +102,7 @@ export default function DatosAdicionalesForm({ open, onClose, formData, onChange
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={onClose} variant="contained">Guardar</Button>
+        <Button onClick={handleSave} variant="contained">Guardar</Button>
       </DialogActions>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- add `handleSave` to validate additional data form fields
- close the dialog only after confirming fields are filled

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b4ed3166c483279d7e2b9678fda30a