### PR TITLE
feat: add baby edit screen

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -12,7 +12,7 @@ import Rutinas from "./dashboard/pages/Rutinas";
 import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
 import AnadirBebe from "./dashboard/pages/AnadirBebe";
-import ConfiguracionBebe from "./dashboard/pages/ConfiguracionBebe";
+import EditarBebe from "./dashboard/pages/EditarBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
@@ -39,7 +39,7 @@ function App() {
             <Route path="citas" element={<Citas />} />
             <Route path="rutinas" element={<Rutinas />} />
             <Route path="anadir-bebe" element={<AnadirBebe />} />
-            <Route path="configuracion-bebe" element={<ConfiguracionBebe />} />
+            <Route path="editar-bebe" element={<EditarBebe />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
           </Route>

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -27,7 +27,7 @@ const mainListItems = [
 
 const secondaryListItems = [
   { text: 'Añadir bebe', icon: <AddCircleRoundedIcon />, to: '/dashboard/anadir-bebe' },
-  { text: 'Configuración bebe', icon: <SettingsRoundedIcon />, to: '/dashboard/configuracion-bebe' },
+  { text: 'Editar bebé', icon: <SettingsRoundedIcon />, to: '/dashboard/editar-bebe' },
   { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
 ];
 

--- a/frontend-baby/src/dashboard/components/MenuContent.tsx
+++ b/frontend-baby/src/dashboard/components/MenuContent.tsx
@@ -22,7 +22,7 @@ const mainListItems = [
 
 const secondaryListItems = [
   { text: 'Añadir bebe', icon: <AddCircleRoundedIcon /> },
-  { text: 'Configuración bebe', icon: <SettingsRoundedIcon /> },
+  { text: 'Editar bebé', icon: <SettingsRoundedIcon /> },
   { text: 'Comentarios', icon: <HelpRoundedIcon /> },
 ];
 

--- a/frontend-baby/src/dashboard/pages/ConfiguracionBebe.js
+++ b/frontend-baby/src/dashboard/pages/ConfiguracionBebe.js
@@ -1,7 +1,0 @@
-import React from 'react';
-import Typography from '@mui/material/Typography';
-
-export default function ConfiguracionBebe() {
-  return <Typography variant="h4">Configuración bebe</Typography>;
-}
-

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -1,0 +1,436 @@
+import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import RadioGroup from '@mui/material/RadioGroup';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Radio from '@mui/material/Radio';
+import Switch from '@mui/material/Switch';
+import Avatar from '@mui/material/Avatar';
+import Stack from '@mui/material/Stack';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import dayjs from 'dayjs';
+import { actualizarBebe } from '../../services/bebesService';
+import { BabyContext } from '../../context/BabyContext';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+
+export default function EditarBebe() {
+  const navigate = useNavigate();
+  const { activeBaby, setActiveBaby } = useContext(BabyContext);
+  const fileInputRef = useRef(null);
+  const [preview, setPreview] = useState(null);
+  const [formData, setFormData] = useState({
+    nombre: '',
+    fechaNacimiento: null,
+    sexo: 'ND',
+    bebeActivo: true,
+    pesoNacer: '',
+    tallaNacer: '',
+    perimetroCranealNacer: '',
+    semanasGestacion: '',
+    imagenBebe: null,
+    numeroSs: '',
+    grupoSanguineo: '',
+    medicaciones: '',
+    alergias: '',
+    pediatra: '',
+    centroMedico: '',
+    telefonoCentroMedico: '',
+    observaciones: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+
+  useEffect(() => {
+    if (activeBaby) {
+      setFormData({
+        nombre: activeBaby.nombre || '',
+        fechaNacimiento: activeBaby.fechaNacimiento ? dayjs(activeBaby.fechaNacimiento) : null,
+        sexo: activeBaby.sexo || 'ND',
+        bebeActivo: activeBaby.bebeActivo ?? true,
+        pesoNacer: activeBaby.pesoNacer || '',
+        tallaNacer: activeBaby.tallaNacer || '',
+        perimetroCranealNacer: activeBaby.perimetroCranealNacer || '',
+        semanasGestacion: activeBaby.semanasGestacion || '',
+        imagenBebe: null,
+        numeroSs: activeBaby.numeroSs || '',
+        grupoSanguineo: activeBaby.grupoSanguineo || '',
+        medicaciones: activeBaby.medicaciones || '',
+        alergias: activeBaby.alergias || '',
+        pediatra: activeBaby.pediatra || '',
+        centroMedico: activeBaby.centroMedico || '',
+        telefonoCentroMedico: activeBaby.telefonoCentroMedico || '',
+        observaciones: activeBaby.observaciones || '',
+      });
+      if (activeBaby.imagenBebe) {
+        setPreview(`data:image/*;base64,${activeBaby.imagenBebe}`);
+      }
+    }
+  }, [activeBaby]);
+
+  const handleCloseSnackbar = (_, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpenSnackbar(false);
+    navigate(-1);
+  };
+
+  const gruposSanguineos = ['O+', 'O-', 'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-'];
+  const alergiasOptions = ['Ninguna', 'Gluten', 'Lactosa', 'Frutos secos', 'Polen', 'Ácaros', 'Medicamentos'];
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value,
+    }));
+  };
+
+  const handleDateChange = (newValue) => {
+    setFormData((prev) => ({ ...prev, fechaNacimiento: newValue }));
+  };
+
+  const handlePhotoChange = (e) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setFormData((prev) => ({ ...prev, imagenBebe: file }));
+      setPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const toBase64 = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => resolve(reader.result.split(',')[1]);
+      reader.onerror = (error) => reject(error);
+    });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {};
+    await Promise.all(
+      Object.entries(formData).map(async ([key, value]) => {
+        if (value !== null && value !== '') {
+          if (dayjs.isDayjs(value)) {
+            payload[key] = value.format('YYYY-MM-DD');
+          } else if (key === 'imagenBebe' && value instanceof File) {
+            payload[key] = await toBase64(value);
+          } else {
+            payload[key] = value;
+          }
+        }
+      })
+    );
+
+    if (!activeBaby?.id) return;
+
+    setLoading(true);
+    try {
+      const response = await actualizarBebe(activeBaby.id, payload);
+      setActiveBaby(response.data);
+      setOpenSnackbar(true);
+    } catch (error) {
+      console.error('Error updating baby:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
+        <Typography variant="h4" sx={{ mb: 2 }}>
+          Editar bebé
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={8}>
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Datos básicos
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    required
+                    label="Nombre del bebé"
+                    name="nombre"
+                    fullWidth
+                    value={formData.nombre}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <DatePicker
+                    label="Fecha de nacimiento"
+                    value={formData.fechaNacimiento}
+                    onChange={handleDateChange}
+                    disabled={loading}
+                    slotProps={{ textField: { fullWidth: true, disabled: loading } }}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <FormControl>
+                    <FormLabel>Sexo</FormLabel>
+                    <RadioGroup
+                      row
+                      name="sexo"
+                      value={formData.sexo}
+                      onChange={handleChange}
+                    >
+                      <FormControlLabel value="M" control={<Radio />} label="M" disabled={loading} />
+                      <FormControlLabel value="F" control={<Radio />} label="F" disabled={loading} />
+                      <FormControlLabel value="ND" control={<Radio />} label="ND" disabled={loading} />
+                    </RadioGroup>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={formData.bebeActivo}
+                        onChange={handleChange}
+                        name="bebeActivo"
+                        disabled={loading}
+                      />
+                    }
+                    label="Bebé activo"
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Datos de nacimiento
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Peso al nacer (kg)"
+                    name="pesoNacer"
+                    type="number"
+                    fullWidth
+                    value={formData.pesoNacer}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Talla al nacer (cm)"
+                    name="tallaNacer"
+                    type="number"
+                    fullWidth
+                    value={formData.tallaNacer}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Perímetro craneal al nacer (cm)"
+                    name="perimetroCranealNacer"
+                    type="number"
+                    fullWidth
+                    value={formData.perimetroCranealNacer}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Semanas de gestación"
+                    name="semanasGestacion"
+                    type="number"
+                    fullWidth
+                    value={formData.semanasGestacion}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Salud
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={4}>
+                  <TextField
+                    select
+                    label="Grupo sanguíneo"
+                    name="grupoSanguineo"
+                    fullWidth
+                    value={formData.grupoSanguineo}
+                    onChange={handleChange}
+                    disabled={loading}
+                  >
+                    {gruposSanguineos.map((grupo) => (
+                      <MenuItem key={grupo} value={grupo}>
+                        {grupo}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Grid>
+                <Grid item xs={12} sm={4}>
+                  <TextField
+                    select
+                    label="Alergias"
+                    name="alergias"
+                    fullWidth
+                    value={formData.alergias}
+                    onChange={handleChange}
+                    disabled={loading}
+                  >
+                    {alergiasOptions.map((alergia) => (
+                      <MenuItem key={alergia} value={alergia}>
+                        {alergia}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                </Grid>
+                <Grid item xs={12} sm={4}>
+                  <TextField
+                    label="Medicaciones"
+                    name="medicaciones"
+                    fullWidth
+                    value={formData.medicaciones}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Datos clínicos
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Número SS"
+                    name="numeroSs"
+                    fullWidth
+                    value={formData.numeroSs}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Pediatra"
+                    name="pediatra"
+                    fullWidth
+                    value={formData.pediatra}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Centro médico"
+                    name="centroMedico"
+                    fullWidth
+                    value={formData.centroMedico}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6}>
+                  <TextField
+                    label="Número centro médico"
+                    name="telefonoCentroMedico"
+                    fullWidth
+                    value={formData.telefonoCentroMedico}
+                    onChange={handleChange}
+                    disabled={loading}
+                  />
+                </Grid>
+              </Grid>
+            </Box>
+
+            <Box component={Paper} sx={{ p: 2, mb: 2 }}>
+              <Typography variant="h6" gutterBottom>
+                Observaciones
+              </Typography>
+              <TextField
+                multiline
+                rows={4}
+                name="observaciones"
+                fullWidth
+                value={formData.observaciones}
+                onChange={handleChange}
+                disabled={loading}
+              />
+            </Box>
+          </Grid>
+
+          <Grid item xs={12} md={4}>
+            <Box component={Paper} sx={{ p: 2, textAlign: 'center' }}>
+              <Typography variant="h6" gutterBottom>
+                Foto/Identidad
+              </Typography>
+              <Stack spacing={2} alignItems="center">
+                <Avatar src={preview} sx={{ width: 120, height: 120 }} />
+                <input
+                  type="file"
+                  accept="image/*"
+                  ref={fileInputRef}
+                  style={{ display: 'none' }}
+                  onChange={handlePhotoChange}
+                  disabled={loading}
+                />
+                <Button
+                  variant="contained"
+                  onClick={() => fileInputRef.current && fileInputRef.current.click()}
+                  disabled={loading}
+                >
+                  Subir foto
+                </Button>
+              </Stack>
+            </Box>
+          </Grid>
+        </Grid>
+
+        <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ mt: 2 }}>
+          <Button onClick={() => navigate(-1)} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button type="submit" variant="contained" disabled={loading}>
+          {loading ? <CircularProgress size={24} /> : 'Guardar'}
+        </Button>
+      </Stack>
+      </Box>
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="success"
+          sx={{ width: '100%' }}
+        >
+          Bebé actualizado correctamente
+        </Alert>
+      </Snackbar>
+    </LocalizationProvider>
+  );
+}
+

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -16,3 +16,13 @@ export const getBebes = () => {
 export const getBebesByUsuario = (usuarioId) => {
   return axios.get(`${API_BEBES_ENDPOINT}?usuarioId=${usuarioId}&activo=true`);
 };
+
+export const getBebeById = (id) => {
+  return axios.get(`${API_BEBES_ENDPOINT}/${id}`);
+};
+
+export const actualizarBebe = (id, payload, headers = {}) => {
+  return axios.put(`${API_BEBES_ENDPOINT}/${id}`, payload, {
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+};


### PR DESCRIPTION
## Summary
- rename menu option to "Editar bebé" and wire new route
- add baby service methods for retrieving and updating
- implement EditarBebe form with fields prefilled for selected baby

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d92547848327a8762b33a66b5a0c