### PR TITLE
Redirect to informational page when user has no babies

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -13,6 +13,7 @@ import Configuracion from "./dashboard/pages/Configuracion";
 import Acerca from "./dashboard/pages/Acerca";
 import AnadirBebe from "./dashboard/pages/AnadirBebe";
 import EditarBebe from "./dashboard/pages/EditarBebe";
+import InicioSinBebe from "./dashboard/pages/InicioSinBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
@@ -42,6 +43,7 @@ function App() {
             <Route path="editar-bebe" element={<EditarBebe />} />
             <Route path="configuracion" element={<Configuracion />} />
             <Route path="acerca" element={<Acerca />} />
+            <Route path="inicio" element={<InicioSinBebe />} />
           </Route>
         </Routes>
       </Router>

--- a/frontend-baby/src/context/BabyContext.js
+++ b/frontend-baby/src/context/BabyContext.js
@@ -13,7 +13,7 @@ export function BabyProvider({ children }) {
     const fetchBabies = async () => {
       if (!user?.id) return;
       try {
-        const response = await getBebesByUsuario(user.id);
+        const response = await getBebesByUsuario(user.id, true);
         const data = response.data || [];
         setBabies(data);
         setActiveBaby(data[0] || null);

--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Copyright from '../internals/components/Copyright';
@@ -6,8 +7,45 @@ import DailyRoutinesCard from './DailyRoutinesCard';
 import UpcomingAppointmentsCard from './UpcomingAppointmentsCard';
 import RecentCareCard from './RecentCareCard';
 import QuickStatsCard from './QuickStatsCard';
+import { BabyContext } from '../../context/BabyContext';
+import { AuthContext } from '../../context/AuthContext';
+import { getBebesByUsuario } from '../../services/bebesService';
 
 export default function MainGrid() {
+  const { babies } = useContext(BabyContext);
+  const { user } = useContext(AuthContext);
+  const [hasBabies, setHasBabies] = useState(null);
+
+  useEffect(() => {
+    const checkBabies = async () => {
+      if (babies.length > 0) {
+        setHasBabies(true);
+        return;
+      }
+      if (!user?.id) {
+        setHasBabies(false);
+        return;
+      }
+      try {
+        const response = await getBebesByUsuario(user.id);
+        setHasBabies((response.data || []).length > 0);
+      } catch (error) {
+        console.error('Error checking babies', error);
+        setHasBabies(false);
+      }
+    };
+
+    checkBabies();
+  }, [babies, user]);
+
+  if (hasBabies === false) {
+    return <Navigate to="/dashboard/inicio" replace />;
+  }
+
+  if (hasBabies === null) {
+    return null;
+  }
+
   return (
     <Box sx={{ width: '100%', maxWidth: { sm: '100%', md: '1700px' } }}>
       <Grid container spacing={2}>

--- a/frontend-baby/src/dashboard/pages/InicioSinBebe.js
+++ b/frontend-baby/src/dashboard/pages/InicioSinBebe.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import logo from '../../assets/baby-logo.png';
+
+export default function InicioSinBebe() {
+  return (
+    <Box sx={{ textAlign: 'center', mt: 4 }}>
+      <Box
+        component="img"
+        src={logo}
+        alt="Baby logo"
+        sx={{ maxWidth: 200, width: '100%', height: 'auto', mb: 2 }}
+      />
+      <Typography variant="body1">
+        La aplicación requiere registrar un bebé para comenzar. Dirígete al menú
+        "Añadir bebé".
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -13,8 +13,12 @@ export const getBebes = () => {
   return axios.get(API_BEBES_ENDPOINT);
 };
 
-export const getBebesByUsuario = (usuarioId) => {
-  return axios.get(`${API_BEBES_ENDPOINT}?usuarioId=${usuarioId}&activo=true`);
+export const getBebesByUsuario = (usuarioId, activo) => {
+  const params = new URLSearchParams({ usuarioId });
+  if (activo !== undefined) {
+    params.append('activo', activo);
+  }
+  return axios.get(`${API_BEBES_ENDPOINT}?${params.toString()}`);
 };
 
 export const getBebeById = (id) => {


### PR DESCRIPTION
## Summary
- add `InicioSinBebe` page with logo and instructions to add a baby
- register the page route and redirect dashboard there when no babies are registered
- fetch active babies with optional API filter and only redirect when the user truly has no associated babies

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b606131900832791c7bb30bdff8d32