### PR TITLE
feat: add appointment reminder scheduling

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
@@ -94,6 +94,15 @@ public class CitaController {
                 return ResponseEntity.ok(service.listarPorTipo(usuarioId, tipoId, page, size));
         }
 
+        @Operation(summary = "Enviar recordatorio de cita")
+        @PostMapping("/{id}/recordatorio")
+        public ResponseEntity<Void> enviarRecordatorio(@PathVariable Long id,
+                        @RequestBody RecordatorioDTO dto) {
+                Long usuarioId = jwtService.resolveUserId();
+                service.enviarRecordatorio(id, usuarioId, dto.getMinutosAntelacion());
+                return ResponseEntity.accepted().build();
+        }
+
         @Operation(summary = "Listar por médico")
         @GetMapping("/medico")
         public ResponseEntity<Page<CitaResponseDTO>> listarPorMedico(@RequestParam String nombre,

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/RecordatorioDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/RecordatorioDTO.java
@@ -1,0 +1,10 @@
+package com.babytrackmaster.api_citas.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RecordatorioDTO {
+    private Integer minutosAntelacion;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
@@ -16,4 +16,5 @@ public interface CitaService {
     Page<CitaResponseDTO> listarPorTipo(Long usuarioId, Long tipoId, int page, int size);
     Page<CitaResponseDTO> listarPorMedico(Long usuarioId, String medico, int page, int size);
     Page<CitaResponseDTO> listarPorBebe(Long usuarioId, Long bebeId, int page, int size);
+    void enviarRecordatorio(Long id, Long usuarioId, Integer minutosAntelacion);
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -176,4 +176,17 @@ public class CitaServiceImpl implements CitaService {
         }
         return new PageImpl<CitaResponseDTO>(list, p, res.getTotalElements());
     }
+
+    @Override
+    public void enviarRecordatorio(Long id, Long usuarioId, Integer minutosAntelacion) {
+        Cita c = repo.findOneByIdAndUsuario(id, usuarioId);
+        if (c == null) {
+            throw new NotFoundException("Cita no encontrada");
+        }
+        // TODO: Integrar con servicio de notificaciones (correo, push, etc.)
+        System.out.printf(
+                "Recordatorio enviado para cita %d con %d minutos de antelación%n",
+                id,
+                minutosAntelacion);
+    }
 }

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -19,6 +19,10 @@ import Chip from '@mui/material/Chip';
 import Badge from '@mui/material/Badge';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
@@ -61,6 +65,9 @@ export default function Citas() {
   const [menuAnchor, setMenuAnchor] = useState(null);
   const [menuCitaId, setMenuCitaId] = useState(null);
   const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [openRecordatorioDialog, setOpenRecordatorioDialog] = useState(false);
+  const [recordatorioId, setRecordatorioId] = useState(null);
+  const [minutosAntelacion, setMinutosAntelacion] = useState(30);
 
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
@@ -202,9 +209,21 @@ export default function Citas() {
 
   const handleRecordatorio = (id) => {
     if (!usuarioId) return;
-    enviarRecordatorio(id).catch((error) =>
-      console.error('Error sending reminder:', error)
-    );
+    setRecordatorioId(id);
+    setMinutosAntelacion(30);
+    setOpenRecordatorioDialog(true);
+  };
+
+  const handleRecordatorioClose = () => {
+    setOpenRecordatorioDialog(false);
+    setRecordatorioId(null);
+  };
+
+  const handleRecordatorioConfirm = () => {
+    if (!recordatorioId) return;
+    enviarRecordatorio(recordatorioId, minutosAntelacion)
+      .catch((error) => console.error('Error sending reminder:', error))
+      .finally(() => handleRecordatorioClose());
   };
 
   const handleChangePage = (event, newPage) => {
@@ -473,6 +492,26 @@ export default function Citas() {
           Cancelar
         </MenuItem>
       </Menu>
+
+      <Dialog open={openRecordatorioDialog} onClose={handleRecordatorioClose}>
+        <DialogTitle>Enviar recordatorio</DialogTitle>
+        <DialogContent>
+          <TextField
+            type="number"
+            label="Minutos de antelación"
+            value={minutosAntelacion}
+            onChange={(e) => setMinutosAntelacion(Number(e.target.value))}
+            fullWidth
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleRecordatorioClose}>Cancelar</Button>
+          <Button onClick={handleRecordatorioConfirm} variant="contained">
+            Enviar
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       <CitaForm
         open={openForm}

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -70,7 +70,9 @@ export const listarEstados = () => {
   return axios.get(`${API_ESTADOS_CITA_ENDPOINT}`);
 };
 
-export const enviarRecordatorio = (id) => {
-  return axios.post(`${API_CITAS_ENDPOINT}/${id}/recordatorio`);
+export const enviarRecordatorio = (id, minutosAntelacion) => {
+  return axios.post(`${API_CITAS_ENDPOINT}/${id}/recordatorio`, {
+    minutosAntelacion,
+  });
 };
 


### PR DESCRIPTION
## Summary
- allow selecting reminder lead time before sending notification
- send reminder lead time in cita service and expose backend endpoint
- add placeholder service logic for reminder dispatch

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test --prefix frontend-baby -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b8906c99148327b278513c0a6ad012