### PR TITLE
feat: add quick daily stats for cuidados

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
 import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
+import com.babytrackmaster.api_cuidados.dto.QuickStatsResponse;
 import com.babytrackmaster.api_cuidados.service.CuidadoService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -102,13 +103,23 @@ public class CuidadoController {
         }
 
 	@Operation(summary = "Listar cuidados por rango de fechas")
-        @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/rango")
-        public ResponseEntity<List<CuidadoResponse>> listarPorRango(
-                        @PathVariable Long usuarioId,
-                        @PathVariable Long bebeId,
-                        @RequestParam("desde") Long desdeMillis,
-                        @RequestParam("hasta") Long hastaMillis) {
-                return ResponseEntity.ok(
-                                service.listarPorRango(usuarioId, bebeId, new Date(desdeMillis), new Date(hastaMillis)));
-        }
-}
+         @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/rango")
+         public ResponseEntity<List<CuidadoResponse>> listarPorRango(
+                         @PathVariable Long usuarioId,
+                         @PathVariable Long bebeId,
+                         @RequestParam("desde") Long desdeMillis,
+                         @RequestParam("hasta") Long hastaMillis) {
+                 return ResponseEntity.ok(
+                                 service.listarPorRango(usuarioId, bebeId, new Date(desdeMillis), new Date(hastaMillis)));
+         }
+
+         @Operation(summary = "Obtener estadísticas rápidas del día")
+         @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/stats")
+         public ResponseEntity<QuickStatsResponse> obtenerStats(
+                         @PathVariable Long usuarioId,
+                         @PathVariable Long bebeId,
+                         @RequestParam(value = "fecha", required = false) Long fechaMillis) {
+                 Date fecha = fechaMillis != null ? new Date(fechaMillis) : new Date();
+                 return ResponseEntity.ok(service.obtenerEstadisticasRapidas(usuarioId, bebeId, fecha));
+         }
+  }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
@@ -1,0 +1,17 @@
+package com.babytrackmaster.api_cuidados.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(name = "QuickStatsResponse", description = "Estadísticas rápidas de cuidados para un día")
+public class QuickStatsResponse {
+    @Schema(example = "8.0", description = "Horas totales de sueño")
+    private double horasSueno;
+    @Schema(example = "5", description = "Cantidad de pañales")
+    private long panales;
+    @Schema(example = "6", description = "Número total de tomas (biberón + pecho)")
+    private long tomas;
+    @Schema(example = "1", description = "Cantidad de baños")
+    private long banos;
+}

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
@@ -15,4 +15,6 @@ public interface CuidadoRepository extends JpaRepository<Cuidado, Long> {
     List<Cuidado> findByBebeIdAndUsuarioIdAndEliminadoFalse(Long bebeId, Long usuarioId, Pageable pageable);
     List<Cuidado> findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long tipoId, Long usuarioId);
     List<Cuidado> findByBebeIdAndUsuarioIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long usuarioId, Date desde, Date hasta);
+    List<Cuidado> findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(Long bebeId, Long usuarioId, String tipoNombre, Date desde, Date hasta);
+    long countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(Long bebeId, Long usuarioId, String tipoNombre, Date desde, Date hasta);
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
 import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
+import com.babytrackmaster.api_cuidados.dto.QuickStatsResponse;
 
 public interface CuidadoService {
     CuidadoResponse crear(Long usuarioId, CuidadoRequest request);
@@ -14,4 +15,5 @@ public interface CuidadoService {
     List<CuidadoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit);
     List<CuidadoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId);
     List<CuidadoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta);
