### PR TITLE
feat: add tipo_citas table with initial data

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
@@ -22,11 +22,13 @@ public class DataInitializer {
         return args -> {
             if (tipoCitaRepository.count() == 0) {
                 tipoCitaRepository.saveAll(List.of(
-                    createTipoCita("Consulta pediátrica"),
-                    createTipoCita("Vacunación"),
-                    createTipoCita("Revisión general"),
-                    createTipoCita("Emergencia"),
-                    createTipoCita("Seguimiento nutricional")
+                    createTipoCita("Vacuna"),
+                    createTipoCita("Revisión/Seguimiento"),
+                    createTipoCita("Pediatra"),
+                    createTipoCita("Niño sano"),
+                    createTipoCita("Urgencia"),
+                    createTipoCita("Odontopediatría"),
+                    createTipoCita("Especialista")
                 ));
             }
         };

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "tipo_cita")
+@Table(name = "tipo_citas")
 public class TipoCita {
 
     @Id


### PR DESCRIPTION
## Summary
- rename appointment type table to `tipo_citas`
- preload default appointment types on startup

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c45ae4c8327b415c4ee9fcb74fe