### PR TITLE
feat: add bebeId filter for citas

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
@@ -73,11 +73,19 @@ public class CitaController {
                 return ResponseEntity.ok(service.listarPorTipo(usuarioId, tipoId, page, size));
         }
 
-	@Operation(summary = "Listar por médico")
-	@GetMapping("/medico")
-	public ResponseEntity<Page<CitaResponseDTO>> listarPorMedico(@RequestParam String nombre,
-			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
-		Long usuarioId = jwtService.resolveUserId();
-		return ResponseEntity.ok(service.listarPorMedico(usuarioId, nombre, page, size));
-	}
+        @Operation(summary = "Listar por médico")
+        @GetMapping("/medico")
+        public ResponseEntity<Page<CitaResponseDTO>> listarPorMedico(@RequestParam String nombre,
+                        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorMedico(usuarioId, nombre, page, size));
+        }
+
+        @Operation(summary = "Listar por bebé")
+        @GetMapping("/bebe/{bebeId}")
+        public ResponseEntity<Page<CitaResponseDTO>> listarPorBebe(@PathVariable Long bebeId,
+                        @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.listarPorBebe(usuarioId, bebeId, page, size));
+        }
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
@@ -38,6 +38,10 @@ public class CitaCreateDTO {
 
     @Schema(example = "1")
     @NotNull
+    private Long bebeId;
+
+    @Schema(example = "1")
+    @NotNull
     private Long tipoId;
 
     @Schema(example = "30")

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.*;
 public class CitaResponseDTO {
     private Long id;
     private Long usuarioId;
+    private Long bebeId;
     private String motivo;
     private String descripcion;
     private String fecha; // ISO

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
@@ -27,6 +27,8 @@ public class CitaUpdateDTO {
     @Size(max = 120)
     private String medico;
 
+    private Long bebeId;
+
     private Long tipoId;
 
     private Integer recordatorioMinutos;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
@@ -28,7 +28,8 @@ import lombok.Setter;
 @Builder
 @Entity
 @Table(name = "citas", indexes = {
-    @Index(name = "idx_usuario_fecha", columnList = "usuarioId,fecha,eliminado")
+    @Index(name = "idx_usuario_fecha", columnList = "usuarioId,fecha,eliminado"),
+    @Index(name = "idx_usuario_bebe", columnList = "usuarioId,bebeId,eliminado")
 })
 public class Cita {
 
@@ -38,6 +39,9 @@ public class Cita {
 
     @Column(nullable = false)
     private Long usuarioId;
+
+    @Column(nullable = false)
+    private Long bebeId;
 
     @Column(nullable = false, length = 150)
     private String motivo;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
@@ -14,6 +14,7 @@ public class CitaMapper {
     public static Cita toEntity(CitaCreateDTO dto, Long usuarioId, TipoCita tipo, EstadoCita estado) {
         Cita c = new Cita();
         c.setUsuarioId(usuarioId);
+        c.setBebeId(dto.getBebeId());
         c.setMotivo(dto.getMotivo());
         c.setDescripcion(dto.getDescripcion());
         c.setFecha(LocalDate.parse(dto.getFecha()));
@@ -34,6 +35,7 @@ public class CitaMapper {
         if (dto.getHora() != null) c.setHora(LocalTime.parse(dto.getHora()));
         if (dto.getCentroMedico() != null) c.setCentroMedico(dto.getCentroMedico());
         if (dto.getMedico() != null) c.setMedico(dto.getMedico());
+        if (dto.getBebeId() != null) c.setBebeId(dto.getBebeId());
         if (tipo != null) c.setTipo(tipo);
         if (dto.getRecordatorioMinutos() != null) c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
         if (estado != null) c.setEstado(estado);
@@ -43,6 +45,7 @@ public class CitaMapper {
         CitaResponseDTO.CitaResponseDTOBuilder b = CitaResponseDTO.builder();
         b.id(c.getId());
         b.usuarioId(c.getUsuarioId());
+        b.bebeId(c.getBebeId());
         b.motivo(c.getMotivo());
         b.descripcion(c.getDescripcion());
         b.fecha(c.getFecha() != null ? c.getFecha().toString() : null);

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
@@ -40,6 +40,12 @@ public interface CitaRepository extends JpaRepository<Cita, Long> {
                                @Param("medico") String medico,
                                Pageable pageable);
 
+    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.bebeId = :bebeId and c.eliminado = false " +
+           "order by c.fecha asc, c.hora asc")
+    Page<Cita> listarPorBebe(@Param("usuarioId") Long usuarioId,
+                             @Param("bebeId") Long bebeId,
+                             Pageable pageable);
+
     @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and " +
            "(c.fecha > :hoy or (c.fecha = :hoy and c.hora >= :hora)) " +
            "order by c.fecha asc, c.hora asc")

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
@@ -12,4 +12,5 @@ public interface CitaService {
     Page<CitaResponseDTO> listarPorEstado(Long usuarioId, Long estadoId, int page, int size);
     Page<CitaResponseDTO> listarPorTipo(Long usuarioId, Long tipoId, int page, int size);
     Page<CitaResponseDTO> listarPorMedico(Long usuarioId, String medico, int page, int size);
+    Page<CitaResponseDTO> listarPorBebe(Long usuarioId, Long bebeId, int page, int size);
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -118,4 +118,15 @@ public class CitaServiceImpl implements CitaService {
         }
         return new PageImpl<CitaResponseDTO>(list, p, res.getTotalElements());
     }
+
+    public Page<CitaResponseDTO> listarPorBebe(Long usuarioId, Long bebeId, int page, int size) {
+        Pageable p = PageRequest.of(page, size);
+        Page<Cita> res = repo.listarPorBebe(usuarioId, bebeId, p);
+        List<CitaResponseDTO> list = new ArrayList<CitaResponseDTO>();
+        int i;
+        for (i = 0; i < res.getContent().size(); i++) {
+            list.add(CitaMapper.toDTO(res.getContent().get(i)));
+        }
+        return new PageImpl<CitaResponseDTO>(list, p, res.getTotalElements());
+    }
 }

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -56,7 +56,7 @@ export default function Citas() {
 
   const fetchCitas = () => {
     if (!bebeId || !usuarioId) return;
-    listarPorBebe(usuarioId, bebeId)
+    listar(bebeId)
       .then((response) =>
         setCitas(
           response.data.map((c) => ({
@@ -66,8 +66,6 @@ export default function Citas() {
           }))
         )
       )
-    listar()
-      .then((response) => setCitas(response.data))
       .catch((error) => console.error('Error fetching citas:', error));
   };
 
@@ -121,8 +119,8 @@ export default function Citas() {
   const handleFormSubmit = (data) => {
     if (!bebeId || !usuarioId) return;
     const request = selectedCita
-      ? actualizarCita(selectedCita.id, data)
-      : crearCita(data);
+      ? actualizarCita(selectedCita.id, { ...data, bebeId })
+      : crearCita({ ...data, bebeId });
 
     request
       .then(() => {

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -4,8 +4,8 @@ import { API_CITAS_URL } from '../config';
 const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
 const API_TIPOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-cita`;
 
-export const listar = () => {
-  return axios.get(`${API_CITAS_ENDPOINT}`);
+export const listar = (bebeId) => {
+  return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`);
 };
 
 export const crearCita = (data) => {


### PR DESCRIPTION
## Summary
- add bebeId field and repository/service methods to filter appointments by baby
- expose `/api/v1/citas/bebe/{bebeId}` endpoint
- include bebeId in frontend service and page calls

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b85863a624832794542cf5f25bb0a6