### PR TITLE
feat: mostrar citas próximas

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
@@ -7,37 +7,85 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-
-const appointments = [
-  { date: '20 Feb', time: '09:00', doctor: 'Pediatra' },
-  { date: '05 Mar', time: '11:30', doctor: 'Vacuna' },
-];
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
+import { BabyContext } from '../../context/BabyContext';
+import { listar } from '../../services/citasService';
 
 export default function UpcomingAppointmentsCard() {
+  const [appointments, setAppointments] = useState([]);
+  const { activeBaby } = React.useContext(BabyContext);
+
+  useEffect(() => {
+    if (!activeBaby?.id) return;
+    listar(activeBaby.id, 0, 100)
+      .then((response) => {
+        const items = Array.isArray(response.data)
+          ? response.data
+          : response.data?.content;
+        if (Array.isArray(items)) {
+          const upcoming = items
+            .map((c) => ({
+              ...c,
+              tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
+              estadoNombre: c.estado?.nombre ?? c.estadoNombre,
+            }))
+            .filter((c) => dayjs(`${c.fecha}T${c.hora}`) >= dayjs())
+            .sort((a, b) =>
+              dayjs(`${a.fecha}T${a.hora}`).diff(dayjs(`${b.fecha}T${b.hora}`))
+            )
+            .slice(0, 10);
+          setAppointments(upcoming);
+        } else {
+          setAppointments([]);
+        }
+      })
+      .catch((err) => {
+        console.error('Error fetching citas:', err);
+        setAppointments([]);
+      });
+  }, [activeBaby]);
+
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>
         <Typography variant="h6" component="h2" gutterBottom>
           Próximas Citas
         </Typography>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Fecha</TableCell>
-              <TableCell>Hora</TableCell>
-              <TableCell>Médico</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {appointments.map((row, index) => (
-              <TableRow key={index}>
-                <TableCell>{row.date}</TableCell>
-                <TableCell>{row.time}</TableCell>
-                <TableCell>{row.doctor}</TableCell>
+        {appointments.length > 0 ? (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Fecha</TableCell>
+                <TableCell>Hora</TableCell>
+                <TableCell>Motivo</TableCell>
+                <TableCell>Tipo</TableCell>
+                <TableCell>Estado</TableCell>
+                <TableCell>Centro médico</TableCell>
               </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            </TableHead>
+            <TableBody>
+              {appointments.map((c) => (
+                <TableRow key={c.id}>
+                  <TableCell>
+                    {dayjs(c.fecha).locale('es').format('DD/MM/YYYY')}
+                  </TableCell>
+                  <TableCell>
+                    {dayjs(`${c.fecha}T${c.hora}`).locale('es').format('HH:mm')}
+                  </TableCell>
+                  <TableCell>{c.motivo}</TableCell>
+                  <TableCell>{c.tipoNombre}</TableCell>
+                  <TableCell>{c.estadoNombre}</TableCell>
+                  <TableCell>{c.centroMedico}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            No hay citas próximas.
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- fetch upcoming appointments for active baby
- display up to ten future appointments

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b87b8d7d18832794c0c5fc8b054e83