+    QuickStatsResponse obtenerEstadisticasRapidas(Long usuarioId, Long bebeId, Date fecha);
 }

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
@@ -1,0 +1,98 @@
+package com.babytrackmaster.api_cuidados;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_cuidados.entity.Cuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class CuidadoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private TipoCuidadoRepository tipoRepo;
+    @Autowired
+    private CuidadoRepository cuidadoRepo;
+
+    private Date baseDate;
+
+    @BeforeEach
+    void setUp() {
+        cuidadoRepo.deleteAll();
+        tipoRepo.deleteAll();
+        baseDate = date(2024,3,10,0,0);
+
+        TipoCuidado sueno = saveTipo("Sue\u00f1o");
+        TipoCuidado panal = saveTipo("Pa\u00f1al");
+        TipoCuidado biberon = saveTipo("Biberon");
+        TipoCuidado pecho = saveTipo("Pecho");
+        TipoCuidado bano = saveTipo("Ba\u00f1o");
+
+        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,2,0));
+        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,11,30));
+        createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
+        createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
+        createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        createCuidado(biberon, date(2024,3,10,6,0), date(2024,3,10,6,30));
+        createCuidado(biberon, date(2024,3,10,9,0), date(2024,3,10,9,20));
+        createCuidado(pecho, date(2024,3,10,15,0), date(2024,3,10,15,15));
+        createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
+    }
+
+    @Test
+    void statsEndpointReturnsAggregatedData() throws Exception {
+        mockMvc.perform(get("/api/v1/cuidados/usuario/1/bebe/1/stats")
+                .param("fecha", String.valueOf(baseDate.getTime())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.horasSueno", closeTo(3.5, 0.01)))
+            .andExpect(jsonPath("$.panales").value(3))
+            .andExpect(jsonPath("$.tomas").value(3))
+            .andExpect(jsonPath("$.banos").value(1));
+    }
+
+    private TipoCuidado saveTipo(String nombre) {
+        TipoCuidado t = new TipoCuidado();
+        Date now = new Date();
+        t.setNombre(nombre);
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return tipoRepo.save(t);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
+        Cuidado c = new Cuidado();
+        c.setBebeId(1L);
+        c.setUsuarioId(1L);
+        c.setTipo(tipo);
+        c.setInicio(inicio);
+        c.setFin(fin);
+        Date now = new Date();
+        c.setCreatedAt(now);
+        c.setUpdatedAt(now);
+        return cuidadoRepo.save(c);
+    }
+
+    private Date date(int year,int month,int day,int hour,int minute) {
+        return Date.from(LocalDateTime.of(year,month,day,hour,minute).atZone(ZoneId.systemDefault()).toInstant());
+    }
+}

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -1,0 +1,92 @@
+package com.babytrackmaster.api_cuidados;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_cuidados.dto.QuickStatsResponse;
+import com.babytrackmaster.api_cuidados.entity.Cuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.service.CuidadoService;
+
+@SpringBootTest
+@Transactional
+class CuidadoServiceImplTest {
+
+    @Autowired
+    private CuidadoService service;
+    @Autowired
+    private TipoCuidadoRepository tipoRepo;
+    @Autowired
+    private CuidadoRepository cuidadoRepo;
+
+    private Date baseDate;
+
+    @BeforeEach
+    void setUp() {
+        cuidadoRepo.deleteAll();
+        tipoRepo.deleteAll();
+        baseDate = date(2024,3,10,0,0);
+
+        TipoCuidado sueno = saveTipo("Sue\u00f1o");
+        TipoCuidado panal = saveTipo("Pa\u00f1al");
+        TipoCuidado biberon = saveTipo("Biberon");
+        TipoCuidado pecho = saveTipo("Pecho");
+        TipoCuidado bano = saveTipo("Ba\u00f1o");
+
+        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,2,0));
+        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,11,30));
+        createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
+        createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
+        createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        createCuidado(biberon, date(2024,3,10,6,0), date(2024,3,10,6,30));
+        createCuidado(biberon, date(2024,3,10,9,0), date(2024,3,10,9,20));
+        createCuidado(pecho, date(2024,3,10,15,0), date(2024,3,10,15,15));
+        createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
+    }
+
+    @Test
+    void testObtenerEstadisticasRapidas() {
+        QuickStatsResponse resp = service.obtenerEstadisticasRapidas(1L,1L, baseDate);
+        assertEquals(3.5, resp.getHorasSueno(), 0.001);
+        assertEquals(3, resp.getPanales());
+        assertEquals(3, resp.getTomas());
+        assertEquals(1, resp.getBanos());
+    }
+
+    private TipoCuidado saveTipo(String nombre) {
+        TipoCuidado t = new TipoCuidado();
+        Date now = new Date();
+        t.setNombre(nombre);
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return tipoRepo.save(t);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
+        Cuidado c = new Cuidado();
+        c.setBebeId(1L);
+        c.setUsuarioId(1L);
+        c.setTipo(tipo);
+        c.setInicio(inicio);
+        c.setFin(fin);
+        Date now = new Date();
+        c.setCreatedAt(now);
+        c.setUpdatedAt(now);
+        return cuidadoRepo.save(c);
+    }
+
+    private Date date(int year,int month,int day,int hour,int minute) {
+        return Date.from(LocalDateTime.of(year,month,day,hour,minute).atZone(ZoneId.systemDefault()).toInstant());
+    }
+}


### PR DESCRIPTION
## Summary
- add `QuickStatsResponse` DTO and repository query helpers
- implement service aggregation for sleep hours, diapers, feedings and baths
- expose `/stats` endpoint and tests for service and controller

## Testing
- `mvn -q -f api-cuidados/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c464060c83279e361467c868f0a8