### PR TITLE
feat(frontend): use active baby from context

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { BabyContext } from '../../context/BabyContext';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
@@ -11,12 +12,15 @@ import { listarRecientes } from '../../services/cuidadosService';
 
 export default function RecentCareCard() {
   const [recentCare, setRecentCare] = useState([]);
-  const bebeId = 1;
+  const { activeBaby } = React.useContext(BabyContext);
+  const bebeId = activeBaby?.id;
 
   useEffect(() => {
-    listarRecientes(bebeId)
-      .then((response) => setRecentCare(response.data))
-      .catch((error) => console.error('Error fetching recent care:', error));
+    if (bebeId) {
+      listarRecientes(bebeId)
+        .then((response) => setRecentCare(response.data))
+        .catch((error) => console.error('Error fetching recent care:', error));
+    }
   }, [bebeId]);
 
   return (

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -29,6 +29,7 @@ import {
   eliminarCuidado,
 } from '../../services/cuidadosService';
 import CuidadoForm from '../components/CuidadoForm';
+import { BabyContext } from '../../context/BabyContext';
 
 const tipos = ['Biberón', 'Pañal', 'Sueño', 'Baño'];
 
@@ -39,7 +40,8 @@ export default function Cuidados() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedCuidado, setSelectedCuidado] = useState(null);
-  const bebeId = 1;
+  const { activeBaby } = React.useContext(BabyContext);
+  const bebeId = activeBaby?.id;
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
 
   const filteredCuidados = useMemo(
@@ -62,6 +64,7 @@ export default function Cuidados() {
   };
 
   const fetchCuidados = () => {
+    if (!bebeId) return;
     listarPorBebe(bebeId)
       .then((response) => {
         setCuidados(response.data);
@@ -72,7 +75,9 @@ export default function Cuidados() {
   };
 
   useEffect(() => {
-    fetchCuidados();
+    if (bebeId) {
+      fetchCuidados();
+    }
   }, [bebeId]);
 
   const handleAdd = () => {
@@ -86,6 +91,7 @@ export default function Cuidados() {
   };
 
   const handleDelete = (id) => {
+    if (!bebeId) return;
     if (window.confirm('¿Eliminar cuidado?')) {
       eliminarCuidado(id)
         .then(() => fetchCuidados())
@@ -96,6 +102,7 @@ export default function Cuidados() {
   };
 
   const handleFormSubmit = (data) => {
+    if (!bebeId) return;
     const payload = { ...data, bebeId, usuarioId: 1 };
     const request = selectedCuidado
       ? actualizarCuidado(selectedCuidado.id, payload)

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -33,6 +33,7 @@ import {
   listarCategorias,
 } from '../../services/gastosService';
 import GastoForm from '../components/GastoForm';
+import { BabyContext } from '../../context/BabyContext';
 
 export default function Gastos() {
   const [gastos, setGastos] = useState([]);
@@ -44,9 +45,11 @@ export default function Gastos() {
   const [categorias, setCategorias] = useState([]);
   const [monthFilter, setMonthFilter] = useState(dayjs().format('YYYY-MM'));
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
-  const bebeId = 1;
+  const { activeBaby } = React.useContext(BabyContext);
+  const bebeId = activeBaby?.id;
 
   const fetchGastos = () => {
+    if (!bebeId) return;
     listarPorBebe(bebeId, page, rowsPerPage)
       .then((response) => {
         setGastos(response.data.content ?? response.data);
@@ -57,14 +60,16 @@ export default function Gastos() {
   };
 
   useEffect(() => {
-    fetchGastos();
-    listarCategorias()
-      .then((response) => {
-        setCategorias(response.data);
-      })
-      .catch((error) => {
-        console.error('Error fetching categorias:', error);
-      });
+    if (bebeId) {
+      fetchGastos();
+      listarCategorias()
+        .then((response) => {
+          setCategorias(response.data);
+        })
+        .catch((error) => {
+          console.error('Error fetching categorias:', error);
+        });
+    }
   }, [bebeId]);
 
   const filteredGastos = useMemo(
@@ -110,6 +115,7 @@ export default function Gastos() {
   };
 
   const handleDelete = (id) => {
+    if (!bebeId) return;
     if (window.confirm('¿Eliminar gasto?')) {
       eliminarGasto(id)
         .then(() => fetchGastos())
@@ -120,6 +126,7 @@ export default function Gastos() {
   };
 
   const handleFormSubmit = (data) => {
+    if (!bebeId) return;
     const payload = { ...data, bebeId, usuarioId: 1 };
     const request = selectedGasto
       ? actualizarGasto(selectedGasto.id, payload)


### PR DESCRIPTION
## Summary
- retrieve active baby from BabyContext and derive bebeId
- guard gastos, cuidados and recent care API calls on bebeId

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b5c93fb1f48327b489127365e7a022