### PR TITLE
Add routine duplication endpoint

### DIFF
--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/controller/RutinaController.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/controller/RutinaController.java
@@ -143,7 +143,20 @@ public class RutinaController {
                 return ResponseEntity.ok(rutinaService.desactivar(usuarioId, bebeId, id));
         }
 
- // -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
+    // Duplicar
+    // -------------------------------------------------------------------------
+    @Operation(summary = "Duplicar rutina", description = "Clona una rutina existente")
+    @PostMapping("/usuario/{usuarioId}/{id}/duplicar")
+    public ResponseEntity<RutinaDTO> duplicar(
+            @PathVariable Long usuarioId,
+            @Parameter(description = "ID de la rutina", example = "1")
+            @PathVariable Long id) {
+                RutinaDTO res = rutinaService.duplicar(usuarioId, id);
+                return ResponseEntity.status(HttpStatus.CREATED).body(res);
+        }
+
+    // -------------------------------------------------------------------------
     // Registrar ejecución
     // -------------------------------------------------------------------------
     @Operation(summary = "Registrar ejecución", description = "Registra una ejecución para la rutina indicada.")

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/RutinaService.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/RutinaService.java
@@ -26,6 +26,8 @@ public interface RutinaService {
 
     RutinaDTO desactivar(Long usuarioId, Long bebeId, Long id);
 
+    RutinaDTO duplicar(Long usuarioId, Long rutinaId);
+
     RutinaEjecucionDTO registrarEjecucion(Long usuarioId, Long bebeId, Long rutinaId, RutinaEjecucionCreateDTO dto);
 
     java.util.List<RutinaEjecucionDTO> historial(Long usuarioId, Long bebeId, Long rutinaId, LocalDate desde, LocalDate hasta);

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/impl/RutinaServiceImpl.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/service/impl/RutinaServiceImpl.java
@@ -85,6 +85,24 @@ public class RutinaServiceImpl implements RutinaService {
         return RutinaMapper.toDTO(r);
     }
 
+    public RutinaDTO duplicar(Long usuarioId, Long rutinaId) {
+        Rutina r = rutinaRepository.findById(rutinaId).orElse(null);
+        if (r == null || Boolean.TRUE.equals(r.getEliminado()) || !r.getUsuarioId().equals(usuarioId)) {
+            throw new NotFoundException("Rutina no encontrada");
+        }
+        Rutina copia = Rutina.builder()
+                .usuarioId(r.getUsuarioId())
+                .bebeId(r.getBebeId())
+                .nombre(r.getNombre())
+                .descripcion(r.getDescripcion())
+                .horaProgramada(r.getHoraProgramada())
+                .diasSemana(r.getDiasSemana())
+                .activa(r.getActiva())
+                .build();
+        copia = rutinaRepository.save(copia);
+        return RutinaMapper.toDTO(copia);
+    }
+
     public RutinaEjecucionDTO registrarEjecucion(Long usuarioId, Long bebeId, Long rutinaId, RutinaEjecucionCreateDTO dto) {
         Rutina r = rutinaRepository.findOneByIdAndUsuarioAndBebe(rutinaId, usuarioId, bebeId);
         if (r == null || Boolean.TRUE.equals(r.getEliminado())) throw new NotFoundException("Rutina no encontrada");

--- a/frontend-baby/src/services/rutinasService.js
+++ b/frontend-baby/src/services/rutinasService.js
@@ -32,9 +32,9 @@ export const eliminarRutina = (usuarioId, bebeId, id) => {
   );
 };
 
-export const duplicarRutina = (usuarioId, bebeId, id) => {
+export const duplicarRutina = (usuarioId, id) => {
   return axios.post(
-    `${API_RUTINAS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/${id}/duplicar`
+    `${API_RUTINAS_ENDPOINT}/usuario/${usuarioId}/${id}/duplicar`
   );
 };
 


### PR DESCRIPTION
## Summary
- add duplicar() to RutinaService and implement cloning of existing routine
- expose POST /usuario/{usuarioId}/{id}/duplicar endpoint
- update frontend rutinasService to target new duplication route

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b7902ab7ac83278880b460696b0019