### PR TITLE
Fix DateCalendar value handling in appointments page

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -24,6 +24,8 @@ import 'dayjs/locale/es';
 import { LocalizationProvider, DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
+dayjs.locale('es');
+
 import {
   listarPorBebe,
   crearCita,
@@ -216,11 +218,15 @@ export default function Citas() {
 
       {view === 'month' ? (
         <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-          <DateCalendar
-            value={selectedDate}
-            onChange={setSelectedDate}
-            slots={{ day: renderDay }}
-          />
+          {selectedDate && (
+            <DateCalendar
+              value={selectedDate}
+              onChange={(newValue) =>
+                setSelectedDate(newValue ? dayjs(newValue) : dayjs())
+              }
+              slots={{ day: renderDay }}
+            />
+          )}
         </LocalizationProvider>
       ) : (
         <TableContainer component={Paper} sx={{ mb: 4 }}>


### PR DESCRIPTION
## Summary
- ensure Day.js uses Spanish locale in Citas page
- prevent DateCalendar from receiving null by coercing value to dayjs

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b632c9c1588327853d76aa83b480e6