### PR TITLE
feat: localize datepicker to spanish

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -20,6 +20,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 import { crearBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -27,6 +28,7 @@ import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 
 export default function AnadirBebe() {
+  dayjs.locale('es');
   const navigate = useNavigate();
   const { addBaby } = useContext(BabyContext);
   const fileInputRef = useRef(null);
@@ -133,7 +135,7 @@ export default function AnadirBebe() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
       <Box
         component="form"
         id="add-baby"


### PR DESCRIPTION
## Summary
- configure Dayjs and MUI DatePicker to use Spanish locale

## Testing
- `node - <<'NODE'...`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf50f10148327b13f938a2fb8a0dc