### PR TITLE
feat: add cita state transition endpoints

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
@@ -27,17 +27,38 @@ public class CitaController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(dto, usuarioId));
 	}
 
-	@Operation(summary = "Actualizar cita")
-	@PutMapping("/{id}")
-	public ResponseEntity<CitaResponseDTO> actualizar(@PathVariable Long id, @Valid @RequestBody CitaUpdateDTO dto) {
-		Long usuarioId = jwtService.resolveUserId();
-		return ResponseEntity.ok(service.actualizar(id, usuarioId, dto));
-	}
+        @Operation(summary = "Actualizar cita")
+        @PutMapping("/{id}")
+        public ResponseEntity<CitaResponseDTO> actualizar(@PathVariable Long id, @Valid @RequestBody CitaUpdateDTO dto) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.actualizar(id, usuarioId, dto));
+        }
 
-	@Operation(summary = "Eliminar cita (lógico)")
-	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> eliminar(@PathVariable Long id) {
-		Long usuarioId = jwtService.resolveUserId();
+        @Operation(summary = "Confirmar cita")
+        @PutMapping("/{id}/confirmar")
+        public ResponseEntity<CitaResponseDTO> confirmar(@PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.confirmar(id, usuarioId));
+        }
+
+        @Operation(summary = "Completar cita")
+        @PutMapping("/{id}/completar")
+        public ResponseEntity<CitaResponseDTO> completar(@PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.completar(id, usuarioId));
+        }
+
+        @Operation(summary = "Marcar cita como no asistida")
+        @PutMapping("/{id}/no-asistida")
+        public ResponseEntity<CitaResponseDTO> noAsistida(@PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
+                return ResponseEntity.ok(service.noAsistida(id, usuarioId));
+        }
+
+        @Operation(summary = "Eliminar cita (lógico)")
+        @DeleteMapping("/{id}")
+        public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+                Long usuarioId = jwtService.resolveUserId();
 		service.eliminar(id, usuarioId);
 		return ResponseEntity.noContent().build();
 	}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
@@ -6,6 +6,9 @@ import org.springframework.data.domain.Page;
 public interface CitaService {
     CitaResponseDTO crear(CitaCreateDTO dto, Long usuarioId);
     CitaResponseDTO actualizar(Long id, Long usuarioId, CitaUpdateDTO dto);
+    CitaResponseDTO confirmar(Long id, Long usuarioId);
+    CitaResponseDTO completar(Long id, Long usuarioId);
+    CitaResponseDTO noAsistida(Long id, Long usuarioId);
     void eliminar(Long id, Long usuarioId);
     CitaResponseDTO obtener(Long id, Long usuarioId);
     Page<CitaResponseDTO> listarRango(Long usuarioId, String desde, String hasta, int page, int size);

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -76,6 +76,29 @@ public class CitaServiceImpl implements CitaService {
         return CitaMapper.toDTO(c);
     }
 
+    private CitaResponseDTO actualizarEstado(Long id, Long usuarioId, String estadoNombre) {
+        EstadoCita estado = estadoRepo.findByNombreIgnoreCase(estadoNombre)
+                .orElseThrow(() -> new NotFoundException("Estado de cita '" + estadoNombre + "' no encontrado"));
+        CitaUpdateDTO dto = new CitaUpdateDTO();
+        dto.setEstadoId(estado.getId());
+        return actualizar(id, usuarioId, dto);
+    }
+
+    @Override
+    public CitaResponseDTO confirmar(Long id, Long usuarioId) {
+        return actualizarEstado(id, usuarioId, "Confirmada");
+    }
+
+    @Override
+    public CitaResponseDTO completar(Long id, Long usuarioId) {
+        return actualizarEstado(id, usuarioId, "Completada");
+    }
+
+    @Override
+    public CitaResponseDTO noAsistida(Long id, Long usuarioId) {
+        return actualizarEstado(id, usuarioId, "No asistida");
+    }
+
     public void eliminar(Long id, Long usuarioId) {
         Cita c = repo.findOneByIdAndUsuario(id, usuarioId);
         if (c == null) {


### PR DESCRIPTION
## Summary
- add service methods to confirm, complete, or mark appointments as unattended
- expose `/confirmar`, `/completar` and `/no-asistida` endpoints in `CitaController`
- reuse existing update logic to apply the state change and document each transition

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b866435bd08327bf2d0cac114bb9c6