### PR TITLE
Filtrar bebés inactivos al listar

### DIFF
--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/repository/BebeRepository.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/repository/BebeRepository.java
@@ -10,4 +10,5 @@ import com.babytrackmaster.api_bebe.entity.Bebe;
 public interface BebeRepository extends JpaRepository<Bebe, Long> {
     Optional<Bebe> findByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
     List<Bebe> findByUsuarioIdAndEliminadoFalseOrderByFechaNacimientoAsc(Long usuarioId);
+    List<Bebe> findByUsuarioIdAndBebeActivoTrueAndEliminadoFalseOrderByFechaNacimientoAsc(Long usuarioId);
 }

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/BebeServiceImpl.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/BebeServiceImpl.java
@@ -148,7 +148,7 @@ public class BebeServiceImpl implements BebeService {
     @Override
     @Transactional(readOnly = true)
     public List<BebeResponse> listar(Long usuarioId) {
-        return repository.findByUsuarioIdAndEliminadoFalseOrderByFechaNacimientoAsc(usuarioId)
+        return repository.findByUsuarioIdAndBebeActivoTrueAndEliminadoFalseOrderByFechaNacimientoAsc(usuarioId)
             .stream().map(BebeMapper::toResponse).collect(Collectors.toList());
     }
 }

--- a/api-bebe/src/test/java/com/babytrackmaster/api_bebe/service/BebeServiceImplTest.java
+++ b/api-bebe/src/test/java/com/babytrackmaster/api_bebe/service/BebeServiceImplTest.java
@@ -1,0 +1,55 @@
+package com.babytrackmaster.api_bebe.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.babytrackmaster.api_bebe.dto.BebeResponse;
+import com.babytrackmaster.api_bebe.entity.Bebe;
+import com.babytrackmaster.api_bebe.repository.BebeRepository;
+
+@SpringBootTest
+class BebeServiceImplTest {
+
+    @Autowired
+    private BebeService bebeService;
+
+    @Autowired
+    private BebeRepository bebeRepository;
+
+    @AfterEach
+    void cleanup() {
+        bebeRepository.deleteAll();
+    }
+
+    @Test
+    void listarExcludesInactiveBabies() {
+        Bebe activo = new Bebe();
+        activo.setUsuarioId(1L);
+        activo.setNombre("Activo");
+        activo.setFechaNacimiento(LocalDate.of(2020, 1, 1));
+        activo.setSexo("M");
+
+        Bebe inactivo = new Bebe();
+        inactivo.setUsuarioId(1L);
+        inactivo.setNombre("Inactivo");
+        inactivo.setFechaNacimiento(LocalDate.of(2021, 1, 1));
+        inactivo.setSexo("M");
+        inactivo.setBebeActivo(false);
+
+        bebeRepository.save(activo);
+        bebeRepository.save(inactivo);
+
+        List<BebeResponse> result = bebeService.listar(1L);
+
+        assertEquals(1, result.size());
+        assertEquals("Activo", result.get(0).getNombre());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Agrega consulta en repositorio para obtener bebés activos ordenados por fecha de nacimiento
- Actualiza servicio para listar solo bebés activos
- Añade prueba que asegura que los bebés inactivos no aparecen en la lista

## Testing
- `./mvnw -q test` *(falla: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c69e741c8327960d2984bfe8d854