### PR TITLE
feat(api-cuidados): seed default TipoCuidado data

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
@@ -1,0 +1,44 @@
+package com.babytrackmaster.api_cuidados.config;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    private final TipoCuidadoRepository tipoCuidadoRepository;
+
+    @Bean
+    public CommandLineRunner loadInitialData() {
+        return args -> {
+            if (tipoCuidadoRepository.count() == 0) {
+                tipoCuidadoRepository.saveAll(List.of(
+                    createTipoCuidado("Higiene"),
+                    createTipoCuidado("Alimentación"),
+                    createTipoCuidado("Sueño"),
+                    createTipoCuidado("Salud"),
+                    createTipoCuidado("Recreación")
+                ));
+            }
+        };
+    }
+
+    private TipoCuidado createTipoCuidado(String nombre) {
+        TipoCuidado tc = new TipoCuidado();
+        Date now = new Date();
+        tc.setNombre(nombre);
+        tc.setCreatedAt(now);
+        tc.setUpdatedAt(now);
+        return tc;
+    }
+}


### PR DESCRIPTION
## Summary
- add DataInitializer configuration to seed default TipoCuidado entries

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aee57ac88327ab4c9422b26bd446