### PR TITLE
feat: add localized date picker to expense form

### DIFF
--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -9,12 +9,17 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 
 import { listarCategorias } from '../../services/gastosService';
 
 export default function GastoForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
-    fecha: '',
+    fecha: null,
     categoriaId: '',
     descripcion: '',
     cantidad: '',
@@ -25,13 +30,13 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
   useEffect(() => {
     if (initialData) {
       setFormData({
-        fecha: initialData.fecha ? new Date(initialData.fecha).toISOString().slice(0, 10) : '',
+        fecha: initialData.fecha ? dayjs(initialData.fecha) : null,
         categoriaId: initialData.categoriaId || '',
         descripcion: initialData.descripcion || '',
         cantidad: initialData.cantidad || '',
       });
     } else {
-      setFormData({ fecha: '', categoriaId: '', descripcion: '', cantidad: '' });
+      setFormData({ fecha: null, categoriaId: '', descripcion: '', cantidad: '' });
     }
     setErrors({});
   }, [initialData, open]);
@@ -58,6 +63,10 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleDateChange = (newValue) => {
+    setFormData((prev) => ({ ...prev, fecha: newValue }));
+  };
+
   const handleSubmit = () => {
     const val = Number(formData.cantidad);
     if (val < 0) {
@@ -67,66 +76,71 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
       }));
       return;
     }
-    onSubmit(formData);
+    const data = {
+      ...formData,
+      fecha: formData.fecha ? formData.fecha.format('YYYY-MM-DD') : '',
+    };
+    onSubmit(data);
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>{initialData && initialData.id ? 'Editar gasto' : 'Añadir nuevo gasto'}</DialogTitle>
-      <DialogContent>
-        <Stack sx={{ mt: 1 }}>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <FormLabel sx={{ mb: 1 }}>Fecha</FormLabel>
-            <TextField
-              type="date"
-              name="fecha"
-              value={formData.fecha}
-              onChange={handleChange}
-            />
-          </FormControl>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <FormLabel sx={{ mb: 1 }}>Categoría</FormLabel>
-            <TextField
-              select
-              name="categoriaId"
-              value={formData.categoriaId}
-              onChange={handleChange}
-            >
-              {categorias.map((option) => (
-                <MenuItem key={option.id} value={option.id}>
-                  {option.nombre}
-                </MenuItem>
-              ))}
-            </TextField>
-          </FormControl>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <FormLabel sx={{ mb: 1 }}>Descripción</FormLabel>
-            <TextField
-              multiline
-              rows={3}
-              name="descripcion"
-              value={formData.descripcion}
-              onChange={handleChange}
-            />
-          </FormControl>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
-            <TextField
-              type="number"
-              name="cantidad"
-              value={formData.cantidad}
-              onChange={handleChange}
-              inputProps={{ min: 0 }}
-              error={Boolean(errors.cantidad)}
-              helperText={errors.cantidad}
-            />
-          </FormControl>
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={handleSubmit} variant="contained">Guardar</Button>
-      </DialogActions>
-    </Dialog>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>{initialData && initialData.id ? 'Editar gasto' : 'Añadir nuevo gasto'}</DialogTitle>
+        <DialogContent>
+          <Stack sx={{ mt: 1 }}>
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Fecha</FormLabel>
+              <DatePicker
+                value={formData.fecha}
+                onChange={handleDateChange}
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            </FormControl>
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Categoría</FormLabel>
+              <TextField
+                select
+                name="categoriaId"
+                value={formData.categoriaId}
+                onChange={handleChange}
+              >
+                {categorias.map((option) => (
+                  <MenuItem key={option.id} value={option.id}>
+                    {option.nombre}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </FormControl>
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Descripción</FormLabel>
+              <TextField
+                multiline
+                rows={3}
+                name="descripcion"
+                value={formData.descripcion}
+                onChange={handleChange}
+              />
+            </FormControl>
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
+              <TextField
+                type="number"
+                name="cantidad"
+                value={formData.cantidad}
+                onChange={handleChange}
+                inputProps={{ min: 0 }}
+                error={Boolean(errors.cantidad)}
+                helperText={errors.cantidad}
+              />
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>Cancelar</Button>
+          <Button onClick={handleSubmit} variant="contained">Guardar</Button>
+        </DialogActions>
+      </Dialog>
+    </LocalizationProvider>
   );
 }


### PR DESCRIPTION
## Summary
- use MUI DatePicker with Spanish locale for expense date
- convert Dayjs value to string on submit and wrap form with LocalizationProvider

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68baf51a89588327b7d1f439649ce2f1