### PR TITLE
feat: alimentación dashboard with forms and charts

### DIFF
--- a/frontend-baby/src/config.js
+++ b/frontend-baby/src/config.js
@@ -12,6 +12,8 @@ const API_DIARIO_URL =
   process.env.REACT_APP_API_DIARIO_URL || 'http://localhost:8085';
 const API_RUTINAS_URL =
   process.env.REACT_APP_API_RUTINAS_URL || 'http://localhost:8086';
+const API_ALIMENTACION_URL =
+  process.env.REACT_APP_API_ALIMENTACION_URL || 'http://localhost:8087';
 const API_BEBE_URL =
   process.env.REACT_APP_API_BEBE_URL || 'http://localhost:8089';
 
@@ -23,6 +25,7 @@ export {
   API_CITAS_URL,
   API_DIARIO_URL,
   API_RUTINAS_URL,
+  API_ALIMENTACION_URL,
   API_BEBE_URL,
 };
 

--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -1,0 +1,229 @@
+import React, { useEffect, useState } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import { DateTimePicker } from '@mui/x-date-pickers';
+import dayjs from 'dayjs';
+
+const tipos = [
+  { value: 'lactancia', label: 'Lactancia' },
+  { value: 'biberon', label: 'Biberón' },
+  { value: 'solidos', label: 'Sólidos' },
+];
+
+export default function AlimentacionForm({ open, onClose, onSubmit, initialData }) {
+  const [formData, setFormData] = useState({
+    tipo: 'lactancia',
+    inicio: null,
+    lado: '',
+    duracion: '',
+    biberonTipo: '',
+    cantidad: '',
+    alimento: '',
+    observaciones: '',
+  });
+
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        tipo: initialData.tipo || 'lactancia',
+        inicio: initialData.inicio ? dayjs(initialData.inicio) : null,
+        lado: initialData.lado || '',
+        duracion: initialData.duracion || '',
+        biberonTipo: initialData.biberonTipo || '',
+        cantidad: initialData.cantidad || '',
+        alimento: initialData.alimento || '',
+        observaciones: initialData.observaciones || '',
+      });
+    } else {
+      setFormData({
+        tipo: initialData?.tipo || 'lactancia',
+        inicio: null,
+        lado: '',
+        duracion: '',
+        biberonTipo: '',
+        cantidad: '',
+        alimento: '',
+        observaciones: '',
+      });
+    }
+    setErrors({});
+  }, [initialData, open]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleInicioChange = (newValue) => {
+    setFormData((prev) => ({ ...prev, inicio: newValue }));
+  };
+
+  const validate = () => {
+    const newErrors = {};
+    if (!formData.inicio) newErrors.inicio = 'Requerido';
+    if (formData.tipo === 'lactancia') {
+      if (!formData.lado) newErrors.lado = 'Requerido';
+      if (!formData.duracion) newErrors.duracion = 'Requerido';
+    }
+    if (formData.tipo === 'biberon') {
+      if (!formData.biberonTipo) newErrors.biberonTipo = 'Requerido';
+      if (!formData.cantidad) newErrors.cantidad = 'Requerido';
+    }
+    if (formData.tipo === 'solidos') {
+      if (!formData.alimento) newErrors.alimento = 'Requerido';
+      if (!formData.cantidad) newErrors.cantidad = 'Requerido';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+    const payload = {
+      ...formData,
+      inicio: formData.inicio ? formData.inicio.format('YYYY-MM-DDTHH:mm') : null,
+    };
+    onSubmit(payload);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {initialData && initialData.id ? 'Editar registro' : 'Añadir registro'}
+      </DialogTitle>
+      <DialogContent>
+        <Stack sx={{ mt: 1 }}>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Tipo</FormLabel>
+            <TextField select name="tipo" value={formData.tipo} onChange={handleChange}>
+              {tipos.map((t) => (
+                <MenuItem key={t.value} value={t.value}>
+                  {t.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          </FormControl>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Hora</FormLabel>
+            <DateTimePicker
+              value={formData.inicio}
+              onChange={handleInicioChange}
+              slotProps={{ textField: { fullWidth: true, error: !!errors.inicio, helperText: errors.inicio } }}
+            />
+          </FormControl>
+          {formData.tipo === 'lactancia' && (
+            <>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Lado</FormLabel>
+                <TextField
+                  select
+                  name="lado"
+                  value={formData.lado}
+                  onChange={handleChange}
+                  error={!!errors.lado}
+                  helperText={errors.lado}
+                >
+                  <MenuItem value="izquierdo">Izquierdo</MenuItem>
+                  <MenuItem value="derecho">Derecho</MenuItem>
+                </TextField>
+              </FormControl>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Duración (minutos)</FormLabel>
+                <TextField
+                  type="number"
+                  name="duracion"
+                  value={formData.duracion}
+                  onChange={handleChange}
+                  error={!!errors.duracion}
+                  helperText={errors.duracion}
+                  inputProps={{ min: 0 }}
+                />
+              </FormControl>
+            </>
+          )}
+          {formData.tipo === 'biberon' && (
+            <>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Tipo</FormLabel>
+                <TextField
+                  select
+                  name="biberonTipo"
+                  value={formData.biberonTipo}
+                  onChange={handleChange}
+                  error={!!errors.biberonTipo}
+                  helperText={errors.biberonTipo}
+                >
+                  <MenuItem value="leche_materna">Leche materna extraída</MenuItem>
+                  <MenuItem value="formula">Fórmula</MenuItem>
+                </TextField>
+              </FormControl>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Cantidad (ml)</FormLabel>
+                <TextField
+                  type="number"
+                  name="cantidad"
+                  value={formData.cantidad}
+                  onChange={handleChange}
+                  error={!!errors.cantidad}
+                  helperText={errors.cantidad}
+                  inputProps={{ min: 0 }}
+                />
+              </FormControl>
+            </>
+          )}
+          {formData.tipo === 'solidos' && (
+            <>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Tipo de alimento</FormLabel>
+                <TextField
+                  name="alimento"
+                  value={formData.alimento}
+                  onChange={handleChange}
+                  error={!!errors.alimento}
+                  helperText={errors.alimento}
+                />
+              </FormControl>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
+                <TextField
+                  name="cantidad"
+                  value={formData.cantidad}
+                  onChange={handleChange}
+                  error={!!errors.cantidad}
+                  helperText={errors.cantidad}
+                />
+              </FormControl>
+            </>
+          )}
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Observaciones</FormLabel>
+            <TextField
+              multiline
+              rows={3}
+              name="observaciones"
+              value={formData.observaciones}
+              onChange={handleChange}
+            />
+          </FormControl>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancelar</Button>
+        <Button onClick={handleSubmit} variant="contained">
+          Guardar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -1,13 +1,338 @@
-import React from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import IconButton from '@mui/material/IconButton';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
+import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import dayjs from 'dayjs';
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { BarChart } from '@mui/x-charts/BarChart';
+
+import {
+  listarPorBebe,
+  crearAlimentacion,
+  actualizarAlimentacion,
+  eliminarAlimentacion,
+} from '../../services/alimentacionService';
+import AlimentacionForm from '../components/AlimentacionForm';
+import { BabyContext } from '../../context/BabyContext';
+import { AuthContext } from '../../context/AuthContext';
 
 export default function Alimentacion() {
+  const tabLabels = ['Lactancia', 'Biberón', 'Sólidos'];
+  const tabValues = ['lactancia', 'biberon', 'solidos'];
+  const [tab, setTab] = useState(0);
+  const [registros, setRegistros] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [openForm, setOpenForm] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const { activeBaby } = React.useContext(BabyContext);
+  const { user } = React.useContext(AuthContext);
+  const bebeId = activeBaby?.id;
+  const usuarioId = user?.id;
+  const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
+
+  const filtered = useMemo(
+    () => registros.filter((r) => r.tipo === tabValues[tab]),
+    [registros, tab]
+  );
+
+  const lactanciaCount = useMemo(
+    () => registros.filter((r) => r.tipo === 'lactancia').length,
+    [registros]
+  );
+  const biberonCount = useMemo(
+    () => registros.filter((r) => r.tipo === 'biberon').length,
+    [registros]
+  );
+
+  useEffect(() => {
+    const stats = Array(7).fill(0);
+    filtered.forEach((r) => {
+      const dayIndex = dayjs(r.inicio).day();
+      stats[(dayIndex + 6) % 7] += 1;
+    });
+    setWeeklyStats(stats);
+  }, [filtered]);
+
+  const handleTabChange = (event, newValue) => {
+    setTab(newValue);
+    setPage(0);
+  };
+
+  const fetchRegistros = () => {
+    if (!bebeId || !usuarioId) return;
+    listarPorBebe(usuarioId, bebeId)
+      .then((res) => setRegistros(res.data))
+      .catch((err) => console.error('Error fetching alimentacion:', err));
+  };
+
+  useEffect(() => {
+    if (bebeId) {
+      fetchRegistros();
+    }
+  }, [bebeId]);
+
+  const handleAdd = () => {
+    setSelected({ tipo: tabValues[tab] });
+    setOpenForm(true);
+  };
+
+  const handleEdit = (reg) => {
+    setSelected(reg);
+    setOpenForm(true);
+  };
+
+  const handleDelete = (id) => {
+    if (!bebeId || !usuarioId) return;
+    if (window.confirm('¿Eliminar registro?')) {
+      eliminarAlimentacion(usuarioId, id)
+        .then(() => fetchRegistros())
+        .catch((err) => console.error('Error deleting registro:', err));
+    }
+  };
+
+  const handleFormSubmit = (data) => {
+    if (!bebeId || !usuarioId) return;
+    const payload = { ...data, bebeId };
+    const request = selected && selected.id
+      ? actualizarAlimentacion(usuarioId, selected.id, payload)
+      : crearAlimentacion(usuarioId, payload);
+    request
+      .then(() => {
+        setOpenForm(false);
+        setSelected(null);
+        fetchRegistros();
+      })
+      .catch((err) => console.error('Error saving registro:', err));
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  const headersMap = {
+    lactancia: ['Hora', 'Lado', 'Duración', 'Observaciones'],
+    biberon: ['Hora', 'Tipo', 'Cantidad (ml)', 'Observaciones'],
+    solidos: ['Hora', 'Alimento', 'Cantidad', 'Observaciones'],
+  };
+
+  const handleExportCsv = () => {
+    const current = tabValues[tab];
+    const headers = headersMap[current];
+    const rows = filtered.map((r) => {
+      const base = [dayjs(r.inicio).format('DD/MM/YYYY HH:mm')];
+      if (current === 'lactancia') {
+        return [...base, r.lado, r.duracion, r.observaciones || ''];
+      }
+      if (current === 'biberon') {
+        return [...base, r.biberonTipo, r.cantidad, r.observaciones || ''];
+      }
+      return [...base, r.alimento, r.cantidad, r.observaciones || ''];
+    });
+    const csvContent = [headers, ...rows].map((e) => e.join(',')).join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', `alimentacion_${current}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const handleExportPdf = () => {
+    const current = tabValues[tab];
+    const headers = headersMap[current];
+    const rows = filtered.map((r) => {
+      const base = [dayjs(r.inicio).format('DD/MM/YYYY HH:mm')];
+      if (current === 'lactancia') {
+        return [...base, r.lado, r.duracion, r.observaciones || ''];
+      }
+      if (current === 'biberon') {
+        return [...base, r.biberonTipo, r.cantidad, r.observaciones || ''];
+      }
+      return [...base, r.alimento, r.cantidad, r.observaciones || ''];
+    });
+    const doc = new jsPDF();
+    autoTable(doc, {
+      head: [headers],
+      body: rows,
+    });
+    doc.save(`alimentacion_${current}.pdf`);
+  };
+
   return (
     <Box sx={{ width: '100%' }}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="flex-start"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={2}
+        mb={2}
+      >
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          sx={{ alignSelf: 'flex-start' }}
+          onClick={handleAdd}
+        >
+          Añadir registro
+        </Button>
+      </Stack>
+
       <Typography variant="h4" gutterBottom>
         Alimentación
       </Typography>
+      <Tabs value={tab} onChange={handleTabChange} sx={{ mb: 2 }}>
+        {tabLabels.map((label) => (
+          <Tab key={label} label={label} />
+        ))}
+      </Tabs>
+
+      <TableContainer component={Paper} sx={{ mb: 4 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {headersMap[tabValues[tab]].map((h) => (
+                <TableCell key={h}>{h}</TableCell>
+              ))}
+              <TableCell align="center">Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((r) => (
+                <TableRow key={r.id}>
+                  <TableCell>
+                    {dayjs(r.inicio).format('DD/MM/YYYY HH:mm')}
+                  </TableCell>
+                  {tabValues[tab] === 'lactancia' && (
+                    <>
+                      <TableCell>{r.lado}</TableCell>
+                      <TableCell>{r.duracion}</TableCell>
+                      <TableCell>{r.observaciones}</TableCell>
+                    </>
+                  )}
+                  {tabValues[tab] === 'biberon' && (
+                    <>
+                      <TableCell>{r.biberonTipo}</TableCell>
+                      <TableCell>{r.cantidad}</TableCell>
+                      <TableCell>{r.observaciones}</TableCell>
+                    </>
+                  )}
+                  {tabValues[tab] === 'solidos' && (
+                    <>
+                      <TableCell>{r.alimento}</TableCell>
+                      <TableCell>{r.cantidad}</TableCell>
+                      <TableCell>{r.observaciones}</TableCell>
+                    </>
+                  )}
+                  <TableCell align="center">
+                    <IconButton
+                      size="small"
+                      aria-label="edit"
+                      onClick={() => handleEdit(r)}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label="delete"
+                      onClick={() => handleDelete(r.id)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={filtered.length}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </TableContainer>
+
+      {filtered.length > 0 && (
+        <Box sx={{ mb: 4, display: 'flex', gap: 2 }}>
+          <Button variant="outlined" onClick={handleExportPdf}>
+            Exportar PDF
+          </Button>
+          <Button variant="outlined" onClick={handleExportCsv}>
+            Exportar CSV
+          </Button>
+        </Box>
+      )}
+
+      <Stack spacing={2}>
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Totales por día de la semana
+            </Typography>
+            <BarChart
+              height={250}
+              xAxis={[{
+                scaleType: 'band',
+                data: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
+              }]}
+              series={[{ data: weeklyStats }]}
+              margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+              grid={{ horizontal: true }}
+            />
+          </CardContent>
+        </Card>
+        <Card variant="outlined">
+          <CardContent>
+            <Typography variant="h6" gutterBottom>
+              Comparativa lactancia vs biberón
+            </Typography>
+            <BarChart
+              height={250}
+              xAxis={[{ scaleType: 'band', data: ['Lactancia', 'Biberón'] }]}
+              series={[{ data: [lactanciaCount, biberonCount] }]}
+              margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+              grid={{ horizontal: true }}
+            />
+          </CardContent>
+        </Card>
+      </Stack>
+
+      <AlimentacionForm
+        open={openForm}
+        onClose={() => setOpenForm(false)}
+        onSubmit={handleFormSubmit}
+        initialData={selected}
+      />
     </Box>
   );
 }
+

--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { API_ALIMENTACION_URL } from '../config';
+
+const API_ALIMENTACION_ENDPOINT = `${API_ALIMENTACION_URL}/api/v1/alimentaciones`;
+
+export const listarPorBebe = (usuarioId, bebeId, page, size) => {
+  const params = {};
+  if (page !== undefined) params.page = page;
+  if (size !== undefined) params.size = size;
+  return axios.get(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
+    { params }
+  );
+};
+
+export const crearAlimentacion = (usuarioId, data) => {
+  return axios.post(`${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}`, data);
+};
+
+export const actualizarAlimentacion = (usuarioId, id, data) => {
+  return axios.put(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/${id}`,
+    data
+  );
+};
+
+export const eliminarAlimentacion = (usuarioId, id) => {
+  return axios.delete(`${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/${id}`);
+};
+


### PR DESCRIPTION
## Summary
- add alimentation dashboard page with tabbed tables, exports and charts
- create alimentation form component with validation
- add alimentation service and API config

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bb7639dcc8832785266f0e28adf5e5