### PR TITLE
feat: extract user id from security context

### DIFF
--- a/api-gastos/src/main/java/com/babytrackmaster/api_gastos/security/JwtService.java
+++ b/api-gastos/src/main/java/com/babytrackmaster/api_gastos/security/JwtService.java
@@ -122,6 +122,9 @@ public class JwtService {
         if (auth != null) {
             // principal.getId()
             Object principal = auth.getPrincipal();
+            if (principal instanceof Number) {
+                return Long.valueOf(((Number) principal).longValue());
+            }
             if (principal != null) {
                 try {
                     java.lang.reflect.Method m = principal.getClass().getMethod("getId", new Class[] {});

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/controller/CategoriaControllerTest.java
@@ -46,6 +46,16 @@ class CategoriaControllerTest {
     }
 
     @Test
+    void crearSinUsuarioRetorna401() throws Exception {
+        Mockito.when(jwtService.resolveUserId()).thenReturn(null);
+
+        mockMvc.perform(post("/api/v1/categorias")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"nombre\":\"Ropa\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void actualizarRetornaOk() throws Exception {
         CategoriaResponse resp = new CategoriaResponse();
         resp.setId(2L);

--- a/api-gastos/src/test/java/com/babytrackmaster/api_gastos/security/JwtServiceTest.java
+++ b/api-gastos/src/test/java/com/babytrackmaster/api_gastos/security/JwtServiceTest.java
@@ -1,0 +1,57 @@
+package com.babytrackmaster.api_gastos.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Base64;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setup() {
+        jwtService = new JwtService();
+        String secret = Base64.getEncoder().encodeToString("testsecretkeytestsecretkeytest12".getBytes());
+        ReflectionTestUtils.setField(jwtService, "secretB64", secret);
+        ReflectionTestUtils.setField(jwtService, "expirationMs", 3600000L);
+    }
+
+    @AfterEach
+    void cleanup() {
+        RequestContextHolder.resetRequestAttributes();
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void resolveUserIdFromSecurityContext() {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(77L, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        assertEquals(77L, jwtService.resolveUserId());
+    }
+
+    @Test
+    void resolveUserIdFromValidToken() {
+        String token = jwtService.generarToken("123");
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.addHeader("Authorization", "Bearer " + token);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+        assertEquals(123L, jwtService.resolveUserId());
+    }
+
+    @Test
+    void resolveUserIdReturnsNullWhenUnauthorized() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(req));
+        assertNull(jwtService.resolveUserId());
+    }
+}


### PR DESCRIPTION
## Summary
- handle numeric principals when resolving user IDs from Spring Security
- cover JWT service and controller behaviors with unit tests

## Testing
- `./mvnw -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b790e0ba388327b2d25f0934adbadb