### PR TITLE
Fix label wrapping in add baby form

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -262,7 +262,7 @@ export default function AnadirBebe() {
                     variant="outlined"
                     sx={{ '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider', borderRadius: 1 } }}
                   >
-                    <InputLabel id="grupo-sanguineo-label">Grupo sanguíneo</InputLabel>
+                    <InputLabel id="grupo-sanguineo-label" shrink>Grupo sanguíneo</InputLabel>
                     <Select
                       labelId="grupo-sanguineo-label"
                       label="Grupo sanguíneo"
@@ -285,7 +285,7 @@ export default function AnadirBebe() {
                     variant="outlined"
                     sx={{ '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider', borderRadius: 1 } }}
                   >
-                    <InputLabel id="alergias-label">Alergias</InputLabel>
+                    <InputLabel id="alergias-label" shrink>Alergias</InputLabel>
                     <Select
                       labelId="alergias-label"
                       label="Alergias"

--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -12,6 +12,6 @@ body {
 /* Ensure long field labels are fully visible on the add baby form */
 #add-baby .MuiInputLabel-root {
   overflow: visible;
-  white-space: normal;
+  white-space: nowrap;
   text-overflow: initial;
 }


### PR DESCRIPTION
## Summary
- ensure health select labels stay above fields by adding `shrink`
- prevent label line breaks with `white-space: nowrap`

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bac227e80483278ac28e2dda91d43e