### PR TITLE
Refactor health fields in EditarBebe

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -6,6 +6,8 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
 import FormLabel from '@mui/material/FormLabel';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -315,53 +317,75 @@ export default function EditarBebe() {
                 Salud
               </Typography>
               <Grid container spacing={2}>
-                <Grid item xs={12} sm={4}>
-                  <TextField
-                    select
-                    label="Grupo sanguíneo"
-                    name="grupoSanguineo"
-                    InputLabelProps={{ shrink: true }}
+                <Grid item xs={12} sm={6}>
+                  <FormControl
+                    fullWidth
                     variant="outlined"
                     sx={{
                       '& .MuiOutlinedInput-root': { borderRadius: 1 },
                       '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
+                      minWidth: 160,
+                      '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                      },
                     }}
-                    fullWidth
-                    value={formData.grupoSanguineo}
-                    onChange={handleChange}
-                    disabled={loading}
                   >
-                    {gruposSanguineos.map((grupo) => (
-                      <MenuItem key={grupo} value={grupo}>
-                        {grupo}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                    <InputLabel id="grupo-sanguineo-label" shrink>
+                      Grupo sanguíneo
+                    </InputLabel>
+                    <Select
+                      labelId="grupo-sanguineo-label"
+                      label="Grupo sanguíneo"
+                      name="grupoSanguineo"
+                      value={formData.grupoSanguineo}
+                      onChange={handleChange}
+                      disabled={loading}
+                      fullWidth
+                    >
+                      {gruposSanguineos.map((grupo) => (
+                        <MenuItem key={grupo} value={grupo}>
+                          {grupo}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
                 </Grid>
-                <Grid item xs={12} sm={4}>
-                  <TextField
-                    select
-                    label="Alergias"
-                    name="alergias"
-                    InputLabelProps={{ shrink: true }}
+                <Grid item xs={12} sm={6}>
+                  <FormControl
+                    fullWidth
                     variant="outlined"
                     sx={{
                       '& .MuiOutlinedInput-root': { borderRadius: 1 },
                       '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
+                      minWidth: 160,
+                      '& .MuiOutlinedInput-notchedOutline': {
+                        borderColor: 'divider',
+                        borderRadius: 1,
+                      },
                     }}
-                    fullWidth
-                    value={formData.alergias}
-                    onChange={handleChange}
-                    disabled={loading}
                   >
-                    {alergiasOptions.map((alergia) => (
-                      <MenuItem key={alergia} value={alergia}>
-                        {alergia}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                    <InputLabel id="alergias-label" shrink>
+                      Alergias
+                    </InputLabel>
+                    <Select
+                      labelId="alergias-label"
+                      label="Alergias"
+                      name="alergias"
+                      value={formData.alergias}
+                      onChange={handleChange}
+                      disabled={loading}
+                      fullWidth
+                    >
+                      {alergiasOptions.map((alergia) => (
+                        <MenuItem key={alergia} value={alergia}>
+                          {alergia}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
                 </Grid>
-                <Grid item xs={12} sm={4}>
+                <Grid item xs={12}>
                   <TextField
                     label="Medicaciones"
                     name="medicaciones"


### PR DESCRIPTION
## Summary
- replace blood group and allergy TextFields with FormControl/Select components
- adjust layout so blood group and allergies share a row and medicaciones spans full width

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae73832f08327b57c1601cb2be775