### PR TITLE
feat: show EditarBebe date picker in Spanish

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -20,11 +20,14 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import dayjs from 'dayjs';
+import 'dayjs/locale/es';
 import { actualizarBebe, eliminarBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+
+dayjs.locale('es');
 
 export default function EditarBebe() {
   const navigate = useNavigate();
@@ -175,7 +178,7 @@ export default function EditarBebe() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
       <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
         <Typography variant="h4" sx={{ mb: 2 }}>
           Editar/borrar bebé


### PR DESCRIPTION
## Summary
- load Dayjs Spanish locale and configure locale to 'es'
- ensure LocalizationProvider uses Spanish locale

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baf513aa2883278006615a99140cb4