### PR TITLE
Allow mobile client origin for CORS

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/CorsConfig.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:19006"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
 

--- a/api-diario/src/main/java/com/babytrackmaster/api_diario/config/CorsConfig.java
+++ b/api-diario/src/main/java/com/babytrackmaster/api_diario/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:19006"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
 

--- a/api-hitos/src/main/java/com/babytrackmaster/api_hitos/config/CorsConfig.java
+++ b/api-hitos/src/main/java/com/babytrackmaster/api_hitos/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:19006"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
 

--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/config/CorsConfig.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:19006"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
- allow requests from `http://localhost:19006` in api-rutinas
- allow requests from `http://localhost:19006` in api-hitos
- allow requests from `http://localhost:19006` in api-cuidados
- allow requests from `http://localhost:19006` in api-diario

## Testing
- `./mvnw -q test` (api-rutinas) *(fails: Network is unreachable)*
- `./mvnw -q test` (api-hitos) *(fails: Network is unreachable)*
- `./mvnw -q test` (api-cuidados) *(fails: Network is unreachable)*
- `./mvnw -q test` (api-diario) *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e5192fc883278d6a61a184df9d2e