### PR TITLE
feat: align citas service with new API endpoints

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -24,7 +24,7 @@ import 'dayjs/locale/es';
 import { LocalizationProvider, DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import {
-  listarPorBebe,
+  listar,
   crearCita,
   actualizarCita,
   eliminarCita,
@@ -56,7 +56,7 @@ export default function Citas() {
 
   const fetchCitas = () => {
     if (!bebeId || !usuarioId) return;
-    listarPorBebe(usuarioId, bebeId)
+    listar()
       .then((response) => setCitas(response.data))
       .catch((error) => console.error('Error fetching citas:', error));
   };
@@ -102,7 +102,7 @@ export default function Citas() {
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
     if (window.confirm('¿Eliminar cita?')) {
-      eliminarCita(usuarioId, id)
+      eliminarCita(id)
         .then(() => fetchCitas())
         .catch((error) => console.error('Error deleting cita:', error));
     }
@@ -110,10 +110,9 @@ export default function Citas() {
 
   const handleFormSubmit = (data) => {
     if (!bebeId || !usuarioId) return;
-    const payload = { ...data, bebeId };
     const request = selectedCita
-      ? actualizarCita(usuarioId, selectedCita.id, payload)
-      : crearCita(usuarioId, payload);
+      ? actualizarCita(selectedCita.id, data)
+      : crearCita(data);
 
     request
       .then(() => {
@@ -126,7 +125,7 @@ export default function Citas() {
 
   const handleRecordatorio = (id) => {
     if (!usuarioId) return;
-    enviarRecordatorio(usuarioId, id).catch((error) =>
+    enviarRecordatorio(id).catch((error) =>
       console.error('Error sending reminder:', error)
     );
   };

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -2,28 +2,29 @@ import axios from 'axios';
 import { API_CITAS_URL } from '../config';
 
 const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
+const API_TIPOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-cita`;
 
-export const listarPorBebe = (usuarioId, bebeId) => {
-  return axios.get(`${API_CITAS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`);
+export const listar = () => {
+  return axios.get(`${API_CITAS_ENDPOINT}`);
 };
 
-export const crearCita = (usuarioId, data) => {
-  return axios.post(`${API_CITAS_ENDPOINT}/usuario/${usuarioId}`, data);
+export const crearCita = (data) => {
+  return axios.post(`${API_CITAS_ENDPOINT}`, data);
 };
 
-export const actualizarCita = (usuarioId, id, data) => {
-  return axios.put(`${API_CITAS_ENDPOINT}/usuario/${usuarioId}/${id}`, data);
+export const actualizarCita = (id, data) => {
+  return axios.put(`${API_CITAS_ENDPOINT}/${id}`, data);
 };
 
-export const eliminarCita = (usuarioId, id) => {
-  return axios.delete(`${API_CITAS_ENDPOINT}/usuario/${usuarioId}/${id}`);
+export const eliminarCita = (id) => {
+  return axios.delete(`${API_CITAS_ENDPOINT}/${id}`);
 };
 
 export const listarTipos = () => {
-  return axios.get(`${API_CITAS_ENDPOINT}/tipos`);
+  return axios.get(`${API_TIPOS_CITA_ENDPOINT}`);
 };
 
-export const enviarRecordatorio = (usuarioId, id) => {
-  return axios.post(`${API_CITAS_ENDPOINT}/usuario/${usuarioId}/${id}/recordatorio`);
+export const enviarRecordatorio = (id) => {
+  return axios.post(`${API_CITAS_ENDPOINT}/${id}/recordatorio`);
 };
 


### PR DESCRIPTION
## Summary
- update citas service to use `/api/v1/citas` and `/api/v1/tipos-cita`
- adjust dashboard Citas page to call updated service functions without usuarioId/bebeId in the path

## Testing
- `npm test --silent`
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84a34195c8327b132d2b1a5b3a4a5