### PR TITLE
Refactor calendar day rendering in Citas page

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -140,7 +140,7 @@ export default function Citas() {
     setPage(0);
   };
 
-  const renderDay = (day, _value, DayComponentProps) => {
+  const CustomDay = ({ day, ...props }) => {
     const citasDelDia = citas.filter((c) =>
       dayjs(c.fecha).isSame(day, 'day')
     );
@@ -151,7 +151,7 @@ export default function Citas() {
         color={citasDelDia.length > 0 ? 'primary' : undefined}
         variant={citasDelDia.length > 0 ? 'dot' : undefined}
       >
-        <PickersDay {...DayComponentProps} />
+        <PickersDay day={day} {...props} />
       </Badge>
     );
   };
@@ -223,7 +223,7 @@ export default function Citas() {
               onChange={(newValue) =>
                 setSelectedDate(newValue ? dayjs(newValue) : dayjs())
               }
-              slots={{ day: renderDay }}
+              slots={{ day: CustomDay }}
             />
           )}
         </LocalizationProvider>


### PR DESCRIPTION
## Summary
- replace renderDay with CustomDay component that forwards day to PickersDay
- wire DateCalendar to use CustomDay via `slots`

## Testing
- `npm run lint` *(fails: Missing script: "lint")*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b63739d48c8327a107890b0d94250e