### PR TITLE
Include bebeId in alimentacion record operations

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -103,7 +103,7 @@ export default function Alimentacion() {
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
     if (window.confirm('¿Eliminar registro?')) {
-      eliminarRegistro(usuarioId, id)
+      eliminarRegistro(usuarioId, bebeId, id)
         .then(() => {
           fetchRegistros();
           fetchEstadisticas();
@@ -116,8 +116,8 @@ export default function Alimentacion() {
     if (!bebeId || !usuarioId) return;
     const payload = { ...data, bebeId };
     const request = selected && selected.id
-      ? actualizarRegistro(usuarioId, selected.id, payload)
-      : crearRegistro(usuarioId, payload);
+      ? actualizarRegistro(usuarioId, bebeId, selected.id, payload)
+      : crearRegistro(usuarioId, bebeId, payload);
     request
       .then(() => {
         setOpenForm(false);

--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { API_ALIMENTACION_URL } from '../config';
 
-const API_ALIMENTACION_ENDPOINT = `${API_ALIMENTACION_URL}/api/v1/alimentaciones`;
+const API_ALIMENTACION_ENDPOINT = `${API_ALIMENTACION_URL}/api/v1/alimentacion`;
 
 export const listarPorBebe = (usuarioId, bebeId) => {
   return axios.get(
@@ -24,19 +24,19 @@ export const obtenerEstadisticas = (usuarioId, bebeId) => {
   );
 };
 
-export const crearRegistro = (usuarioId, data) => {
-  return axios.post(`${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}`, data);
-};
-
-export const actualizarRegistro = (usuarioId, id, data) => {
-  return axios.put(
-    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/${id}`,
+export const crearRegistro = (usuarioId, bebeId, data) =>
+  axios.post(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
     data
   );
-};
 
-export const eliminarRegistro = (usuarioId, id) => {
-  return axios.delete(
-    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/${id}`
+export const actualizarRegistro = (usuarioId, bebeId, id, data) =>
+  axios.put(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/${id}`,
+    data
   );
-};
+
+export const eliminarRegistro = (usuarioId, bebeId, id) =>
+  axios.delete(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/${id}`
+  );


### PR DESCRIPTION
## Summary
- Switch alimentacion endpoint to singular path
- Include bebeId in create/update/delete service calls
- Pass bebeId from Alimentacion page when creating, updating, or deleting records

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb84279e9483279d1547082c04e16d