### PR TITLE
feat: add quick care stats service

### DIFF
--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -23,6 +23,11 @@ export const listarRecientes = (usuarioId, bebeId, limit = 5) => {
   );
 };
 
+export const obtenerStatsRapidas = (usuarioId, bebeId) =>
+  axios.get(
+    `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+  );
+
 export const crearCuidado = (usuarioId, data) => {
   return axios.post(`${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}`, data);
 };

--- a/frontend-baby/src/services/cuidadosService.test.js
+++ b/frontend-baby/src/services/cuidadosService.test.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { obtenerStatsRapidas } from './cuidadosService';
+import { API_CUIDADOS_URL } from '../config';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+describe('cuidadosService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('obtenerStatsRapidas realiza la llamada HTTP correcta', () => {
+    axios.get.mockResolvedValue({});
+    const usuarioId = 1;
+    const bebeId = 2;
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    obtenerStatsRapidas(usuarioId, bebeId);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add obtenerStatsRapidas service calling stats endpoint
- test axios call for quick stats

## Testing
- `cd frontend-baby && CI=true npm test -- src/services/cuidadosService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8c5796bf083278dd9381fe8cc3d22