### PR TITLE
fix: remove gradient background from sign-in

### DIFF
--- a/frontend-baby/src/sign-in-side/SignInSide.js
+++ b/frontend-baby/src/sign-in-side/SignInSide.js
@@ -25,12 +25,9 @@ export default function SignInSide(props) {
               position: 'absolute',
               zIndex: -1,
               inset: 0,
-              backgroundImage:
-                'radial-gradient(ellipse at 50% 50%, hsl(210, 100%, 97%), hsl(0, 0%, 100%))',
-              backgroundRepeat: 'no-repeat',
+              backgroundColor: '#000000',
               ...theme.applyStyles('dark', {
-                backgroundImage:
-                  'radial-gradient(at 50% 50%, hsla(210, 100%, 16%, 0.5), hsl(220, 30%, 5%))',
+                backgroundColor: '#000000',
               }),
             },
           }),


### PR DESCRIPTION
## Summary
- replace sign-in radial gradients with solid black background

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b752bbcaec832793e394c6c8ba0115