### PR TITLE
feat: soporta tipo alimentacion en minusculas

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -12,6 +12,7 @@ import lombok.Data;
 @Schema(name = "AlimentacionRequest", description = "Datos para crear/actualizar un registro de alimentacion")
 public class AlimentacionRequest {
     @NotNull
+    @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
     private TipoAlimentacion tipo;
     @NotNull
     private Date fechaHora;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
@@ -13,6 +13,7 @@ public class AlimentacionResponse {
     private Long id;
     private Long usuarioId;
     private Long bebeId;
+    @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
     private TipoAlimentacion tipo;
     private Date fechaHora;
     private String lado;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoAlimentacion.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoAlimentacion.java
@@ -1,7 +1,27 @@
 package com.babytrackmaster.api_alimentacion.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum TipoAlimentacion {
     LACTANCIA,
     BIBERON,
-    SOLIDOS
+    SOLIDOS;
+
+    /**
+     * Permite la deserialización case-insensitive del enum.
+     *
+     * @param value cadena con el tipo de alimentación
+     * @return enum correspondiente
+     */
+    @JsonCreator
+    public static TipoAlimentacion from(String value) {
+        return TipoAlimentacion.valueOf(value.toUpperCase());
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
 }

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
@@ -54,9 +54,11 @@ class AlimentacionControllerTest {
         resp.setId(1L);
         when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
 
+        String json = mapper.writeValueAsString(req).replace("BIBERON", "biberon");
+
         mockMvc.perform(post("/api/v1/alimentacion/usuario/1/bebe/2")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(mapper.writeValueAsString(req)))
+                .content(json))
                 .andExpect(status().isCreated());
     }
 }

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
@@ -32,7 +32,7 @@ class AlimentacionServiceImplTest {
     @Test
     void crearGuardaYDevuelve() {
         AlimentacionRequest req = new AlimentacionRequest();
-        req.setTipo(TipoAlimentacion.BIBERON);
+        req.setTipo(TipoAlimentacion.from("biberon"));
         req.setFechaHora(new Date());
         req.setCantidadMl(120);
 


### PR DESCRIPTION
## Summary
- deserializar TipoAlimentacion ignorando mayúsculas y serializar en minúsculas
- documentar valores permitidos en DTOs de alimentación
- cubrir con tests JSON con tipo en minúsculas

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd31a3984832788859b9a4fae634b