### PR TITLE
feat: block InicioSinBebe when babies exist

### DIFF
--- a/frontend-baby/README.md
+++ b/frontend-baby/README.md
@@ -3,7 +3,7 @@
 Aplicación **React** (SPA) para la interfaz de usuario.
 
 ## Descripción
-Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas y rutinas. Rutas protegidas con JWT y consumo de APIs vía Axios.
+Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas y rutinas. Rutas protegidas con JWT y consumo de APIs vía Axios. La página **Inicio sin bebé** está destinada únicamente a usuarios que aún no tienen bebés registrados.
 
 ## Tecnologías usadas
 - **React**

--- a/frontend-baby/src/dashboard/pages/InicioSinBebe.js
+++ b/frontend-baby/src/dashboard/pages/InicioSinBebe.js
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { Navigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { BabyContext } from '../../context/BabyContext';
 import logo from '../../assets/baby-logo.png';
 
 export default function InicioSinBebe() {
+  const { babies } = useContext(BabyContext);
+
+  if (babies.length > 0) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
   return (
     <Box sx={{ textAlign: 'center', mt: 4 }}>
       <Box


### PR DESCRIPTION
## Summary
- redirect InicioSinBebe users to dashboard when babies exist
- clarify README that page only applies to users without babies

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')

------
https://chatgpt.com/codex/tasks/task_e_68b60d3a70048327a5dd2b25497ffefd