### PR TITLE
Use "Programada" as default appointment status

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -29,7 +29,7 @@ public class CitaServiceImpl implements CitaService {
     public CitaResponseDTO crear(CitaCreateDTO dto, Long usuarioId) {
         TipoCita tipo = tipoRepo.findById(dto.getTipoId())
                 .orElseThrow(() -> new NotFoundException("Tipo de cita no encontrado"));
-        EstadoCita estado = estadoRepo.findByNombreIgnoreCase("PENDIENTE")
+        EstadoCita estado = estadoRepo.findByNombreIgnoreCase("Programada")
                 .orElseThrow(() -> new NotFoundException("Estado de cita por defecto no encontrado"));
         Cita c = CitaMapper.toEntity(dto, usuarioId, tipo, estado);
         c = repo.save(c);

--- a/api-citas/src/test/java/com/babytrackmaster/api_citas/dto/EstadoCitaDtoSerializationTest.java
+++ b/api-citas/src/test/java/com/babytrackmaster/api_citas/dto/EstadoCitaDtoSerializationTest.java
@@ -13,10 +13,10 @@ public class EstadoCitaDtoSerializationTest {
     void serializaResponse() throws Exception {
         EstadoCitaResponseDTO dto = EstadoCitaResponseDTO.builder()
                 .id(1L)
-                .nombre("Pendiente")
+                .nombre("Programada")
                 .build();
         String json = mapper.writeValueAsString(dto);
-        assertThat(json).contains("\"id\":1", "\"nombre\":\"Pendiente\"");
+        assertThat(json).contains("\"id\":1", "\"nombre\":\"Programada\"");
     }
 }
 


### PR DESCRIPTION
## Summary
- Default new appointments to the "Programada" state
- Update DTO serialization test to expect "Programada"

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8640bcb048327a84757055b56383a