### PR TITLE
Show additional details in recent care list

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -37,7 +37,9 @@ export default function RecentCareCard() {
             <ListItem key={item.id} disableGutters>
               <ListItemText
                 primary={item.tipoNombre}
-                secondary={dayjs(item.inicio).locale('es').format('DD/MM/YYYY HH:mm')}
+                secondary={`${dayjs(item.inicio)
+                  .locale('es')
+                  .format('DD/MM/YYYY HH:mm')} | ${item.cantidadMl ?? '-'} | ${item.observaciones ?? ''}`}
                 primaryTypographyProps={{ variant: 'body2' }}
                 secondaryTypographyProps={{ variant: 'caption', color: 'text.secondary' }}
               />


### PR DESCRIPTION
## Summary
- Include time, amount in milliliters, and notes for each recent care entry
- Confirm backend already exposes `cantidadMl` and `observaciones`

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68b89676a4b48327bfb007bb66d90757