### PR TITLE
Remove active baby name from side menu

### DIFF
--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -10,7 +10,6 @@ import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
 import { AuthContext } from '../../context/AuthContext';
-import { BabyContext } from '../../context/BabyContext';
 
 const drawerWidth = 240;
 
@@ -27,7 +26,6 @@ const Drawer = styled(MuiDrawer)({
 
 export default function SideMenu() {
   const { user } = React.useContext(AuthContext);
-  const { activeBaby } = React.useContext(BabyContext);
   return (
     <Drawer
       variant="permanent"
@@ -47,9 +45,6 @@ export default function SideMenu() {
       >
         <SelectContent />
       </Box>
-      <Typography variant="body2" sx={{ px: 2, pb: 1 }}>
-        {activeBaby?.nombre || ''}
-      </Typography>
       <Divider />
       <Box
         sx={{


### PR DESCRIPTION
## Summary
- drop BabyContext usage and remove active baby name from side menu

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b5e492f9a88327b3ed3dfcfb8b0ab7