### PR TITLE
feat: fetch babies list and allow adding

### DIFF
--- a/frontend-baby/src/context/BabyContext.js
+++ b/frontend-baby/src/context/BabyContext.js
@@ -1,18 +1,34 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
+import { getBebes } from '../services/bebesService';
 
 export const BabyContext = createContext(null);
 
 export function BabyProvider({ children }) {
-  const initialBabies = [
-    { id: 1, nombre: 'Carlos', fechaNacimiento: '2023-01-01' },
-    { id: 2, nombre: 'Lucía', fechaNacimiento: '2022-09-15' },
-  ];
+  const [babies, setBabies] = useState([]);
+  const [activeBaby, setActiveBaby] = useState(null);
 
-  const [babies] = useState(initialBabies);
-  const [activeBaby, setActiveBaby] = useState(initialBabies[0]);
+  useEffect(() => {
+    const fetchBabies = async () => {
+      try {
+        const response = await getBebes();
+        const data = response.data || [];
+        setBabies(data);
+        setActiveBaby(data[0] || null);
+      } catch (error) {
+        console.error('Error fetching babies', error);
+      }
+    };
+
+    fetchBabies();
+  }, []);
+
+  const addBaby = (baby) => {
+    setBabies((prev) => [...prev, baby]);
+    setActiveBaby(baby);
+  };
 
   return (
-    <BabyContext.Provider value={{ babies, activeBaby, setActiveBaby }}>
+    <BabyContext.Provider value={{ babies, activeBaby, setActiveBaby, addBaby }}>
       {children}
     </BabyContext.Provider>
   );

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -8,3 +8,7 @@ export const crearBebe = (payload, headers = {}) => {
     headers: { 'Content-Type': 'application/json', ...headers },
   });
 };
+
+export const getBebes = () => {
+  return axios.get(API_BEBES_ENDPOINT);
+};


### PR DESCRIPTION
## Summary
- add service to list babies
- load babies in context and expose addBaby helper

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b4c9624483279070d1e1d139c475