### PR TITLE
feat: ampliar datos del bebé

### DIFF
--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/BebeController.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/BebeController.java
@@ -32,14 +32,14 @@ public class BebeController {
     private final BebeService service;
     private final JwtService jwtService;
 
-    @Operation(summary = "Crear bebé")
+    @Operation(summary = "Crear bebé", description = "La imagen debe enviarse como Base64 en el campo imagenBebe")
     @PostMapping
     public ResponseEntity<BebeResponse> crear(@Valid @RequestBody BebeRequest req) {
         Long usuarioId = jwtService.resolveUserId();
         return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(usuarioId, req));
     }
 
-    @Operation(summary = "Actualizar bebé")
+    @Operation(summary = "Actualizar bebé", description = "La imagen debe enviarse como Base64 en el campo imagenBebe")
     @PutMapping("/{id}")
     public ResponseEntity<BebeResponse> actualizar(@PathVariable Long id, @Valid @RequestBody BebeRequest req) {
         Long usuarioId = jwtService.resolveUserId();

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/BebeRequest.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/BebeRequest.java
@@ -4,6 +4,8 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
@@ -16,4 +18,47 @@ public class BebeRequest {
 
     @NotBlank
     private String sexo;
+
+    @PositiveOrZero
+    private Double pesoNacer;
+
+    @PositiveOrZero
+    private Double tallaNacer;
+
+    @PositiveOrZero
+    private Integer semanasGestacion;
+
+    @PositiveOrZero
+    private Double pesoActual;
+
+    @PositiveOrZero
+    private Double tallaActual;
+
+    private Boolean bebeActivo;
+
+    @Size(max = 50)
+    private String numeroSs;
+
+    @Size(max = 10)
+    private String grupoSanguineo;
+
+    @Size(max = 500)
+    private String medicaciones;
+
+    @Size(max = 500)
+    private String alergias;
+
+    @Size(max = 100)
+    private String pediatra;
+
+    @Size(max = 255)
+    private String centroMedico;
+
+    @Size(max = 20)
+    private String telefonoCentroMedico;
+
+    @Size(max = 1000)
+    private String observaciones;
+
+    private byte[] imagenBebe;
 }

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/BebeResponse.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/BebeResponse.java
@@ -10,4 +10,19 @@ public class BebeResponse {
     private String nombre;
     private LocalDate fechaNacimiento;
     private String sexo;
+    private Double pesoNacer;
+    private Double tallaNacer;
+    private Integer semanasGestacion;
+    private Double pesoActual;
+    private Double tallaActual;
+    private Boolean bebeActivo;
+    private String numeroSs;
+    private String grupoSanguineo;
+    private String medicaciones;
+    private String alergias;
+    private String pediatra;
+    private String centroMedico;
+    private String telefonoCentroMedico;
+    private String observaciones;
+    private byte[] imagenBebe;
 }

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/entity/Bebe.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/entity/Bebe.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -33,6 +34,52 @@ public class Bebe {
 
     @Column(nullable = false, length = 10)
     private String sexo;
+
+    @Column(name = "peso_nacer")
+    private Double pesoNacer;
+
+    @Column(name = "talla_nacer")
+    private Double tallaNacer;
+
+    @Column(name = "semanas_gestacion")
+    private Integer semanasGestacion;
+
+    @Column(name = "peso_actual")
+    private Double pesoActual;
+
+    @Column(name = "talla_actual")
+    private Double tallaActual;
+
+    @Column(name = "bebe_activo")
+    private Boolean bebeActivo = true;
+
+    @Column(name = "numero_ss", length = 50)
+    private String numeroSs;
+
+    @Column(name = "grupo_sanguineo", length = 10)
+    private String grupoSanguineo;
+
+    @Column(length = 500)
+    private String medicaciones;
+
+    @Column(length = 500)
+    private String alergias;
+
+    @Column(length = 100)
+    private String pediatra;
+
+    @Column(name = "centro_medico", length = 255)
+    private String centroMedico;
+
+    @Column(name = "telefono_centro_medico", length = 20)
+    private String telefonoCentroMedico;
+
+    @Column(length = 1000)
+    private String observaciones;
+
+    @Lob
+    @Column(name = "imagen_bebe")
+    private byte[] imagenBebe;
 
     @Column(nullable = false)
     private Boolean eliminado = false;

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/mapper/BebeMapper.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/mapper/BebeMapper.java
@@ -12,6 +12,23 @@ public class BebeMapper {
         b.setNombre(req.getNombre());
         b.setFechaNacimiento(req.getFechaNacimiento());
         b.setSexo(req.getSexo());
+        b.setPesoNacer(req.getPesoNacer());
+        b.setTallaNacer(req.getTallaNacer());
+        b.setSemanasGestacion(req.getSemanasGestacion());
+        b.setPesoActual(req.getPesoActual());
+        b.setTallaActual(req.getTallaActual());
+        if (req.getBebeActivo() != null) {
+            b.setBebeActivo(req.getBebeActivo());
+        }
+        b.setNumeroSs(req.getNumeroSs());
+        b.setGrupoSanguineo(req.getGrupoSanguineo());
+        b.setMedicaciones(req.getMedicaciones());
+        b.setAlergias(req.getAlergias());
+        b.setPediatra(req.getPediatra());
+        b.setCentroMedico(req.getCentroMedico());
+        b.setTelefonoCentroMedico(req.getTelefonoCentroMedico());
+        b.setObservaciones(req.getObservaciones());
+        b.setImagenBebe(req.getImagenBebe());
         return b;
     }
 
@@ -22,6 +39,21 @@ public class BebeMapper {
         resp.setNombre(entity.getNombre());
         resp.setFechaNacimiento(entity.getFechaNacimiento());
         resp.setSexo(entity.getSexo());
+        resp.setPesoNacer(entity.getPesoNacer());
+        resp.setTallaNacer(entity.getTallaNacer());
+        resp.setSemanasGestacion(entity.getSemanasGestacion());
+        resp.setPesoActual(entity.getPesoActual());
+        resp.setTallaActual(entity.getTallaActual());
+        resp.setBebeActivo(entity.getBebeActivo());
+        resp.setNumeroSs(entity.getNumeroSs());
+        resp.setGrupoSanguineo(entity.getGrupoSanguineo());
+        resp.setMedicaciones(entity.getMedicaciones());
+        resp.setAlergias(entity.getAlergias());
+        resp.setPediatra(entity.getPediatra());
+        resp.setCentroMedico(entity.getCentroMedico());
+        resp.setTelefonoCentroMedico(entity.getTelefonoCentroMedico());
+        resp.setObservaciones(entity.getObservaciones());
+        resp.setImagenBebe(entity.getImagenBebe());
         return resp;
     }
 }

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/BebeServiceImpl.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/BebeServiceImpl.java
@@ -44,6 +44,51 @@ public class BebeServiceImpl implements BebeService {
         if (request.getSexo() != null) {
             bebe.setSexo(request.getSexo());
         }
+        if (request.getPesoNacer() != null) {
+            bebe.setPesoNacer(request.getPesoNacer());
+        }
+        if (request.getTallaNacer() != null) {
+            bebe.setTallaNacer(request.getTallaNacer());
+        }
+        if (request.getSemanasGestacion() != null) {
+            bebe.setSemanasGestacion(request.getSemanasGestacion());
+        }
+        if (request.getPesoActual() != null) {
+            bebe.setPesoActual(request.getPesoActual());
+        }
+        if (request.getTallaActual() != null) {
+            bebe.setTallaActual(request.getTallaActual());
+        }
+        if (request.getBebeActivo() != null) {
+            bebe.setBebeActivo(request.getBebeActivo());
+        }
+        if (request.getNumeroSs() != null) {
+            bebe.setNumeroSs(request.getNumeroSs());
+        }
+        if (request.getGrupoSanguineo() != null) {
+            bebe.setGrupoSanguineo(request.getGrupoSanguineo());
+        }
+        if (request.getMedicaciones() != null) {
+            bebe.setMedicaciones(request.getMedicaciones());
+        }
+        if (request.getAlergias() != null) {
+            bebe.setAlergias(request.getAlergias());
+        }
+        if (request.getPediatra() != null) {
+            bebe.setPediatra(request.getPediatra());
+        }
+        if (request.getCentroMedico() != null) {
+            bebe.setCentroMedico(request.getCentroMedico());
+        }
+        if (request.getTelefonoCentroMedico() != null) {
+            bebe.setTelefonoCentroMedico(request.getTelefonoCentroMedico());
+        }
+        if (request.getObservaciones() != null) {
+            bebe.setObservaciones(request.getObservaciones());
+        }
+        if (request.getImagenBebe() != null) {
+            bebe.setImagenBebe(request.getImagenBebe());
+        }
         Bebe saved = repository.save(bebe);
         return BebeMapper.toResponse(saved);
     }

--- a/api-bebe/src/test/java/com/babytrackmaster/api_bebe/repository/BebeRepositoryTest.java
+++ b/api-bebe/src/test/java/com/babytrackmaster/api_bebe/repository/BebeRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.babytrackmaster.api_bebe.repository;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
@@ -39,6 +40,49 @@ class BebeRepositoryTest {
 
         assertEquals(1, lista.size());
         assertEquals("bebe1", lista.get(0).getNombre());
+    }
+
+    @Test
+    void persistAndRetrieveAllFields() {
+        byte[] imagen = new byte[]{1, 2, 3};
+        Bebe bebe = new Bebe();
+        bebe.setUsuarioId(2L);
+        bebe.setNombre("test");
+        bebe.setFechaNacimiento(LocalDate.of(2024, 1, 1));
+        bebe.setSexo("F");
+        bebe.setPesoNacer(3.2);
+        bebe.setTallaNacer(50.0);
+        bebe.setSemanasGestacion(40);
+        bebe.setPesoActual(3.2);
+        bebe.setTallaActual(50.0);
+        bebe.setBebeActivo(false);
+        bebe.setNumeroSs("123");
+        bebe.setGrupoSanguineo("O+");
+        bebe.setMedicaciones("med");
+        bebe.setAlergias("ale");
+        bebe.setPediatra("doc");
+        bebe.setCentroMedico("centro");
+        bebe.setTelefonoCentroMedico("555");
+        bebe.setObservaciones("obs");
+        bebe.setImagenBebe(imagen);
+        repository.save(bebe);
+
+        Bebe encontrado = repository.findByIdAndUsuarioIdAndEliminadoFalse(bebe.getId(), 2L).orElseThrow();
+        assertEquals(3.2, encontrado.getPesoNacer());
+        assertEquals(50.0, encontrado.getTallaNacer());
+        assertEquals(40, encontrado.getSemanasGestacion());
+        assertEquals(3.2, encontrado.getPesoActual());
+        assertEquals(50.0, encontrado.getTallaActual());
+        assertEquals(false, encontrado.getBebeActivo());
+        assertEquals("123", encontrado.getNumeroSs());
+        assertEquals("O+", encontrado.getGrupoSanguineo());
+        assertEquals("med", encontrado.getMedicaciones());
+        assertEquals("ale", encontrado.getAlergias());
+        assertEquals("doc", encontrado.getPediatra());
+        assertEquals("centro", encontrado.getCentroMedico());
+        assertEquals("555", encontrado.getTelefonoCentroMedico());
+        assertEquals("obs", encontrado.getObservaciones());
+        assertArrayEquals(imagen, encontrado.getImagenBebe());
     }
 }
 


### PR DESCRIPTION
## Summary
- add new baby attributes including weight, size, medical info and image field
- map and persist new fields through DTOs, mapper and service
- document Base64 image upload and test persistence of all fields

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f30cf8b4832793da0f59d3ec65dc