### PR TITLE
feat(api-citas): seed default appointment types

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
@@ -1,0 +1,41 @@
+package com.babytrackmaster.api_citas.config;
+
+import java.util.List;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+
+import com.babytrackmaster.api_citas.entity.TipoCita;
+import com.babytrackmaster.api_citas.repository.TipoCitaRepository;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    private final TipoCitaRepository tipoCitaRepository;
+
+    @Bean
+    public CommandLineRunner loadInitialData() {
+        return args -> {
+            if (tipoCitaRepository.count() == 0) {
+                tipoCitaRepository.saveAll(List.of(
+                    createTipoCita("Consulta pediátrica"),
+                    createTipoCita("Vacunación"),
+                    createTipoCita("Revisión general"),
+                    createTipoCita("Emergencia"),
+                    createTipoCita("Seguimiento nutricional")
+                ));
+            }
+        };
+    }
+
+    private TipoCita createTipoCita(String nombre) {
+        TipoCita tipo = new TipoCita();
+        tipo.setNombre(nombre);
+        return tipo;
+    }
+}
+


### PR DESCRIPTION
## Summary
- initialize default TipoCita records at startup when empty

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b036e88c83278ea4df1a6c154447