### PR TITLE
Globalize Dayjs localization

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -1,5 +1,9 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import dayjs from 'dayjs';
+import 'dayjs/locale/es';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import SignInSide from "./sign-in-side/SignInSide";
 import SignUp from "./sign-up/SignUp";
 import DashboardLayout from "./dashboard/Dashboard";
@@ -17,37 +21,41 @@ import InicioSinBebe from "./dashboard/pages/InicioSinBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
+dayjs.locale('es');
+
 function App() {
   return (
-    <AuthProvider>
-      <Router>
-        <Routes>
-          <Route path="/" element={<SignInSide />} />
-          <Route path="/signup" element={<SignUp />} />
-          <Route path="/signin" element={<SignInSide />} />
-          <Route
-            path="/dashboard/*"
-            element={
-              <ProtectedRoute>
-                <DashboardLayout />
-              </ProtectedRoute>
-            }
-          >
-            <Route index element={<MainGrid />} />
-            <Route path="cuidados" element={<Cuidados />} />
-            <Route path="gastos" element={<Gastos />} />
-            <Route path="diario" element={<Diario />} />
-            <Route path="citas" element={<Citas />} />
-            <Route path="rutinas" element={<Rutinas />} />
-            <Route path="anadir-bebe" element={<AnadirBebe />} />
-            <Route path="editar-bebe" element={<EditarBebe />} />
-            <Route path="configuracion" element={<Configuracion />} />
-            <Route path="acerca" element={<Acerca />} />
-            <Route path="inicio" element={<InicioSinBebe />} />
-          </Route>
-        </Routes>
-      </Router>
-    </AuthProvider>
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
+      <AuthProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<SignInSide />} />
+            <Route path="/signup" element={<SignUp />} />
+            <Route path="/signin" element={<SignInSide />} />
+            <Route
+              path="/dashboard/*"
+              element={
+                <ProtectedRoute>
+                  <DashboardLayout />
+                </ProtectedRoute>
+              }
+            >
+              <Route index element={<MainGrid />} />
+              <Route path="cuidados" element={<Cuidados />} />
+              <Route path="gastos" element={<Gastos />} />
+              <Route path="diario" element={<Diario />} />
+              <Route path="citas" element={<Citas />} />
+              <Route path="rutinas" element={<Rutinas />} />
+              <Route path="anadir-bebe" element={<AnadirBebe />} />
+              <Route path="editar-bebe" element={<EditarBebe />} />
+              <Route path="configuracion" element={<Configuracion />} />
+              <Route path="acerca" element={<Acerca />} />
+              <Route path="inicio" element={<InicioSinBebe />} />
+            </Route>
+          </Routes>
+        </Router>
+      </AuthProvider>
+    </LocalizationProvider>
   );
 }
 

--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -10,14 +10,8 @@ import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { DatePicker, TimePicker } from '@mui/x-date-pickers';
 import { listarTipos, listarEstados } from '../../services/citasService';
-
-dayjs.locale('es');
 
 export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -84,8 +78,7 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
         <DialogTitle>{initialData && initialData.id ? 'Editar cita' : 'Añadir cita'}</DialogTitle>
         <DialogContent>
           <Stack sx={{ mt: 1 }}>
@@ -164,7 +157,6 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
           </Button>
         </DialogActions>
       </Dialog>
-    </LocalizationProvider>
   );
 }
 

--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -9,11 +9,8 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
+import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { listarTipos } from '../../services/cuidadosService';
 
 export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
@@ -79,11 +76,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   };
 
   return (
-    <LocalizationProvider
-      dateAdapter={AdapterDayjs}
-      adapterLocale="es"
-    >
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
         <DialogTitle>
           {initialData && initialData.id
             ? 'Editar cuidado'
@@ -157,6 +150,5 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
           </Button>
         </DialogActions>
       </Dialog>
-    </LocalizationProvider>
   );
 }

