### PR TITLE
feat: add selectable active baby context

### DIFF
--- a/frontend-baby/src/context/BabyContext.js
+++ b/frontend-baby/src/context/BabyContext.js
@@ -1,0 +1,19 @@
+import React, { createContext, useState } from 'react';
+
+export const BabyContext = createContext(null);
+
+export function BabyProvider({ children }) {
+  const initialBabies = [
+    { id: 1, nombre: 'Carlos', fechaNacimiento: '2023-01-01' },
+    { id: 2, nombre: 'Lucía', fechaNacimiento: '2022-09-15' },
+  ];
+
+  const [babies] = useState(initialBabies);
+  const [activeBaby, setActiveBaby] = useState(initialBabies[0]);
+
+  return (
+    <BabyContext.Provider value={{ babies, activeBaby, setActiveBaby }}>
+      {children}
+    </BabyContext.Provider>
+  );
+}

--- a/frontend-baby/src/dashboard/Dashboard.js
+++ b/frontend-baby/src/dashboard/Dashboard.js
@@ -9,6 +9,7 @@ import Header from './components/Header';
 import SideMenu from './components/SideMenu';
 import { Outlet } from 'react-router-dom';
 import AppTheme from '../shared-theme/AppTheme';
+import { BabyProvider } from '../context/BabyContext';
 import {
   chartsCustomizations,
   dataGridCustomizations,
@@ -25,37 +26,39 @@ const xThemeComponents = {
 
 export default function Dashboard(props) {
   return (
-    <AppTheme {...props} themeComponents={xThemeComponents}>
-      <CssBaseline enableColorScheme />
-      <Box sx={{ display: 'flex', minHeight: '100vh' }}>
-        <SideMenu />
-        <AppNavbar />
-        {/* Main content */}
-        <Box
-          component="main"
-          sx={(theme) => ({
-            flexGrow: 1,
-            minHeight: '100vh',
-            backgroundColor: theme.vars
-              ? `rgba(${theme.vars.palette.background.defaultChannel} / 1)`
-              : alpha(theme.palette.background.default, 1),
-            overflow: 'auto',
-          })}
-        >
-          <Stack
-            spacing={2}
-            sx={{
-              alignItems: 'center',
-              mx: 3,
-              pb: 5,
-              mt: { xs: 8, md: 0 },
-            }}
+    <BabyProvider>
+      <AppTheme {...props} themeComponents={xThemeComponents}>
+        <CssBaseline enableColorScheme />
+        <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+          <SideMenu />
+          <AppNavbar />
+          {/* Main content */}
+          <Box
+            component="main"
+            sx={(theme) => ({
+              flexGrow: 1,
+              minHeight: '100vh',
+              backgroundColor: theme.vars
+                ? `rgba(${theme.vars.palette.background.defaultChannel} / 1)`
+                : alpha(theme.palette.background.default, 1),
+              overflow: 'auto',
+            })}
           >
-            <Header />
-            <Outlet />
-          </Stack>
+            <Stack
+              spacing={2}
+              sx={{
+                alignItems: 'center',
+                mx: 3,
+                pb: 5,
+                mt: { xs: 8, md: 0 },
+              }}
+            >
+              <Header />
+              <Outlet />
+            </Stack>
+          </Box>
         </Box>
-      </Box>
-    </AppTheme>
+      </AppTheme>
+    </BabyProvider>
   );
 }

--- a/frontend-baby/src/dashboard/components/SelectContent.js
+++ b/frontend-baby/src/dashboard/components/SelectContent.js
@@ -3,15 +3,9 @@ import MuiAvatar from '@mui/material/Avatar';
 import MuiListItemAvatar from '@mui/material/ListItemAvatar';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListSubheader from '@mui/material/ListSubheader';
 import Select, { selectClasses } from '@mui/material/Select';
-import Divider from '@mui/material/Divider';
 import { styled } from '@mui/material/styles';
-import AddRoundedIcon from '@mui/icons-material/AddRounded';
-import DevicesRoundedIcon from '@mui/icons-material/DevicesRounded';
-import SmartphoneRoundedIcon from '@mui/icons-material/SmartphoneRounded';
-import ConstructionRoundedIcon from '@mui/icons-material/ConstructionRounded';
+import { BabyContext } from '../../context/BabyContext';
 
 const Avatar = styled(MuiAvatar)(({ theme }) => ({
   width: 28,
@@ -27,20 +21,24 @@ const ListItemAvatar = styled(MuiListItemAvatar)({
 });
 
 export default function SelectContent() {
-  const [company, setCompany] = React.useState('');
+  const { babies, activeBaby, setActiveBaby } = React.useContext(BabyContext);
 
   const handleChange = (event) => {
-    setCompany(event.target.value);
+    const selectedId = parseInt(event.target.value, 10);
+    const baby = babies.find((b) => b.id === selectedId);
+    if (baby) {
+      setActiveBaby(baby);
+    }
   };
 
   return (
     <Select
-      labelId="company-select"
-      id="company-simple-select"
-      value={company}
+      labelId="baby-select"
+      id="baby-select"
+      value={activeBaby?.id.toString() || ''}
       onChange={handleChange}
       displayEmpty
-      inputProps={{ 'aria-label': 'Seleccionar empresa' }}
+      inputProps={{ 'aria-label': 'Seleccionar bebé' }}
       fullWidth
       sx={{
         maxHeight: 56,
@@ -55,48 +53,22 @@ export default function SelectContent() {
           pl: 1,
         },
       }}
+      renderValue={(selected) => {
+        const baby = babies.find((b) => b.id.toString() === selected);
+        return baby ? baby.nombre : 'Seleccionar bebé';
+      }}
     >
-      <ListSubheader sx={{ pt: 0 }}>Producción</ListSubheader>
-      <MenuItem value="">
-        <ListItemAvatar>
-          <Avatar alt="Sitemark web">
-            <DevicesRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-web" secondary="Aplicación web" />
-      </MenuItem>
-      <MenuItem value={10}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark App">
-            <SmartphoneRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-app" secondary="Aplicación móvil" />
-      </MenuItem>
-      <MenuItem value={20}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark Store">
-            <DevicesRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-Store" secondary="Aplicación web" />
-      </MenuItem>
-      <ListSubheader>Desarrollo</ListSubheader>
-      <MenuItem value={30}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark Store">
-            <ConstructionRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-Admin" secondary="Aplicación web" />
-      </MenuItem>
-      <Divider sx={{ mx: -1 }} />
-      <MenuItem value={40}>
-        <ListItemIcon>
-          <AddRoundedIcon />
-        </ListItemIcon>
-        <ListItemText primary="Agregar producto" secondary="Aplicación web" />
-      </MenuItem>
+      {babies.map((baby) => (
+        <MenuItem key={baby.id} value={baby.id.toString()}>
+          <ListItemAvatar>
+            <Avatar alt={baby.nombre}>{baby.nombre.charAt(0)}</Avatar>
+          </ListItemAvatar>
+          <ListItemText
+            primary={baby.nombre}
+            secondary={`Nacimiento: ${baby.fechaNacimiento}`}
+          />
+        </MenuItem>
+      ))}
     </Select>
   );
 }

--- a/frontend-baby/src/dashboard/components/SelectContent.tsx
+++ b/frontend-baby/src/dashboard/components/SelectContent.tsx
@@ -3,15 +3,15 @@ import MuiAvatar from '@mui/material/Avatar';
 import MuiListItemAvatar from '@mui/material/ListItemAvatar';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListSubheader from '@mui/material/ListSubheader';
 import Select, { SelectChangeEvent, selectClasses } from '@mui/material/Select';
-import Divider from '@mui/material/Divider';
 import { styled } from '@mui/material/styles';
-import AddRoundedIcon from '@mui/icons-material/AddRounded';
-import DevicesRoundedIcon from '@mui/icons-material/DevicesRounded';
-import SmartphoneRoundedIcon from '@mui/icons-material/SmartphoneRounded';
-import ConstructionRoundedIcon from '@mui/icons-material/ConstructionRounded';
+import { BabyContext } from '../../context/BabyContext';
+
+interface Baby {
+  id: number;
+  nombre: string;
+  fechaNacimiento: string;
+}
 
 const Avatar = styled(MuiAvatar)(({ theme }) => ({
   width: 28,
@@ -27,20 +27,28 @@ const ListItemAvatar = styled(MuiListItemAvatar)({
 });
 
 export default function SelectContent() {
-  const [company, setCompany] = React.useState('');
+  const { babies, activeBaby, setActiveBaby } = React.useContext(BabyContext) as {
+    babies: Baby[];
+    activeBaby: Baby;
+    setActiveBaby: (baby: Baby) => void;
+  };
 
-  const handleChange = (event: SelectChangeEvent) => {
-    setCompany(event.target.value as string);
+  const handleChange = (event: SelectChangeEvent<string>) => {
+    const selectedId = parseInt(event.target.value, 10);
+    const baby = babies.find((b) => b.id === selectedId);
+    if (baby) {
+      setActiveBaby(baby);
+    }
   };
 
   return (
     <Select
-      labelId="company-select"
-      id="company-simple-select"
-      value={company}
+      labelId="baby-select"
+      id="baby-select"
+      value={activeBaby?.id.toString() || ''}
       onChange={handleChange}
       displayEmpty
-      inputProps={{ 'aria-label': 'Seleccionar empresa' }}
+      inputProps={{ 'aria-label': 'Seleccionar bebé' }}
       fullWidth
       sx={{
         maxHeight: 56,
@@ -55,48 +63,22 @@ export default function SelectContent() {
           pl: 1,
         },
       }}
+      renderValue={(selected) => {
+        const baby = babies.find((b) => b.id.toString() === selected);
+        return baby ? baby.nombre : 'Seleccionar bebé';
+      }}
     >
-      <ListSubheader sx={{ pt: 0 }}>Producción</ListSubheader>
-      <MenuItem value="">
-        <ListItemAvatar>
-          <Avatar alt="Sitemark web">
-            <DevicesRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-web" secondary="Aplicación web" />
-      </MenuItem>
-      <MenuItem value={10}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark App">
-            <SmartphoneRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-app" secondary="Aplicación móvil" />
-      </MenuItem>
-      <MenuItem value={20}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark Store">
-            <DevicesRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-Store" secondary="Aplicación web" />
-      </MenuItem>
-      <ListSubheader>Desarrollo</ListSubheader>
-      <MenuItem value={30}>
-        <ListItemAvatar>
-          <Avatar alt="Sitemark Store">
-            <ConstructionRoundedIcon sx={{ fontSize: '1rem' }} />
-          </Avatar>
-        </ListItemAvatar>
-        <ListItemText primary="Sitemark-Admin" secondary="Aplicación web" />
-      </MenuItem>
-      <Divider sx={{ mx: -1 }} />
-      <MenuItem value={40}>
-        <ListItemIcon>
-          <AddRoundedIcon />
-        </ListItemIcon>
-        <ListItemText primary="Agregar producto" secondary="Aplicación web" />
-      </MenuItem>
+      {babies.map((baby) => (
+        <MenuItem key={baby.id} value={baby.id.toString()}>
+          <ListItemAvatar>
+            <Avatar alt={baby.nombre}>{baby.nombre.charAt(0)}</Avatar>
+          </ListItemAvatar>
+          <ListItemText
+            primary={baby.nombre}
+            secondary={`Nacimiento: ${baby.fechaNacimiento}`}
+          />
+        </MenuItem>
+      ))}
     </Select>
   );
 }

--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -10,6 +10,7 @@ import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
 import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
 
 const drawerWidth = 240;
 
@@ -26,6 +27,7 @@ const Drawer = styled(MuiDrawer)({
 
 export default function SideMenu() {
   const { user } = React.useContext(AuthContext);
+  const { activeBaby } = React.useContext(BabyContext);
   return (
     <Drawer
       variant="permanent"
@@ -45,6 +47,9 @@ export default function SideMenu() {
       >
         <SelectContent />
       </Box>
+      <Typography variant="body2" sx={{ px: 2, pb: 1 }}>
+        {activeBaby?.nombre || ''}
+      </Typography>
       <Divider />
       <Box
         sx={{


### PR DESCRIPTION
## Summary
- add BabyContext to hold active baby and available babies
- replace static SelectContent with dynamic list from context
- show active baby in side menu and provide context across dashboard

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b4f9c09a3883278a8499071761852d