### PR TITLE
Handle paginated citas response

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -71,9 +71,12 @@ export default function Citas() {
     if (!bebeId || !usuarioId) return;
     listar(bebeId)
       .then((response) => {
-        if (Array.isArray(response.data)) {
+        const items = Array.isArray(response.data)
+          ? response.data
+          : response.data?.content;
+        if (Array.isArray(items)) {
           setCitas(
-            response.data.map((c) => ({
+            items.map((c) => ({
               ...c,
               tipoId: c.tipo?.id ?? c.tipoId,
               tipoNombre: c.tipo?.nombre ?? c.tipoNombre,

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -5,8 +5,11 @@ const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
 const API_TIPOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-cita`;
 const API_ESTADOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/estados-cita`;
 
-export const listar = (bebeId) => {
-  return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`);
+export const listar = (bebeId, page, size) => {
+  const params = {};
+  if (page !== undefined) params.page = page;
+  if (size !== undefined) params.size = size;
+  return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`, { params });
 };
 
 export const crearCita = (data) => {


### PR DESCRIPTION
## Summary
- handle citas responses that return items inside `content`
- allow citas listing to accept optional page and size params

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b87801154c8327ad61bdd9d661a99f