### PR TITLE
test: verify default stats message

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
@@ -48,7 +48,7 @@ describe('QuickStatsCard', () => {
     });
   });
 
-  it('muestra mensaje cuando no hay estadísticas', async () => {
+  it('muestra mensaje cuando el servicio devuelve valores por defecto', async () => {
     obtenerStatsRapidas.mockResolvedValue({
       data: { horasSueno: 0, panales: 0, tomas: 0, banos: 0 },
     });


### PR DESCRIPTION
## Summary
- refine test for QuickStatsCard to confirm the default message when obtenerStatsRapidas returns zeroed stats

## Testing
- `cd frontend-baby && CI=true npm test src/dashboard/components/QuickStatsCard.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68babc34dd7c8327944dba3d88e1c6d8