### PR TITLE
Actualizar eliminación de citas para usar estado Cancelada

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
@@ -22,7 +22,8 @@ public interface CitaRepository extends JpaRepository<Cita, Long> {
                               @Param("hasta") LocalDate hasta,
                               Pageable pageable);
 
-    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and c.estado.id = :estadoId " +
+    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.estado.id = :estadoId and " +
+           "(c.eliminado = false or c.estado.nombre = 'Cancelada') " +
            "order by c.fecha asc, c.hora asc")
     Page<Cita> listarPorEstado(@Param("usuarioId") Long usuarioId,
                                @Param("estadoId") Long estadoId,

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -61,6 +61,10 @@ public class CitaServiceImpl implements CitaService {
         if (c == null) {
             throw new NotFoundException("Cita no encontrada");
         }
+        // Al eliminar una cita se marca como cancelada y se mantiene el registro
+        EstadoCita cancelada = estadoRepo.findByNombreIgnoreCase("Cancelada")
+                .orElseThrow(() -> new NotFoundException("Estado de cita 'Cancelada' no encontrado"));
+        c.setEstado(cancelada);
         c.setEliminado(Boolean.TRUE);
         repo.save(c);
     }


### PR DESCRIPTION
## Summary
- Set appointment status to "Cancelada" on delete instead of removing record
- Allow listing appointments with estado "Cancelada" even when flagged as eliminated

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b864eb7ac48327b055b47aacf3edc4