### PR TITLE
Remove manual margins on add baby form controls

### DIFF
--- a/frontend-baby/src/index.css
+++ b/frontend-baby/src/index.css
@@ -17,7 +17,6 @@ body {
 }
 
 #add-baby .MuiFormControl-root {
-  width: calc(100% - 16px);
-  margin-right: 16px;
   box-sizing: border-box;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- remove margin-based layout from add baby form controls
- ensure selects fill their column by relying on Grid spacing

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bac86d3b648327a419325b589603aa