### PR TITLE
feat: expose allergy and blood type lists

### DIFF
--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoAlergiaController.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoAlergiaController.java
@@ -1,0 +1,29 @@
+package com.babytrackmaster.api_bebe.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_bebe.entity.TipoAlergia;
+import com.babytrackmaster.api_bebe.repository.TipoAlergiaRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/tipo-alergias")
+@RequiredArgsConstructor
+@Tag(name = "Tipos de alergia", description = "Obtención de tipos de alergia")
+public class TipoAlergiaController {
+
+    private final TipoAlergiaRepository repository;
+
+    @GetMapping
+    @Operation(summary = "Listar tipos de alergia")
+    public List<TipoAlergia> listar() {
+        return repository.findAll();
+    }
+}

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoGrupoSanguineoController.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoGrupoSanguineoController.java
@@ -1,0 +1,29 @@
+package com.babytrackmaster.api_bebe.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_bebe.entity.TipoGrupoSanguineo;
+import com.babytrackmaster.api_bebe.repository.TipoGrupoSanguineoRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/tipo-gruposanguineo")
+@RequiredArgsConstructor
+@Tag(name = "Tipos de grupo sanguíneo", description = "Obtención de tipos de grupo sanguíneo")
+public class TipoGrupoSanguineoController {
+
+    private final TipoGrupoSanguineoRepository repository;
+
+    @GetMapping
+    @Operation(summary = "Listar tipos de grupo sanguíneo")
+    public List<TipoGrupoSanguineo> listar() {
+        return repository.findAll();
+    }
+}

--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext } from 'react';
+import React, { useRef, useState, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
@@ -20,7 +20,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
-import { crearBebe } from '../../services/bebesService';
+import { crearBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
@@ -60,25 +60,17 @@ export default function AnadirBebe() {
     navigate(-1);
   };
 
-  const gruposSanguineos = [
-    { id: 1, nombre: 'O+' },
-    { id: 2, nombre: 'O-' },
-    { id: 3, nombre: 'A+' },
-    { id: 4, nombre: 'A-' },
-    { id: 5, nombre: 'B+' },
-    { id: 6, nombre: 'B-' },
-    { id: 7, nombre: 'AB+' },
-    { id: 8, nombre: 'AB-' },
-  ];
-  const alergiasOptions = [
-    { id: 1, nombre: 'Ninguna' },
-    { id: 2, nombre: 'Gluten' },
-    { id: 3, nombre: 'Lactosa' },
-    { id: 4, nombre: 'Frutos secos' },
-    { id: 5, nombre: 'Polen' },
-    { id: 6, nombre: 'Ácaros' },
-    { id: 7, nombre: 'Medicamentos' },
-  ];
+  const [gruposSanguineos, setGruposSanguineos] = useState([]);
+  const [alergiasOptions, setAlergiasOptions] = useState([]);
+
+  useEffect(() => {
+    fetchTipoGrupoSanguineo()
+      .then((res) => setGruposSanguineos(res.data))
+      .catch((err) => console.error('Error fetching tipos grupo sanguíneo:', err));
+    fetchTipoAlergias()
+      .then((res) => setAlergiasOptions(res.data))
+      .catch((err) => console.error('Error fetching tipos alergia:', err));
+  }, []);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -20,7 +20,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
-import { actualizarBebe, eliminarBebe } from '../../services/bebesService';
+import { actualizarBebe, eliminarBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
@@ -86,25 +86,17 @@ export default function EditarBebe() {
     navigate(-1);
   };
 
-  const gruposSanguineos = [
-    { id: 1, nombre: 'O+' },
-    { id: 2, nombre: 'O-' },
-    { id: 3, nombre: 'A+' },
-    { id: 4, nombre: 'A-' },
-    { id: 5, nombre: 'B+' },
-    { id: 6, nombre: 'B-' },
-    { id: 7, nombre: 'AB+' },
-    { id: 8, nombre: 'AB-' },
-  ];
-  const alergiasOptions = [
-    { id: 1, nombre: 'Ninguna' },
-    { id: 2, nombre: 'Gluten' },
-    { id: 3, nombre: 'Lactosa' },
-    { id: 4, nombre: 'Frutos secos' },
-    { id: 5, nombre: 'Polen' },
-    { id: 6, nombre: 'Ácaros' },
-    { id: 7, nombre: 'Medicamentos' },
-  ];
+  const [gruposSanguineos, setGruposSanguineos] = useState([]);
+  const [alergiasOptions, setAlergiasOptions] = useState([]);
+
+  useEffect(() => {
+    fetchTipoGrupoSanguineo()
+      .then((res) => setGruposSanguineos(res.data))
+      .catch((err) => console.error('Error fetching tipos grupo sanguíneo:', err));
+    fetchTipoAlergias()
+      .then((res) => setAlergiasOptions(res.data))
+      .catch((err) => console.error('Error fetching tipos alergia:', err));
+  }, []);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;

--- a/frontend-baby/src/services/bebesService.js
+++ b/frontend-baby/src/services/bebesService.js
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { API_BEBE_URL } from '../config';
 
 const API_BEBES_ENDPOINT = `${API_BEBE_URL}/api/v1/bebes`;
+const API_TIPO_ALERGIAS_ENDPOINT = `${API_BEBE_URL}/api/v1/tipo-alergias`;
+const API_TIPO_GRUPO_SANGUINEO_ENDPOINT = `${API_BEBE_URL}/api/v1/tipo-gruposanguineo`;
 
 export const crearBebe = (payload, headers = {}) => {
   return axios.post(API_BEBES_ENDPOINT, payload, {
@@ -29,4 +31,12 @@ export const actualizarBebe = (id, payload, headers = {}) => {
 
 export const eliminarBebe = (id) => {
   return axios.delete(`${API_BEBES_ENDPOINT}/${id}`);
+};
+
+export const fetchTipoAlergias = () => {
+  return axios.get(API_TIPO_ALERGIAS_ENDPOINT);
+};
+
+export const fetchTipoGrupoSanguineo = () => {
+  return axios.get(API_TIPO_GRUPO_SANGUINEO_ENDPOINT);
 };


### PR DESCRIPTION
## Summary
- expose `tipo-alergias` and `tipo-gruposanguineo` endpoints
- load allergy and blood type options from API in add/edit baby forms

## Testing
- `npm test -- --watchAll=false`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baed87781c832783424465df798f79