### PR TITLE
Calcular horas de sueño sumando cantidad_ml

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -122,14 +122,13 @@ public class CuidadoServiceImpl implements CuidadoService {
         long pechos = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pecho", inicio, fin);
         long banos = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Baño", inicio, fin);
 
-        double horasSueno = 0d;
+        double minutosSueno = 0d;
         for (Cuidado c : suenos) {
-            Date finSueno = c.getFin() != null ? c.getFin() : new Date();
-            horasSueno += (finSueno.getTime() - c.getInicio().getTime()) / (1000d * 60d * 60d);
+            minutosSueno += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
         }
 
         QuickStatsResponse resp = new QuickStatsResponse();
-        resp.setHorasSueno(horasSueno);
+        resp.setHorasSueno(minutosSueno / 60d);
         resp.setPanales(panales);
         resp.setTomas(biberones + pechos);
         resp.setBanos(banos);

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -44,8 +44,9 @@ class CuidadoServiceImplTest {
         TipoCuidado pecho = saveTipo("Pecho");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
 
-        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,2,0));
-        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,11,30));
+        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,4,0), 120);
+        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,10,30), 90);
+        createCuidado(sueno, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
         createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
         createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
         createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
@@ -73,17 +74,22 @@ class CuidadoServiceImplTest {
         return tipoRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
+    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin, Integer cantidad) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
         c.setTipo(tipo);
         c.setInicio(inicio);
         c.setFin(fin);
+        c.setCantidadMl(cantidad);
         Date now = new Date();
         c.setCreatedAt(now);
         c.setUpdatedAt(now);
         return cuidadoRepo.save(c);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
+        return createCuidado(tipo, inicio, fin, null);
     }
 
     private Date date(int year,int month,int day,int hour,int minute) {


### PR DESCRIPTION
## Summary
- Calcular las horas de sueño sumando `cantidad_ml` de los cuidados de tipo sueño
- Actualizar pruebas unitarias para reflejar el nuevo cálculo y contemplar valores nulos

## Testing
- `bash ./mvnw -q test` *(falla: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cd4a09b0832795f30c96c1dab26c