--- a/frontend-baby/src/dashboard/components/CustomDatePicker.js
+++ b/frontend-baby/src/dashboard/components/CustomDatePicker.js
@@ -1,12 +1,9 @@
 import * as React from 'react';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { useForkRef } from '@mui/material/utils';
 import Button from '@mui/material/Button';
 import CalendarTodayRoundedIcon from '@mui/icons-material/CalendarTodayRounded';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DatePicker } from '@mui/x-date-pickers';
 import {
   useParsedFormat,
   usePickerContext,
@@ -40,21 +37,18 @@ function ButtonField(props) {
 
 export default function CustomDatePicker() {
   const [value, setValue] = React.useState(dayjs('2023-04-17'));
-  dayjs.locale('es');
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <DatePicker
-        value={value}
-        label={value == null ? null : value.format('DD MMM YYYY')}
-        onChange={(newValue) => setValue(newValue)}
-        slots={{ field: ButtonField }}
-        slotProps={{
-          nextIconButton: { size: 'small' },
-          previousIconButton: { size: 'small' },
-        }}
-        views={['day', 'month', 'year']}
-      />
-    </LocalizationProvider>
+    <DatePicker
+      value={value}
+      label={value == null ? null : value.format('DD MMM YYYY')}
+      onChange={(newValue) => setValue(newValue)}
+      slots={{ field: ButtonField }}
+      slotProps={{
+        nextIconButton: { size: 'small' },
+        previousIconButton: { size: 'small' },
+      }}
+      views={['day', 'month', 'year']}
+    />
   );
 }

--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -10,10 +10,7 @@ import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DatePicker } from '@mui/x-date-pickers';
 
 import { listarCategorias } from '../../services/gastosService';
 
@@ -84,8 +81,7 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
         <DialogTitle>{initialData && initialData.id ? 'Editar gasto' : 'Añadir nuevo gasto'}</DialogTitle>
         <DialogContent>
           <Stack sx={{ mt: 1 }}>
@@ -141,6 +137,5 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
           <Button onClick={handleSubmit} variant="contained">Guardar</Button>
         </DialogActions>
       </Dialog>
-    </LocalizationProvider>
   );
 }

