### PR TITLE
Load care types from API

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -9,13 +9,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-
-const tipoOptions = [
-  { id: 1, label: 'Biberón' },
-  { id: 2, label: 'Pañal' },
-  { id: 3, label: 'Sueño' },
-  { id: 4, label: 'Baño' },
-];
+import { listarTipos } from '../../services/cuidadosService';
 
 export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -24,6 +18,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     cantidadMl: '',
     observaciones: '',
   });
+  const [tipoOptions, setTipoOptions] = useState([]);
 
   useEffect(() => {
     if (initialData) {
@@ -37,6 +32,12 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
       setFormData({ inicio: '', tipoId: '', cantidadMl: '', observaciones: '' });
     }
   }, [initialData, open]);
+
+  useEffect(() => {
+    listarTipos()
+      .then((response) => setTipoOptions(response.data))
+      .catch((err) => console.error('Error fetching tipos cuidado:', err));
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -71,7 +72,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             >
               {tipoOptions.map((option) => (
                 <MenuItem key={option.id} value={option.id}>
-                  {option.label}
+                  {option.nombre}
                 </MenuItem>
               ))}
             </TextField>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -29,12 +29,11 @@ import {
   crearCuidado,
   actualizarCuidado,
   eliminarCuidado,
+  listarTipos,
 } from '../../services/cuidadosService';
 import CuidadoForm from '../components/CuidadoForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
-
-const tipos = ['Biberón', 'Pañal', 'Sueño', 'Baño'];
 
 export default function Cuidados() {
   const [tab, setTab] = useState(0);
@@ -43,6 +42,7 @@ export default function Cuidados() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedCuidado, setSelectedCuidado] = useState(null);
+  const [tipos, setTipos] = useState([]);
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
   const usuarioId = user?.id;
@@ -50,9 +50,14 @@ export default function Cuidados() {
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
 
   const filteredCuidados = useMemo(
-  () => cuidados.filter(c => c.tipoNombre === tipos[tab]),
-  [cuidados, tab]
-);
+    () =>
+      tipos[tab]
+        ? cuidados.filter(
+            (c) => Number(c.tipoId) === Number(tipos[tab].id)
+          )
+        : [],
+    [cuidados, tab, tipos]
+  );
 
   useEffect(() => {
   const stats = Array(7).fill(0);
@@ -82,6 +87,9 @@ export default function Cuidados() {
   useEffect(() => {
     if (bebeId) {
       fetchCuidados();
+      listarTipos()
+        .then((response) => setTipos(response.data))
+        .catch((error) => console.error('Error fetching tipos cuidado:', error));
     }
   }, [bebeId]);
 
@@ -146,7 +154,10 @@ export default function Cuidados() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    link.setAttribute('download', `cuidados_${tipos[tab].toLowerCase()}.csv`);
+    link.setAttribute(
+      'download',
+      `cuidados_${tipos[tab]?.nombre.toLowerCase()}.csv`
+    );
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -165,7 +176,7 @@ export default function Cuidados() {
       head: [tableColumn],
       body: tableRows,
     });
-    doc.save(`cuidados_${tipos[tab].toLowerCase()}.pdf`);
+    doc.save(`cuidados_${tipos[tab]?.nombre.toLowerCase()}.pdf`);
   };
 
   return (
@@ -191,10 +202,9 @@ export default function Cuidados() {
         Cuidados
       </Typography>
       <Tabs value={tab} onChange={handleTabChange} sx={{ mb: 2 }}>
-        <Tab label="Biberón" />
-        <Tab label="Pañal" />
-        <Tab label="Sueño" />
-        <Tab label="Baño" />
+        {tipos.map((t) => (
+          <Tab key={t.id} label={t.nombre} />
+        ))}
       </Tabs>
 
       <TableContainer component={Paper} sx={{ mb: 4 }}>

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { API_CUIDADOS_URL } from '../config';
 
 const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+const API_TIPOS_CUIDADO_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/tipos-cuidado`;
 
 export const listarPorBebe = (usuarioId, bebeId, page, size) => {
   const params = {};
@@ -35,5 +36,9 @@ export const actualizarCuidado = (usuarioId, id, data) => {
 
 export const eliminarCuidado = (usuarioId, id) => {
   return axios.delete(`${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/${id}`);
+};
+
+export const listarTipos = () => {
+  return axios.get(`${API_TIPOS_CUIDADO_ENDPOINT}`);
 };
 


### PR DESCRIPTION
## Summary
- fetch care types from API-cuidados instead of using hardcoded arrays
- dynamically populate care form and tabs with backend types

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b89f6f50088327b3d57c8c72abd4b1