### PR TITLE
Expose inactive babies and derive active selection

### DIFF
--- a/frontend-baby/src/context/BabyContext.js
+++ b/frontend-baby/src/context/BabyContext.js
@@ -16,7 +16,8 @@ export function BabyProvider({ children }) {
         const response = await getBebesByUsuario(user.id);
         const data = response.data || [];
         setBabies(data);
-        setActiveBaby(data[0] || null);
+        const firstActive = data.find((baby) => baby.activo);
+        setActiveBaby(firstActive || null);
       } catch (error) {
         console.error('Error fetching babies', error);
       }
@@ -34,7 +35,8 @@ export function BabyProvider({ children }) {
     setBabies((prev) => {
       const updatedBabies = prev.filter((baby) => baby.id !== id);
       if (activeBaby && activeBaby.id === id) {
-        setActiveBaby(updatedBabies[0] || null);
+        const firstActive = updatedBabies.find((baby) => baby.activo);
+        setActiveBaby(firstActive || null);
       }
       return updatedBabies;
     });

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -14,7 +14,7 @@ export const getBebes = () => {
 };
 
 export const getBebesByUsuario = (usuarioId) => {
-  return axios.get(`${API_BEBES_ENDPOINT}?usuarioId=${usuarioId}&activo=true`);
+  return axios.get(`${API_BEBES_ENDPOINT}?usuarioId=${usuarioId}`);
 };
 
 export const getBebeById = (id) => {


### PR DESCRIPTION
## Summary
- Remove active flag filter when fetching babies by usuario to get full list
- Choose first active baby from fetched list and when removing a baby

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b60c99930c8327b96ce52266831a23