--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -10,7 +10,6 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { listarRecientes } from '../../services/cuidadosService';
 
 export default function RecentCareCard() {
@@ -48,8 +47,8 @@ export default function RecentCareCard() {
             <TableBody>
               {recentCare.slice(0, 5).map((item) => (
                 <TableRow key={item.id}>
-                  <TableCell>{dayjs(item.inicio).locale('es').format('DD/MM/YYYY')}</TableCell>
-                  <TableCell>{dayjs(item.inicio).locale('es').format('HH:mm')}</TableCell>
+                  <TableCell>{dayjs(item.inicio).format('DD/MM/YYYY')}</TableCell>
+                  <TableCell>{dayjs(item.inicio).format('HH:mm')}</TableCell>
                   <TableCell>{item.tipoNombre}</TableCell>
                   <TableCell>{item.cantidadMl ?? '-'}</TableCell>
                   <TableCell>{item.observaciones ?? ''}</TableCell>

--- a/frontend-baby/src/dashboard/components/RutinaForm.js
+++ b/frontend-baby/src/dashboard/components/RutinaForm.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -11,9 +10,7 @@ import MenuItem from '@mui/material/MenuItem';
 import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
+import { TimePicker } from '@mui/x-date-pickers';
 
 const diasOptions = [
   { value: 'L', label: 'Lunes' },
@@ -68,11 +65,8 @@ export default function RutinaForm({ open, onClose, onSubmit, initialData }) {
 
   const isValid = formData.dia && formData.hora && formData.tipo;
 
-  dayjs.locale('es');
-
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
         <DialogTitle>{initialData && initialData.id ? 'Editar rutina' : 'Añadir rutina'}</DialogTitle>
         <DialogContent>
           <Stack sx={{ mt: 1 }}>
@@ -123,6 +117,5 @@ export default function RutinaForm({ open, onClose, onSubmit, initialData }) {
           </Button>
         </DialogActions>
       </Dialog>
-    </LocalizationProvider>
   );
 }

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -8,7 +8,6 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { BabyContext } from '../../context/BabyContext';
 import { listarProximas } from '../../services/citasService';
 
@@ -50,10 +49,10 @@ export default function UpcomingAppointmentsCard() {
               {appointments.map((c) => (
                 <TableRow key={c.id}>
                   <TableCell>
-                    {dayjs(c.fecha).locale('es').format('DD/MM/YYYY')}
+                    {dayjs(c.fecha).format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
-                    {dayjs(`${c.fecha}T${c.hora}`).locale('es').format('HH:mm')}
+                    {dayjs(`${c.fecha}T${c.hora}`).format('HH:mm')}
                   </TableCell>
                   <TableCell>{c.motivo}</TableCell>
                   <TableCell>{c.tipoNombre}</TableCell>

--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -16,11 +16,8 @@ import Avatar from '@mui/material/Avatar';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { crearBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -28,7 +25,6 @@ import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 
 export default function AnadirBebe() {
-  dayjs.locale('es');
   const navigate = useNavigate();
   const { addBaby } = useContext(BabyContext);
   const fileInputRef = useRef(null);
@@ -135,8 +131,7 @@ export default function AnadirBebe() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Box
+    <Box
         component="form"
         id="add-baby"
         onSubmit={handleSubmit}
@@ -524,7 +519,7 @@ export default function AnadirBebe() {
           Bebé guardado correctamente
         </Alert>
       </Snackbar>
-    </LocalizationProvider>
+    </Box>
   );
 }
 

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -28,9 +28,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
-import { LocalizationProvider, DateCalendar, PickersDay } from '@mui/x-date-pickers';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import {
   listar,
   crearCita,
@@ -46,8 +44,6 @@ import {
 import CitaForm from '../components/CitaForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
-
-dayjs.locale('es');
 
 export default function Citas() {
   const [citas, setCitas] = useState([]);
@@ -336,19 +332,17 @@ export default function Citas() {
 
       {view === 'month' ? (
         <>
-          <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-            {selectedDate && (
-              <DateCalendar
-                value={selectedDate}
-                onChange={(newValue) => {
-                  const date = newValue ? dayjs(newValue) : dayjs();
-                  setSelectedDate(date);
-                  setSelectedDay(date);
-                }}
-                slots={{ day: CustomDay }}
-              />
-            )}
-          </LocalizationProvider>
+          {selectedDate && (
+            <DateCalendar
+              value={selectedDate}
+              onChange={(newValue) => {
+                const date = newValue ? dayjs(newValue) : dayjs();
+                setSelectedDate(date);
+                setSelectedDay(date);
+              }}
+              slots={{ day: CustomDay }}
+            />
+          )}
           {selectedDay && (
             <Button
               variant="outlined"
@@ -376,10 +370,10 @@ export default function Citas() {
               {citasSemana.map((cita) => (
                 <TableRow key={cita.id}>
                   <TableCell>
-                    {dayjs(cita.fecha).locale('es').format('DD/MM/YYYY')}
+                    {dayjs(cita.fecha).format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
-                    {dayjs(`${cita.fecha}T${cita.hora}`).locale('es').format('HH:mm')}
+                    {dayjs(`${cita.fecha}T${cita.hora}`).format('HH:mm')}
                   </TableCell>
                   <TableCell>{cita.motivo}</TableCell>
                   <TableCell>
@@ -442,10 +436,10 @@ export default function Citas() {
               .map((cita) => (
                 <TableRow key={cita.id}>
                   <TableCell>
-                    {dayjs(cita.fecha).locale('es').format('DD/MM/YYYY')}
+                    {dayjs(cita.fecha).format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
-                    {dayjs(`${cita.fecha}T${cita.hora}`).locale('es').format('HH:mm')}
+                    {dayjs(`${cita.fecha}T${cita.hora}`).format('HH:mm')}
                   </TableCell>
                   <TableCell>{cita.motivo}</TableCell>
                   <TableCell>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -17,7 +17,6 @@ import TablePagination from '@mui/material/TablePagination';
 import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import AddIcon from '@mui/icons-material/Add';
@@ -146,7 +145,7 @@ export default function Cuidados() {
   const handleExportCsv = () => {
     const headers = ['Hora', 'Tipo', esPecho ? 'Pecho' : 'Cantidad', 'Nota'];
     const rows = filteredCuidados.map((cuidado) => [
-      dayjs(cuidado.inicio).locale('es').format('DD/MM/YYYY HH:mm'),
+      dayjs(cuidado.inicio).format('DD/MM/YYYY HH:mm'),
       cuidado.tipoNombre,
       esPecho ? cuidado.pecho ?? '-' : cuidado.cantidadMl ?? '-',
       cuidado.observaciones ?? '',
@@ -169,7 +168,7 @@ export default function Cuidados() {
     const doc = new jsPDF();
     const tableColumn = ['Hora', 'Tipo', esPecho ? 'Pecho' : 'Cantidad', 'Nota'];
     const tableRows = filteredCuidados.map((cuidado) => [
-      dayjs(cuidado.inicio).locale('es').format('DD/MM/YYYY HH:mm'),
+      dayjs(cuidado.inicio).format('DD/MM/YYYY HH:mm'),
       cuidado.tipoNombre,
       esPecho ? cuidado.pecho ?? '-' : cuidado.cantidadMl ?? '-',
       cuidado.observaciones ?? '',
@@ -226,7 +225,7 @@ export default function Cuidados() {
               .map((cuidado) => (
               <TableRow key={cuidado.id}>
                 <TableCell>
-                  {dayjs(cuidado.inicio).locale('es').format('DD/MM/YYYY HH:mm')}
+                  {dayjs(cuidado.inicio).format('DD/MM/YYYY HH:mm')}
                 </TableCell>
                 <TableCell>{cuidado.tipoNombre}</TableCell>
                 <TableCell>{esPecho ? cuidado.pecho ?? '-' : cuidado.cantidadMl ?? '-'}</TableCell>

--- a/frontend-baby/src/dashboard/pages/Diario.js
+++ b/frontend-baby/src/dashboard/pages/Diario.js
@@ -14,14 +14,10 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import SearchIcon from '@mui/icons-material/Search';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
-import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { DatePicker } from '@mui/x-date-pickers';
 import { listarEntradas, crearEntrada } from '../../services/diarioService';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
-
-dayjs.locale('es');
 
 const emociones = [
   { value: 'happy', label: '😊 Feliz' },
@@ -89,8 +85,7 @@ export default function Diario() {
   );
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Box
+    <Box
         sx={{
           width: '100%',
           display: 'grid',
@@ -223,7 +218,6 @@ export default function Diario() {
           </Card>
         </Box>
       </Box>
-    </LocalizationProvider>
   );
 }
 

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -16,18 +16,13 @@ import Avatar from '@mui/material/Avatar';
 import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import { actualizarBebe, eliminarBebe, fetchTipoAlergias, fetchTipoGrupoSanguineo } from '../../services/bebesService';
 import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
-
-dayjs.locale('es');
 
 export default function EditarBebe() {
   const navigate = useNavigate();
@@ -178,8 +173,7 @@ export default function EditarBebe() {
   };
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
+    <Box component="form" onSubmit={handleSubmit} sx={{ flexGrow: 1 }}>
         <Typography variant="h4" sx={{ mb: 2 }}>
           Editar/borrar bebé
         </Typography>
@@ -563,7 +557,7 @@ export default function EditarBebe() {
           Bebé actualizado correctamente
         </Alert>
       </Snackbar>
-    </LocalizationProvider>
+    </Box>
   );
 }
 

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -23,7 +23,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { BarChart } from '@mui/x-charts/BarChart';
 import dayjs from 'dayjs';
-import 'dayjs/locale/es';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 
@@ -161,7 +160,7 @@ export default function Gastos() {
   const handleExportCsv = () => {
     const headers = ['Fecha', 'Categoría', 'Descripción', 'Cantidad'];
     const rows = filteredGastos.map((gasto) => [
-      dayjs(gasto.fecha).locale('es').format('DD/MM/YYYY'),
+      dayjs(gasto.fecha).format('DD/MM/YYYY'),
       gasto.categoriaNombre ||
         categorias.find((c) => Number(c.id) === Number(gasto.categoriaId))?.nombre ||
         '',
@@ -187,7 +186,7 @@ export default function Gastos() {
     const doc = new jsPDF();
     const tableColumn = ['Fecha', 'Categoría', 'Descripción', 'Cantidad'];
     const tableRows = filteredGastos.map((gasto) => [
-      dayjs(gasto.fecha).locale('es').format('DD/MM/YYYY'),
+      dayjs(gasto.fecha).format('DD/MM/YYYY'),
       gasto.categoriaNombre ||
         categorias.find((c) => Number(c.id) === Number(gasto.categoriaId))?.nombre ||
         '',
@@ -271,7 +270,7 @@ export default function Gastos() {
               .map((gasto) => (
                 <TableRow key={gasto.id}>
                   <TableCell>
-                    {dayjs(gasto.fecha).locale('es').format('DD/MM/YYYY')}
+                    {dayjs(gasto.fecha).format('DD/MM/YYYY')}
                   </TableCell>
                   <TableCell>
                     {gasto.categoriaNombre ||


### PR DESCRIPTION
## Summary
- Apply global Dayjs locale and wrap app with MUI LocalizationProvider for Spanish defaults
- Drop redundant LocalizationProvider instances across forms and pages
- Simplify date picker components to rely on global config

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68baf6aa9924832782be9ef9d8a409d4