### PR TITLE
feat: preload appointment types and statuses

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
@@ -9,24 +9,39 @@ import org.springframework.context.annotation.Configuration;
 import lombok.RequiredArgsConstructor;
 
 import com.babytrackmaster.api_citas.entity.TipoCita;
+import com.babytrackmaster.api_citas.entity.EstadoCita;
 import com.babytrackmaster.api_citas.repository.TipoCitaRepository;
+import com.babytrackmaster.api_citas.repository.EstadoCitaRepository;
 
 @Configuration
 @RequiredArgsConstructor
 public class DataInitializer {
 
     private final TipoCitaRepository tipoCitaRepository;
+    private final EstadoCitaRepository estadoCitaRepository;
 
     @Bean
     public CommandLineRunner loadInitialData() {
         return args -> {
             if (tipoCitaRepository.count() == 0) {
                 tipoCitaRepository.saveAll(List.of(
-                    createTipoCita("Consulta pediátrica"),
-                    createTipoCita("Vacunación"),
-                    createTipoCita("Revisión general"),
-                    createTipoCita("Emergencia"),
-                    createTipoCita("Seguimiento nutricional")
+                    createTipoCita("Vacuna"),
+                    createTipoCita("Revisión/Seguimiento"),
+                    createTipoCita("Pediatra"),
+                    createTipoCita("Niño sano"),
+                    createTipoCita("Urgencia"),
+                    createTipoCita("Odontopediatría"),
+                    createTipoCita("Especialista")
+                ));
+            }
+            if (estadoCitaRepository.count() == 0) {
+                estadoCitaRepository.saveAll(List.of(
+                    createEstadoCita("Programada"),
+                    createEstadoCita("Confirmada"),
+                    createEstadoCita("Cancelada"),
+                    createEstadoCita("Reprogramada"),
+                    createEstadoCita("Completada"),
+                    createEstadoCita("No asistida")
                 ));
             }
         };
@@ -36,6 +51,12 @@ public class DataInitializer {
         TipoCita tipo = new TipoCita();
         tipo.setNombre(nombre);
         return tipo;
+    }
+
+    private EstadoCita createEstadoCita(String nombre) {
+        EstadoCita estado = new EstadoCita();
+        estado.setNombre(nombre);
+        return estado;
     }
 }
 

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoCita.java
@@ -9,7 +9,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "tipo_cita")
+@Table(name = "tipo_citas")
 public class TipoCita {
 
     @Id


### PR DESCRIPTION
## Summary
- rename appointment type table to `tipo_citas`
- preload default appointment types on startup
- preload default appointment statuses on startup

## Testing
- `cd api-citas && bash ./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c45ae4c8327b415c4ee9fcb74fe