### PR TITLE
feat: use blood group and allergy IDs in baby edit

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -41,9 +41,9 @@ export default function EditarBebe() {
     semanasGestacion: '',
     imagenBebe: null,
     numeroSs: '',
-    grupoSanguineo: '',
+    tipoGrupoSanguineoId: '',
     medicaciones: '',
-    alergias: '',
+    tipoAlergiaId: '',
     pediatra: '',
     centroMedico: '',
     telefonoCentroMedico: '',
@@ -64,9 +64,9 @@ export default function EditarBebe() {
         semanasGestacion: activeBaby.semanasGestacion || '',
         imagenBebe: null,
         numeroSs: activeBaby.numeroSs || '',
-        grupoSanguineo: activeBaby.grupoSanguineo || '',
+        tipoGrupoSanguineoId: activeBaby.tipoGrupoSanguineoId || '',
         medicaciones: activeBaby.medicaciones || '',
-        alergias: activeBaby.alergias || '',
+        tipoAlergiaId: activeBaby.tipoAlergiaId || '',
         pediatra: activeBaby.pediatra || '',
         centroMedico: activeBaby.centroMedico || '',
         telefonoCentroMedico: activeBaby.telefonoCentroMedico || '',
@@ -86,8 +86,25 @@ export default function EditarBebe() {
     navigate(-1);
   };
 
-  const gruposSanguineos = ['O+', 'O-', 'A+', 'A-', 'B+', 'B-', 'AB+', 'AB-'];
-  const alergiasOptions = ['Ninguna', 'Gluten', 'Lactosa', 'Frutos secos', 'Polen', 'Ácaros', 'Medicamentos'];
+  const gruposSanguineos = [
+    { id: 1, nombre: 'O+' },
+    { id: 2, nombre: 'O-' },
+    { id: 3, nombre: 'A+' },
+    { id: 4, nombre: 'A-' },
+    { id: 5, nombre: 'B+' },
+    { id: 6, nombre: 'B-' },
+    { id: 7, nombre: 'AB+' },
+    { id: 8, nombre: 'AB-' },
+  ];
+  const alergiasOptions = [
+    { id: 1, nombre: 'Ninguna' },
+    { id: 2, nombre: 'Gluten' },
+    { id: 3, nombre: 'Lactosa' },
+    { id: 4, nombre: 'Frutos secos' },
+    { id: 5, nombre: 'Polen' },
+    { id: 6, nombre: 'Ácaros' },
+    { id: 7, nombre: 'Medicamentos' },
+  ];
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -128,6 +145,8 @@ export default function EditarBebe() {
             payload[key] = value.format('YYYY-MM-DD');
           } else if (key === 'imagenBebe' && value instanceof File) {
             payload[key] = await toBase64(value);
+          } else if (key === 'tipoGrupoSanguineoId' || key === 'tipoAlergiaId') {
+            payload[key] = Number(value);
           } else {
             payload[key] = value;
           }
@@ -337,15 +356,15 @@ export default function EditarBebe() {
                     <Select
                       labelId="grupo-sanguineo-label"
                       label="Grupo sanguíneo"
-                      name="grupoSanguineo"
-                      value={formData.grupoSanguineo}
+                      name="tipoGrupoSanguineoId"
+                      value={formData.tipoGrupoSanguineoId}
                       onChange={handleChange}
                       disabled={loading}
                       fullWidth
                     >
                       {gruposSanguineos.map((grupo) => (
-                        <MenuItem key={grupo} value={grupo}>
-                          {grupo}
+                        <MenuItem key={grupo.id} value={grupo.id}>
+                          {grupo.nombre}
                         </MenuItem>
                       ))}
                     </Select>
@@ -371,15 +390,15 @@ export default function EditarBebe() {
                     <Select
                       labelId="alergias-label"
                       label="Alergias"
-                      name="alergias"
-                      value={formData.alergias}
+                      name="tipoAlergiaId"
+                      value={formData.tipoAlergiaId}
                       onChange={handleChange}
                       disabled={loading}
                       fullWidth
                     >
                       {alergiasOptions.map((alergia) => (
-                        <MenuItem key={alergia} value={alergia}>
-                          {alergia}
+                        <MenuItem key={alergia.id} value={alergia.id}>
+                          {alergia.nombre}
                         </MenuItem>
                       ))}
                     </Select>


### PR DESCRIPTION
## Summary
- use tipoGrupoSanguineoId and tipoAlergiaId in EditarBebe form state
- load and submit these IDs and adjust Select fields accordingly

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baeb2c5dc08327b91129d63599816b