### PR TITLE
Use DELETE endpoint to remove baby

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -18,7 +18,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
-import { actualizarBebe } from '../../services/bebesService';
+import { actualizarBebe, eliminarBebe } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
@@ -150,7 +150,7 @@ export default function EditarBebe() {
     if (!activeBaby?.id) return;
     setLoading(true);
     try {
-      await actualizarBebe(activeBaby.id, { bebeActivo: false });
+      await eliminarBebe(activeBaby.id);
       removeBaby(activeBaby.id);
       navigate(-1);
     } catch (error) {

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -26,3 +26,7 @@ export const actualizarBebe = (id, payload, headers = {}) => {
     headers: { 'Content-Type': 'application/json', ...headers },
   });
 };
+
+export const eliminarBebe = (id) => {
+  return axios.delete(`${API_BEBES_ENDPOINT}/${id}`);
+};


### PR DESCRIPTION
## Summary
- add eliminarBebe service calling DELETE endpoint
- update EditarBebe to use eliminarBebe instead of updating bebeActivo

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e6e2f7688327a5ffef03dc4363d9