### PR TITLE
Reorder Citas imports and adjust dayjs locale

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -23,9 +23,6 @@ import dayjs from 'dayjs';
 import 'dayjs/locale/es';
 import { LocalizationProvider, DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-
-dayjs.locale('es');
-
 import {
   listarPorBebe,
   crearCita,
@@ -37,6 +34,8 @@ import {
 import CitaForm from '../components/CitaForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
+
+dayjs.locale('es');
 
 export default function Citas() {
   const [citas, setCitas] = useState([]);


### PR DESCRIPTION
## Summary
- Reorder citas service and context imports in Citas page after MUI and dayjs imports
- Ensure dayjs Spanish locale is set only after all imports

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b635a257308327ade0ab39d8b9e67d