### PR TITLE
feat: prevent negative care quantity

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -43,11 +43,13 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
+    const sanitizedValue =
+      name === 'cantidadMl' ? String(Math.max(0, Number(value))) : value;
     setFormData((prev) => ({
       ...prev,
-      [name]: value,
+      [name]: sanitizedValue,
       ...(name === 'tipoId' &&
-      tipoOptions.find((option) => option.id == value)?.nombre !== 'Pecho'
+      tipoOptions.find((option) => option.id == sanitizedValue)?.nombre !== 'Pecho'
         ? { pecho: '' }
         : {}),
     }));
@@ -110,6 +112,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
               name="cantidadMl"
               value={formData.cantidadMl}
               onChange={handleChange}
+              inputProps={{ min: 0 }}
             />
           </FormControl>
           <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- prevent negative quantity values in `CuidadoForm` handler
- enforce non-negative numbers in quantity field with `min` input prop

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baf30c79108327adda0dc1da5c7cf2