### PR TITLE
feat: add alimentación section

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -11,6 +11,7 @@ import MainGrid from "./dashboard/components/MainGrid";
 import Cuidados from "./dashboard/pages/Cuidados";
 import Gastos from "./dashboard/pages/Gastos";
 import Diario from "./dashboard/pages/Diario";
+import Alimentacion from "./dashboard/pages/Alimentacion";
 import Citas from "./dashboard/pages/Citas";
 import Rutinas from "./dashboard/pages/Rutinas";
 import Configuracion from "./dashboard/pages/Configuracion";
@@ -44,6 +45,7 @@ function App() {
               <Route path="cuidados" element={<Cuidados />} />
               <Route path="gastos" element={<Gastos />} />
               <Route path="diario" element={<Diario />} />
+              <Route path="alimentacion" element={<Alimentacion />} />
               <Route path="citas" element={<Citas />} />
               <Route path="rutinas" element={<Rutinas />} />
               <Route path="anadir-bebe" element={<AnadirBebe />} />

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -10,6 +10,7 @@ import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import FavoriteRoundedIcon from '@mui/icons-material/FavoriteRounded';
 import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded';
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
+import RamenDiningRoundedIcon from '@mui/icons-material/RamenDiningRounded';
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import ScheduleRoundedIcon from '@mui/icons-material/ScheduleRounded';
 import AddCircleRoundedIcon from '@mui/icons-material/AddCircleRounded';
@@ -21,6 +22,7 @@ const mainListItems = [
   { text: 'Cuidados', icon: <FavoriteRoundedIcon />, to: '/dashboard/cuidados' },
   { text: 'Gastos', icon: <MonetizationOnRoundedIcon />, to: '/dashboard/gastos' },
   { text: 'Diario', icon: <MenuBookRoundedIcon />, to: '/dashboard/diario' },
+  { text: 'Alimentación', icon: <RamenDiningRoundedIcon />, to: '/dashboard/alimentacion' },
   { text: 'Citas', icon: <EventRoundedIcon />, to: '/dashboard/citas' },
   { text: 'Rutinas', icon: <ScheduleRoundedIcon />, to: '/dashboard/rutinas' },
 ];

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+export default function Alimentacion() {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Typography variant="h4" gutterBottom>
+        Alimentación
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add Alimentación link in dashboard menu
- register Alimentación page route and component

## Testing
- `npm install`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb74ff48e083278d78f4a22fb5e5f1