### PR TITLE
feat: manage appointment states

### DIFF
--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -9,7 +9,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import { listarTipos } from '../../services/citasService';
+import { listarTipos, listarEstados } from '../../services/citasService';
 
 export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -18,8 +18,10 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
     motivo: '',
     tipoId: '',
     centroMedico: '',
+    estadoId: '',
   });
   const [tipos, setTipos] = useState([]);
+  const [estados, setEstados] = useState([]);
 
   useEffect(() => {
     if (initialData) {
@@ -29,9 +31,17 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
         motivo: initialData.motivo || '',
         tipoId: initialData.tipoId || '',
         centroMedico: initialData.centroMedico || '',
+        estadoId: initialData.estadoId || '',
       });
     } else {
-      setFormData({ fecha: '', hora: '', motivo: '', tipoId: '', centroMedico: '' });
+      setFormData({
+        fecha: '',
+        hora: '',
+        motivo: '',
+        tipoId: '',
+        centroMedico: '',
+        estadoId: '',
+      });
     }
   }, [initialData, open]);
 
@@ -39,7 +49,12 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
     listarTipos()
       .then((response) => setTipos(response.data))
       .catch((err) => console.error('Error fetching tipos cita:', err));
-  }, []);
+    if (initialData && initialData.id) {
+      listarEstados()
+        .then((response) => setEstados(response.data))
+        .catch((err) => console.error('Error fetching estados cita:', err));
+    }
+  }, [initialData]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -47,8 +62,12 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   };
 
   const handleSubmit = () => {
-    const { fecha, hora, motivo, tipoId, centroMedico } = formData;
-    onSubmit({ fecha, hora, motivo, tipoId, centroMedico });
+    const { fecha, hora, motivo, tipoId, centroMedico, estadoId } = formData;
+    const data = { fecha, hora, motivo, tipoId, centroMedico };
+    if (initialData && initialData.id) {
+      data.estadoId = estadoId;
+    }
+    onSubmit(data);
   };
 
   return (
@@ -82,6 +101,23 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
             <FormLabel sx={{ mb: 1 }}>Centro médico (opcional)</FormLabel>
             <TextField name="centroMedico" value={formData.centroMedico} onChange={handleChange} />
           </FormControl>
+          {initialData && initialData.id && (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Estado</FormLabel>
+              <TextField
+                select
+                name="estadoId"
+                value={formData.estadoId}
+                onChange={handleChange}
+              >
+                {estados.map((e) => (
+                  <MenuItem key={e.id} value={e.id}>
+                    {e.nombre}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </FormControl>
+          )}
         </Stack>
       </DialogContent>
       <DialogActions>

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -3,6 +3,7 @@ import { API_CITAS_URL } from '../config';
 
 const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
 const API_TIPOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-cita`;
+const API_ESTADOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/estados-cita`;
 
 export const listar = (bebeId) => {
   return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`);
@@ -20,8 +21,28 @@ export const eliminarCita = (id) => {
   return axios.delete(`${API_CITAS_ENDPOINT}/${id}`);
 };
 
+export const confirmarCita = (id) => {
+  return axios.put(`${API_CITAS_ENDPOINT}/${id}/confirmar`);
+};
+
+export const cancelarCita = (id) => {
+  return axios.delete(`${API_CITAS_ENDPOINT}/${id}`);
+};
+
+export const completarCita = (id) => {
+  return axios.put(`${API_CITAS_ENDPOINT}/${id}/completar`);
+};
+
+export const marcarNoAsistida = (id) => {
+  return axios.put(`${API_CITAS_ENDPOINT}/${id}/no-asistida`);
+};
+
 export const listarTipos = () => {
   return axios.get(`${API_TIPOS_CITA_ENDPOINT}`);
+};
+
+export const listarEstados = () => {
+  return axios.get(`${API_ESTADOS_CITA_ENDPOINT}`);
 };
 
 export const enviarRecordatorio = (id) => {


### PR DESCRIPTION
## Summary
- allow listing and changing appointment state
- display appointment state in Citas table with colored chips
- enable selecting state when editing a cita

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.js')

------
https://chatgpt.com/codex/tasks/task_e_68b86719086c8327b622ddd634a29a8c