### PR TITLE
Translate color mode labels to Spanish

### DIFF
--- a/frontend-baby/src/shared-theme/ColorModeIconDropdown.js
+++ b/frontend-baby/src/shared-theme/ColorModeIconDropdown.js
@@ -75,13 +75,13 @@ export default function ColorModeIconDropdown(props) {
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
         <MenuItem selected={mode === 'system'} onClick={handleMode('system')}>
-          System
+          Sistema
         </MenuItem>
         <MenuItem selected={mode === 'light'} onClick={handleMode('light')}>
-          Light
+          Claro
         </MenuItem>
         <MenuItem selected={mode === 'dark'} onClick={handleMode('dark')}>
-          Dark
+          Oscuro
         </MenuItem>
       </Menu>
     </React.Fragment>

--- a/frontend-baby/src/shared-theme/ColorModeSelect.js
+++ b/frontend-baby/src/shared-theme/ColorModeSelect.js
@@ -17,9 +17,9 @@ export default function ColorModeSelect(props) {
       }}
       {...props}
     >
-      <MenuItem value="system">System</MenuItem>
-      <MenuItem value="light">Light</MenuItem>
-      <MenuItem value="dark">Dark</MenuItem>
+      <MenuItem value="system">Sistema</MenuItem>
+      <MenuItem value="light">Claro</MenuItem>
+      <MenuItem value="dark">Oscuro</MenuItem>
     </Select>
   );
 }


### PR DESCRIPTION
## Summary
- Localize theme mode dropdown to show "Sistema", "Claro" and "Oscuro"
- Mirror Spanish labels in the color mode select component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bae2fde48c8327baa6571e1b8be5a5