### PR TITLE
Handle empty statistics in QuickStatsCard

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickStatsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.js
@@ -42,25 +42,35 @@ export default function QuickStatsCard() {
     { id: 3, value: stats.banos, label: 'Baños' },
   ];
 
+  const hasStats = Object.values(stats).some((value) => value > 0);
+
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>
         <Typography variant="h6" component="h2" gutterBottom>
           Estadísticas rápidas del día
         </Typography>
-        <PieChart series={[{ data: chartData }]} width={200} height={200} />
-        <Grid container spacing={2}>
-          {statsArray.map((stat, index) => (
-            <Grid item xs={6} key={index}>
-              <Typography variant="h5" component="p">
-                {stat.value}
-              </Typography>
-              <Typography variant="caption" color="text.secondary">
-                {stat.label}
-              </Typography>
+        {hasStats ? (
+          <>
+            <PieChart series={[{ data: chartData }]} width={200} height={200} />
+            <Grid container spacing={2}>
+              {statsArray.map((stat, index) => (
+                <Grid item xs={6} key={index}>
+                  <Typography variant="h5" component="p">
+                    {stat.value}
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {stat.label}
+                  </Typography>
+                </Grid>
+              ))}
             </Grid>
-          ))}
-        </Grid>
+          </>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            No hay estadísticas que mostrar para el día de hoy.
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
@@ -47,4 +47,26 @@ describe('QuickStatsCard', () => {
       expect(screen.getByText('1')).toBeInTheDocument();
     });
   });
+
+  it('muestra mensaje cuando no hay estadísticas', async () => {
+    obtenerStatsRapidas.mockResolvedValue({
+      data: { horasSueno: 0, panales: 0, tomas: 0, banos: 0 },
+    });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <QuickStatsCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    expect(obtenerStatsRapidas).toHaveBeenCalledWith(1, 2);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No hay estadísticas que mostrar para el día de hoy.')
+      ).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add `hasStats` to detect if any stat value is greater than 0
- display a message when there are no stats for the day and hide chart/grid
- add unit test for zero stats scenario

## Testing
- `CI=true npm test -- src/dashboard/components/QuickStatsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68babb9393e88327b626f964b489abe5