### PR TITLE
Prevent negative values in Add Baby numeric fields

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -65,6 +65,7 @@ export default function AnadirBebe() {
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
+    if (type === 'number' && Number(value) < 0) return;
     setFormData((prev) => ({
       ...prev,
       [name]: type === 'checkbox' ? checked : value,
@@ -204,6 +205,7 @@ export default function AnadirBebe() {
                     label="Peso al nacer (kg)"
                     name="pesoNacer"
                     type="number"
+                    inputProps={{ min: 0 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.pesoNacer}
@@ -221,6 +223,7 @@ export default function AnadirBebe() {
                     label="Talla al nacer (cm)"
                     name="tallaNacer"
                     type="number"
+                    inputProps={{ min: 0 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.tallaNacer}
@@ -238,6 +241,7 @@ export default function AnadirBebe() {
                     label="Perímetro craneal al nacer (cm)"
                     name="perimetroCranealNacer"
                     type="number"
+                    inputProps={{ min: 0 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.perimetroCranealNacer}
@@ -255,6 +259,7 @@ export default function AnadirBebe() {
                     label="Semanas de gestación"
                     name="semanasGestacion"
                     type="number"
+                    inputProps={{ min: 0 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.semanasGestacion}


### PR DESCRIPTION
## Summary
- ignore negative values in handleChange
- enforce min=0 in numeric fields on baby creation form

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bacfa2765883279ca3a5a40e2f3cb8