### PR TITLE
Require birth date and sex selection in baby form

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -34,7 +34,7 @@ export default function AnadirBebe() {
   const [formData, setFormData] = useState({
     nombre: '',
     fechaNacimiento: null,
-    sexo: 'ND',
+    sexo: '',
     pesoNacer: '',
     tallaNacer: '',
     perimetroCranealNacer: '',
@@ -163,6 +163,7 @@ export default function AnadirBebe() {
                     disabled={loading}
                     slotProps={{
                       textField: {
+                        required: true,
                         variant: 'outlined',
                         sx: {
                           '& .MuiOutlinedInput-root': { borderRadius: 1 },
@@ -176,8 +177,8 @@ export default function AnadirBebe() {
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
-                  <FormControl>
-                    <FormLabel>Sexo</FormLabel>
+                  <FormControl required>
+                    <FormLabel required>Sexo</FormLabel>
                     <RadioGroup
                       row
                       name="sexo"


### PR DESCRIPTION
## Summary
- Require birth date by passing `required` to DatePicker text field
- Enforce explicit sex selection with required radio group and empty initial state

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bacf039bc0832788c02a5a17c21852