### PR TITLE
fix: prevent form control overflow

### DIFF
--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -17,6 +17,7 @@ body {
 }
 
 #add-baby .MuiFormControl-root {
-  width: 100%;
+  width: calc(100% - 16px);
   margin-right: 16px;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- prevent overflow on add baby form by including right margin in width

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bac654b41483279b5a6a11c2eb20c5