### PR TITLE
Align Cita fields across backend and frontend

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
@@ -14,7 +14,7 @@ public class CitaCreateDTO {
     @Schema(example = "Revisión 1 mes")
     @NotBlank
     @Size(max = 150)
-    private String titulo;
+    private String motivo;
 
     @Schema(example = "Control de peso y lactancia")
     @Size(max = 500)
@@ -30,7 +30,7 @@ public class CitaCreateDTO {
 
     @Schema(example = "Centro de Salud Los Álamos")
     @Size(max = 150)
-    private String ubicacion;
+    private String centroMedico;
 
     @Schema(example = "Dra. García")
     @Size(max = 120)

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
@@ -7,11 +7,11 @@ import lombok.*;
 public class CitaResponseDTO {
     private Long id;
     private Long usuarioId;
-    private String titulo;
+    private String motivo;
     private String descripcion;
     private String fecha; // ISO
     private String hora;  // HH:mm
-    private String ubicacion;
+    private String centroMedico;
     private String medico;
     private TipoCitaResponseDTO tipo;
     private EstadoCitaResponseDTO estado;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
@@ -9,7 +9,7 @@ import lombok.*;
 public class CitaUpdateDTO {
 
     @Size(max = 150)
-    private String titulo;
+    private String motivo;
 
     @Size(max = 500)
     private String descripcion;
@@ -22,7 +22,7 @@ public class CitaUpdateDTO {
     private String hora;
 
     @Size(max = 150)
-    private String ubicacion;
+    private String centroMedico;
 
     @Size(max = 120)
     private String medico;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
@@ -40,7 +40,7 @@ public class Cita {
     private Long usuarioId;
 
     @Column(nullable = false, length = 150)
-    private String titulo;
+    private String motivo;
 
     @Column(length = 500)
     private String descripcion;
@@ -52,7 +52,7 @@ public class Cita {
     private LocalTime hora;
 
     @Column(length = 150)
-    private String ubicacion;
+    private String centroMedico;
 
     @Column(length = 120)
     private String medico;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
@@ -14,11 +14,11 @@ public class CitaMapper {
     public static Cita toEntity(CitaCreateDTO dto, Long usuarioId, TipoCita tipo, EstadoCita estado) {
         Cita c = new Cita();
         c.setUsuarioId(usuarioId);
-        c.setTitulo(dto.getTitulo());
+        c.setMotivo(dto.getMotivo());
         c.setDescripcion(dto.getDescripcion());
         c.setFecha(LocalDate.parse(dto.getFecha()));
         c.setHora(LocalTime.parse(dto.getHora()));
-        c.setUbicacion(dto.getUbicacion());
+        c.setCentroMedico(dto.getCentroMedico());
         c.setMedico(dto.getMedico());
         c.setTipo(tipo);
         c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
@@ -28,11 +28,11 @@ public class CitaMapper {
     }
 
     public static void applyUpdate(Cita c, CitaUpdateDTO dto, TipoCita tipo, EstadoCita estado) {
-        if (dto.getTitulo() != null) c.setTitulo(dto.getTitulo());
+        if (dto.getMotivo() != null) c.setMotivo(dto.getMotivo());
         if (dto.getDescripcion() != null) c.setDescripcion(dto.getDescripcion());
         if (dto.getFecha() != null) c.setFecha(LocalDate.parse(dto.getFecha()));
         if (dto.getHora() != null) c.setHora(LocalTime.parse(dto.getHora()));
-        if (dto.getUbicacion() != null) c.setUbicacion(dto.getUbicacion());
+        if (dto.getCentroMedico() != null) c.setCentroMedico(dto.getCentroMedico());
         if (dto.getMedico() != null) c.setMedico(dto.getMedico());
         if (tipo != null) c.setTipo(tipo);
         if (dto.getRecordatorioMinutos() != null) c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
@@ -43,11 +43,11 @@ public class CitaMapper {
         CitaResponseDTO.CitaResponseDTOBuilder b = CitaResponseDTO.builder();
         b.id(c.getId());
         b.usuarioId(c.getUsuarioId());
-        b.titulo(c.getTitulo());
+        b.motivo(c.getMotivo());
         b.descripcion(c.getDescripcion());
         b.fecha(c.getFecha() != null ? c.getFecha().toString() : null);
         b.hora(c.getHora() != null ? c.getHora().toString() : null);
-        b.ubicacion(c.getUbicacion());
+        b.centroMedico(c.getCentroMedico());
         b.medico(c.getMedico());
         if (c.getTipo() != null) {
             b.tipo(TipoCitaMapper.toDTO(c.getTipo()));

--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -9,7 +9,6 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import dayjs from 'dayjs';
 import { listarTipos } from '../../services/citasService';
 
 export default function CitaForm({ open, onClose, onSubmit, initialData }) {
@@ -25,8 +24,8 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   useEffect(() => {
     if (initialData) {
       setFormData({
-        fecha: initialData.fecha ? dayjs(initialData.fecha).format('YYYY-MM-DD') : '',
-        hora: initialData.fecha ? dayjs(initialData.fecha).format('HH:mm') : '',
+        fecha: initialData.fecha || '',
+        hora: initialData.hora || '',
         motivo: initialData.motivo || '',
         tipoId: initialData.tipoId || '',
         centroMedico: initialData.centroMedico || '',
@@ -49,8 +48,7 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
 
   const handleSubmit = () => {
     const { fecha, hora, motivo, tipoId, centroMedico } = formData;
-    const fechaHora = fecha && hora ? `${fecha}T${hora}` : fecha;
-    onSubmit({ fecha: fechaHora, motivo, tipoId, centroMedico });
+    onSubmit({ fecha, hora, motivo, tipoId, centroMedico });
   };
 
   return (

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -57,7 +57,15 @@ export default function Citas() {
   const fetchCitas = () => {
     if (!bebeId || !usuarioId) return;
     listarPorBebe(usuarioId, bebeId)
-      .then((response) => setCitas(response.data))
+      .then((response) =>
+        setCitas(
+          response.data.map((c) => ({
+            ...c,
+            tipoId: c.tipo?.id ?? c.tipoId,
+            tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
+          }))
+        )
+      )
       .catch((error) => console.error('Error fetching citas:', error));
   };
 
@@ -246,7 +254,7 @@ export default function Citas() {
                     {dayjs(cita.fecha).locale('es').format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
-                    {dayjs(cita.fecha).locale('es').format('HH:mm')}
+                    {dayjs(`${cita.fecha}T${cita.hora}`).locale('es').format('HH:mm')}
                   </TableCell>
                   <TableCell>{cita.motivo}</TableCell>
                   <TableCell>
@@ -304,7 +312,7 @@ export default function Citas() {
                     {dayjs(cita.fecha).locale('es').format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
-                    {dayjs(cita.fecha).locale('es').format('HH:mm')}
+                    {dayjs(`${cita.fecha}T${cita.hora}`).locale('es').format('HH:mm')}
                   </TableCell>
                   <TableCell>{cita.motivo}</TableCell>
                   <TableCell>


### PR DESCRIPTION
## Summary
- Rename Cita entity fields to `motivo` and `centroMedico`
- Update DTOs and mapper to new names
- Adjust CitaForm and Citas pages to send and read `motivo`, `centroMedico`, `fecha` and `hora`

## Testing
- `mvn -q -f api-citas/pom.xml test` *(fails: Non-resolvable parent POM)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b84bf5a25883279498c34502188bb3