### PR TITLE
feat: restrict reminder minutes to non-negative

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -522,7 +522,10 @@ export default function Citas() {
             type="number"
             label="Minutos de antelación"
             value={minutosAntelacion}
-            onChange={(e) => setMinutosAntelacion(Number(e.target.value))}
+            onChange={(e) =>
+              setMinutosAntelacion(Math.max(0, Number(e.target.value)))
+            }
+            inputProps={{ min: 0 }}
             fullWidth
             sx={{ mt: 1 }}
           />


### PR DESCRIPTION
## Summary
- prevent negative minutes in reminder dialog

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baf30f0fd083278413b2faf718a434