### PR TITLE
Allow frontend on port 3000 for routines API CORS

### DIFF
--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/config/SecurityConfig.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.babytrackmaster.api_rutinas.config;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -99,7 +98,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
         // En local puedes permitir todo; ajusta en producción
-        cfg.setAllowedOrigins(Collections.singletonList("http://localhost:8086"));
+        cfg.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:8086"));
         cfg.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
         cfg.setAllowedHeaders(Arrays.asList("*"));
         //cfg.setExposedHeaders(Arrays.asList("Authorization","Content-Type"));


### PR DESCRIPTION
## Summary
- allow CORS requests from localhost:3000 in the routines API

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central: Network is unreachable)*
- `mvn spring-boot:run` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b842f104648327ad7e085b8f08457d