### PR TITLE
Fix truncated labels in Add Baby form

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -122,7 +122,12 @@ export default function AnadirBebe() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
-      <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
+      <Box
+        component="form"
+        id="add-baby"
+        onSubmit={handleSubmit}
+        sx={{ flexGrow: 1 }}
+      >
         <Typography variant="h4" sx={{ mb: 2 }}>
           Añadir bebé
         </Typography>

--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -8,3 +8,10 @@ body {
   background: radial-gradient(circle at 20% 10%, #ff7aa8 0%, #c5456f 35%, #9b2a4f 65%, #641d37 100%);
   background-size: cover;
 }
+
+/* Ensure long field labels are fully visible on the add baby form */
+#add-baby .MuiInputLabel-root {
+  overflow: visible;
+  white-space: normal;
+  text-overflow: initial;
+}


### PR DESCRIPTION
## Summary
- ensure full labels display in Add Baby form by overriding MUI InputLabel styles
- scope override with unique form id
- remove width override so select labels align correctly

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68babdcf33788327aceba8d67df3dcb8