### PR TITLE
fix: remove autofill blue background on sign-in

### DIFF
--- a/frontend-baby/src/sign-in-side/components/SignInCard.js
+++ b/frontend-baby/src/sign-in-side/components/SignInCard.js
@@ -133,6 +133,14 @@ export default function SignInCard() {
             fullWidth
             variant="outlined"
             color={emailError ? 'error' : 'primary'}
+            sx={(theme) => ({
+              '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus, & input:-webkit-autofill:active': {
+                WebkitBoxShadow: `0 0 0 1000px ${theme.palette.background.paper} inset`,
+                WebkitTextFillColor: theme.palette.text.primary,
+                caretColor: theme.palette.text.primary,
+                transition: 'background-color 5000s ease-in-out 0s',
+              },
+            })}
           />
         </FormControl>
         <FormControl>
@@ -161,6 +169,14 @@ export default function SignInCard() {
             fullWidth
             variant="outlined"
             color={passwordError ? 'error' : 'primary'}
+            sx={(theme) => ({
+              '& input:-webkit-autofill, & input:-webkit-autofill:hover, & input:-webkit-autofill:focus, & input:-webkit-autofill:active': {
+                WebkitBoxShadow: `0 0 0 1000px ${theme.palette.background.paper} inset`,
+                WebkitTextFillColor: theme.palette.text.primary,
+                caretColor: theme.palette.text.primary,
+                transition: 'background-color 5000s ease-in-out 0s',
+              },
+            })}
           />
         </FormControl>
         <FormControlLabel


### PR DESCRIPTION
## Summary
- restore radial gradient background on sign-in page
- override autofill styling to avoid blue background in email/password fields

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b752bbcaec832793e394c6c8ba0115