### PR TITLE
Seed reference data for allergy, blood type, and lactation

### DIFF
--- a/api-bebe/README.md
+++ b/api-bebe/README.md
@@ -13,3 +13,13 @@ CRUD básico de bebés (nombre, fecha de nacimiento, sexo, etc.).
 - Lombok
 - springdoc-openapi (**Swagger UI**)
 - Spring Cloud Config (cliente)
+
+## Inicialización de datos
+
+Al iniciar la aplicación se insertan valores predeterminados en las tablas `tipo_alergia`, `tipo_grupo_sanguineo` y `tipo_lactancia` si se encuentran vacías.
+
+- **tipo_alergia**: Ninguna, Gluten, Lactosa, Frutos secos, Polen, Ácaros, Medicamentos.
+- **tipo_grupo_sanguineo**: O+, O-, A+, A-, B+, B-, AB+, AB-.
+- **tipo_lactancia**: Lactancia exclusiva, Lactancia predominante, Lactancia mixta,
+  Lactancia complementaria, Lactancia directa, Lactancia diferida,
+  Lactancia inducida o relactación, Lactancia en tándem.

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/config/DataInitializer.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/config/DataInitializer.java
@@ -1,0 +1,86 @@
+package com.babytrackmaster.api_bebe.config;
+
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.babytrackmaster.api_bebe.entity.TipoAlergia;
+import com.babytrackmaster.api_bebe.entity.TipoGrupoSanguineo;
+import com.babytrackmaster.api_bebe.entity.TipoLactancia;
+import com.babytrackmaster.api_bebe.repository.TipoAlergiaRepository;
+import com.babytrackmaster.api_bebe.repository.TipoGrupoSanguineoRepository;
+import com.babytrackmaster.api_bebe.repository.TipoLactanciaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    private final TipoAlergiaRepository tipoAlergiaRepository;
+    private final TipoGrupoSanguineoRepository tipoGrupoSanguineoRepository;
+    private final TipoLactanciaRepository tipoLactanciaRepository;
+
+    @Bean
+    public CommandLineRunner loadInitialData() {
+        return args -> {
+            if (tipoAlergiaRepository.count() == 0) {
+                tipoAlergiaRepository.saveAll(List.of(
+                    createTipoAlergia("Ninguna"),
+                    createTipoAlergia("Gluten"),
+                    createTipoAlergia("Lactosa"),
+                    createTipoAlergia("Frutos secos"),
+                    createTipoAlergia("Polen"),
+                    createTipoAlergia("Ácaros"),
+                    createTipoAlergia("Medicamentos")
+                ));
+            }
+
+            if (tipoGrupoSanguineoRepository.count() == 0) {
+                tipoGrupoSanguineoRepository.saveAll(List.of(
+                    createTipoGrupoSanguineo("O+"),
+                    createTipoGrupoSanguineo("O-"),
+                    createTipoGrupoSanguineo("A+"),
+                    createTipoGrupoSanguineo("A-"),
+                    createTipoGrupoSanguineo("B+"),
+                    createTipoGrupoSanguineo("B-"),
+                    createTipoGrupoSanguineo("AB+"),
+                    createTipoGrupoSanguineo("AB-")
+                ));
+            }
+
+            if (tipoLactanciaRepository.count() == 0) {
+                tipoLactanciaRepository.saveAll(List.of(
+                    createTipoLactancia("Lactancia exclusiva"),
+                    createTipoLactancia("Lactancia predominante"),
+                    createTipoLactancia("Lactancia mixta"),
+                    createTipoLactancia("Lactancia complementaria"),
+                    createTipoLactancia("Lactancia directa"),
+                    createTipoLactancia("Lactancia diferida"),
+                    createTipoLactancia("Lactancia inducida o relactación"),
+                    createTipoLactancia("Lactancia en tándem")
+                ));
+            }
+        };
+    }
+
+    private TipoAlergia createTipoAlergia(String nombre) {
+        TipoAlergia ta = new TipoAlergia();
+        ta.setNombre(nombre);
+        return ta;
+    }
+
+    private TipoGrupoSanguineo createTipoGrupoSanguineo(String nombre) {
+        TipoGrupoSanguineo tgs = new TipoGrupoSanguineo();
+        tgs.setNombre(nombre);
+        return tgs;
+    }
+
+    private TipoLactancia createTipoLactancia(String nombre) {
+        TipoLactancia tl = new TipoLactancia();
+        tl.setNombre(nombre);
+        return tl;
+    }
+}

--- a/api-bebe/src/test/java/com/babytrackmaster/api_bebe/DataInitializerTest.java
+++ b/api-bebe/src/test/java/com/babytrackmaster/api_bebe/DataInitializerTest.java
@@ -1,0 +1,55 @@
+package com.babytrackmaster.api_bebe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.babytrackmaster.api_bebe.entity.TipoAlergia;
+import com.babytrackmaster.api_bebe.entity.TipoGrupoSanguineo;
+import com.babytrackmaster.api_bebe.entity.TipoLactancia;
+import com.babytrackmaster.api_bebe.repository.TipoAlergiaRepository;
+import com.babytrackmaster.api_bebe.repository.TipoGrupoSanguineoRepository;
+import com.babytrackmaster.api_bebe.repository.TipoLactanciaRepository;
+
+@SpringBootTest
+class DataInitializerTest {
+
+    @Autowired
+    private TipoAlergiaRepository tipoAlergiaRepository;
+
+    @Autowired
+    private TipoGrupoSanguineoRepository tipoGrupoSanguineoRepository;
+
+    @Autowired
+    private TipoLactanciaRepository tipoLactanciaRepository;
+
+    @Test
+    void repositoriesArePopulated() {
+        List<String> alergias = tipoAlergiaRepository.findAll().stream()
+                .map(TipoAlergia::getNombre)
+                .toList();
+        assertEquals(7, alergias.size());
+        assertTrue(alergias.containsAll(List.of(
+                "Ninguna", "Gluten", "Lactosa", "Frutos secos", "Polen", "Ácaros", "Medicamentos")));
+
+        List<String> grupos = tipoGrupoSanguineoRepository.findAll().stream()
+                .map(TipoGrupoSanguineo::getNombre)
+                .toList();
+        assertEquals(8, grupos.size());
+        assertTrue(grupos.containsAll(List.of(
+                "O+", "O-", "A+", "A-", "B+", "B-", "AB+", "AB-")));
+
+        List<String> lactancias = tipoLactanciaRepository.findAll().stream()
+                .map(TipoLactancia::getNombre)
+                .toList();
+        assertEquals(8, lactancias.size());
+        assertTrue(lactancias.containsAll(List.of(
+                "Lactancia exclusiva", "Lactancia predominante", "Lactancia mixta", "Lactancia complementaria",
+                "Lactancia directa", "Lactancia diferida", "Lactancia inducida o relactación", "Lactancia en tándem")));
+    }
+}


### PR DESCRIPTION
## Summary
- add configuration component that seeds reference tables on application startup
- document default values loaded for allergies, blood groups, and lactation types
- integration test ensures repositories contain expected values

## Testing
- `mvn -q test` *(fails: Network is unreachable when resolving Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a93b96008327b15bdcee29249201