### PR TITLE
feat(frontend): hide export buttons when table is empty

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -249,14 +249,16 @@ export default function Cuidados() {
         />
       </TableContainer>
 
-      <Box sx={{ mb: 4, display: 'flex', gap: 2 }}>
-        <Button variant="outlined" onClick={handleExportPdf}>
-          Exportar PDF
-        </Button>
-        <Button variant="outlined" onClick={handleExportCsv}>
-          Exportar CSV
-        </Button>
-      </Box>
+      {filteredCuidados.length > 0 && (
+        <Box sx={{ mb: 4, display: 'flex', gap: 2 }}>
+          <Button variant="outlined" onClick={handleExportPdf}>
+            Exportar PDF
+          </Button>
+          <Button variant="outlined" onClick={handleExportCsv}>
+            Exportar CSV
+          </Button>
+        </Box>
+      )}
 
       <Card variant="outlined">
         <CardContent>


### PR DESCRIPTION
## Summary
- show export buttons only when there are cuidados listed

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b78274845c83279dd203784efe8438