### PR TITLE
Fetch quick stats from service

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickStatsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.js
@@ -1,17 +1,39 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-
-const stats = [
-  { label: 'Horas de sueño', value: '8h' },
-  { label: 'Pañales', value: '5' },
-  { label: 'Tomas', value: '6' },
-  { label: 'Baños', value: '1' },
-];
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+import { obtenerStatsRapidas } from '../../services/cuidadosService';
 
 export default function QuickStatsCard() {
+  const { user } = useContext(AuthContext);
+  const { activeBaby } = useContext(BabyContext);
+  const [stats, setStats] = useState({
+    horasSueno: 0,
+    panales: 0,
+    tomas: 0,
+    banos: 0,
+  });
+
+  useEffect(() => {
+    if (user?.id && activeBaby?.id) {
+      obtenerStatsRapidas(user.id, activeBaby.id)
+        .then(({ data }) => setStats(data))
+        .catch(() =>
+          setStats({ horasSueno: 0, panales: 0, tomas: 0, banos: 0 })
+        );
+    }
+  }, [user, activeBaby]);
+
+  const statsArray = [
+    { label: 'Horas de sueño', value: `${stats.horasSueno}h` },
+    { label: 'Pañales', value: `${stats.panales}` },
+    { label: 'Tomas', value: `${stats.tomas}` },
+    { label: 'Baños', value: `${stats.banos}` },
+  ];
+
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>
@@ -19,7 +41,7 @@ export default function QuickStatsCard() {
           Estadísticas Rápidas
         </Typography>
         <Grid container spacing={2}>
-          {stats.map((stat, index) => (
+          {statsArray.map((stat, index) => (
             <Grid item xs={6} key={index}>
               <Typography variant="h5" component="p">
                 {stat.value}

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import QuickStatsCard from './QuickStatsCard';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+import { obtenerStatsRapidas } from '../../services/cuidadosService';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('../../services/cuidadosService', () => ({
+  obtenerStatsRapidas: jest.fn(),
+}));
+
+describe('QuickStatsCard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('muestra estadísticas obtenidas del servicio', async () => {
+    obtenerStatsRapidas.mockResolvedValue({
+      data: { horasSueno: 8, panales: 5, tomas: 6, banos: 1 },
+    });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <QuickStatsCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    expect(obtenerStatsRapidas).toHaveBeenCalledWith(1, 2);
+
+    await waitFor(() => {
+      expect(screen.getByText('8h')).toBeInTheDocument();
+      expect(screen.getByText('5')).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fetch quick stats using cuidados service and show results in QuickStatsCard
- Add rendering test covering service integration and context usage

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token in App.test.js due to ESM modules)*
- `npm test -- src/dashboard/components/QuickStatsCard.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b8c60e719c8327854eb86f42f57703