### PR TITLE
Fix EditarBebe snackbar placement

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -543,20 +543,19 @@ export default function EditarBebe() {
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>
         </Stack>
-      </Box>
-      <Snackbar
-        open={openSnackbar}
-        autoHideDuration={6000}
-        onClose={handleCloseSnackbar}
-      >
-        <Alert
+        <Snackbar
+          open={openSnackbar}
+          autoHideDuration={6000}
           onClose={handleCloseSnackbar}
-          severity="success"
-          sx={{ width: '100%' }}
         >
-          Bebé actualizado correctamente
-        </Alert>
-      </Snackbar>
+          <Alert
+            onClose={handleCloseSnackbar}
+            severity="success"
+            sx={{ width: '100%' }}
+          >
+            Bebé actualizado correctamente
+          </Alert>
+        </Snackbar>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- move success Snackbar inside root Box
- remove stray closing Box tag

## Testing
- `cd frontend-baby && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf9029b4883278c80d8b39ca11db9