### PR TITLE
Improve add baby health section layout

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -270,6 +270,7 @@ export default function AnadirBebe() {
                       value={formData.grupoSanguineo}
                       onChange={handleChange}
                       disabled={loading}
+                      fullWidth
                     >
                       {gruposSanguineos.map((grupo) => (
                         <MenuItem key={grupo} value={grupo}>
@@ -293,6 +294,7 @@ export default function AnadirBebe() {
                       value={formData.alergias}
                       onChange={handleChange}
                       disabled={loading}
+                      fullWidth
                     >
                       {alergiasOptions.map((alergia) => (
                         <MenuItem key={alergia} value={alergia}>

--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -15,3 +15,8 @@ body {
   white-space: nowrap;
   text-overflow: initial;
 }
+
+#add-baby .MuiFormControl-root {
+  width: 100%;
+  margin-right: 16px;
+}


### PR DESCRIPTION
## Summary
- Ensure health Select fields span full width
- Style Add Baby form controls to occupy full width with spacing

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bac4a6ea2483278d41fc21226a9492