### PR TITLE
refactor: rely on active baby context

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -103,7 +103,7 @@ export default function Cuidados() {
 
   const handleFormSubmit = (data) => {
     if (!bebeId) return;
-    const payload = { ...data, bebeId, usuarioId: 1 };
+    const payload = { ...data, bebeId };
     const request = selectedCuidado
       ? actualizarCuidado(selectedCuidado.id, payload)
       : crearCuidado(payload);

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -127,7 +127,7 @@ export default function Gastos() {
 
   const handleFormSubmit = (data) => {
     if (!bebeId) return;
-    const payload = { ...data, bebeId, usuarioId: 1 };
+    const payload = { ...data, bebeId };
     const request = selectedGasto
       ? actualizarGasto(selectedGasto.id, payload)
       : crearGasto(payload);


### PR DESCRIPTION
## Summary
- remove hardcoded user id from care and expense forms
- use active baby id from context for payloads

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ca3988688327bfde84adf35cd507