### PR TITLE
Ensure pecho column exists in cuidados table

### DIFF
--- a/api-cuidados/src/main/resources/schema.sql
+++ b/api-cuidados/src/main/resources/schema.sql
@@ -14,5 +14,8 @@ INSERT INTO tipo_cuidado (nombre, created_at, updated_at) VALUES
 ('PASEO', NOW(), NOW());
 
 ALTER TABLE cuidados
+    ADD COLUMN pecho VARCHAR(10);
+
+ALTER TABLE cuidados
     ADD CONSTRAINT fk_cuidados_tipo FOREIGN KEY (tipo) REFERENCES tipo_cuidado(id);
 


### PR DESCRIPTION
## Summary
- add SQL migration to include `pecho` column in `cuidados` table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a748e26c83278f1ce232c0a4590f