### PR TITLE
feat: add lactation types listing

### DIFF
--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoLactanciaController.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/controller/TipoLactanciaController.java
@@ -1,0 +1,29 @@
+package com.babytrackmaster.api_bebe.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_bebe.dto.TipoLactanciaResponse;
+import com.babytrackmaster.api_bebe.service.TipoLactanciaService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/tipo-lactancias")
+@RequiredArgsConstructor
+@Tag(name = "Tipos de lactancia", description = "Obtención de tipos de lactancia")
+public class TipoLactanciaController {
+
+    private final TipoLactanciaService service;
+
+    @GetMapping
+    @Operation(summary = "Listar tipos de lactancia")
+    public List<TipoLactanciaResponse> listar() {
+        return service.listar();
+    }
+}

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/TipoLactanciaResponse.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/dto/TipoLactanciaResponse.java
@@ -1,0 +1,9 @@
+package com.babytrackmaster.api_bebe.dto;
+
+import lombok.Data;
+
+@Data
+public class TipoLactanciaResponse {
+    private Long id;
+    private String nombre;
+}

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/mapper/TipoLactanciaMapper.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/mapper/TipoLactanciaMapper.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_bebe.mapper;
+
+import com.babytrackmaster.api_bebe.dto.TipoLactanciaResponse;
+import com.babytrackmaster.api_bebe.entity.TipoLactancia;
+
+public class TipoLactanciaMapper {
+    public static TipoLactanciaResponse toResponse(TipoLactancia entity) {
+        if (entity == null) return null;
+        TipoLactanciaResponse resp = new TipoLactanciaResponse();
+        resp.setId(entity.getId());
+        resp.setNombre(entity.getNombre());
+        return resp;
+        }
+}

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/TipoLactanciaService.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/TipoLactanciaService.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_bebe.service;
+
+import java.util.List;
+import com.babytrackmaster.api_bebe.dto.TipoLactanciaResponse;
+
+public interface TipoLactanciaService {
+    List<TipoLactanciaResponse> listar();
+}

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/TipoLactanciaServiceImpl.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/service/impl/TipoLactanciaServiceImpl.java
@@ -1,0 +1,29 @@
+package com.babytrackmaster.api_bebe.service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_bebe.dto.TipoLactanciaResponse;
+import com.babytrackmaster.api_bebe.mapper.TipoLactanciaMapper;
+import com.babytrackmaster.api_bebe.repository.TipoLactanciaRepository;
+import com.babytrackmaster.api_bebe.service.TipoLactanciaService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TipoLactanciaServiceImpl implements TipoLactanciaService {
+
+    private final TipoLactanciaRepository repository;
+
+    @Override
+    public List<TipoLactanciaResponse> listar() {
+        return repository.findAll().stream()
+                .map(TipoLactanciaMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO, mapper, service and controller to list lactation types
- expose `/api/v1/tipo-lactancias` endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf015620083279023d621b6d1ee0a