### PR TITLE
Enable stable Page serialization for api-rutinas

### DIFF
--- a/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/ApiRutinasApplication.java
+++ b/api-rutinas/src/main/java/com/babytrackmaster/api_rutinas/ApiRutinasApplication.java
@@ -2,7 +2,10 @@ package com.babytrackmaster.api_rutinas;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 @SpringBootApplication
 public class ApiRutinasApplication {
 


### PR DESCRIPTION
## Summary
- enable stable Page serialization via DTO in ApiRutinasApplication

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b8469f18fc8327885ae7cf3e3c3f0f