### PR TITLE
fix(frontend): keep snackbar within add-baby form container

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -505,21 +505,20 @@ export default function AnadirBebe() {
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>
         </Stack>
-      </Box>
-      <Snackbar
-        open={openSnackbar}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-      >
-        <Alert
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={6000}
           onClose={handleCloseSnackbar}
-          severity="success"
-          sx={{ width: '100%' }}
         >
-          Bebé guardado correctamente
-        </Alert>
-      </Snackbar>
-    </Box>
+          <Alert
+            onClose={handleCloseSnackbar}
+            severity="success"
+            sx={{ width: '100%' }}
+          >
+            Bebé guardado correctamente
+          </Alert>
+        </Snackbar>
+      </Box>
   );
 }
 


### PR DESCRIPTION
## Summary
- move Snackbar into main form Box for proper component layout
- remove stray closing Box tag

## Testing
- `cd frontend-baby && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf8ec4eac8327b0645d70dd34e464