### PR TITLE
Fix multiline OutlinedInput height

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/inputs.js
+++ b/frontend-baby/src/shared-theme/customizations/inputs.js
@@ -385,6 +385,7 @@ export const inputsCustomizations = {
       },
       root: ({ theme, ownerState }) => ({
         padding: ownerState.multiline ? 0 : '8px 12px',
+        ...(ownerState.multiline && { height: 'auto' }),
         color: (theme.vars || theme).palette.text.primary,
         borderRadius: (theme.vars || theme).shape.borderRadius,
         border: `1px solid ${(theme.vars || theme).palette.divider}`,
@@ -406,6 +407,7 @@ export const inputsCustomizations = {
           {
             props: {
               size: 'small',
+              multiline: false,
             },
             style: {
               height: '2.25rem',
@@ -414,6 +416,7 @@ export const inputsCustomizations = {
           {
             props: {
               size: 'medium',
+              multiline: false,
             },
             style: {
               height: '2.5rem',


### PR DESCRIPTION
## Summary
- allow OutlinedInput to grow automatically when multiline
- restrict fixed-height variants to non-multiline inputs

## Testing
- `npm test -- --watchAll=false`
- `npm start` (manual check: Observaciones field expands and text stays within the box)

------
https://chatgpt.com/codex/tasks/task_e_68b8e2bbefb88327bf1e1448fc4adb70