### PR TITLE
Allow feeding entries without timestamp

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -14,7 +14,6 @@ public class AlimentacionRequest {
     @NotNull
     @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
     private TipoAlimentacion tipo;
-    @NotNull
     private Date fechaHora;
 
     // Lactancia

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
@@ -13,7 +13,8 @@ public class AlimentacionMapper {
         a.setUsuarioId(usuarioId);
         a.setBebeId(bebeId);
         a.setTipo(req.getTipo());
-        a.setFechaHora(req.getFechaHora());
+        Date now = new Date();
+        a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : now);
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLeche(req.getTipoLeche());
@@ -21,7 +22,6 @@ public class AlimentacionMapper {
         a.setAlimento(req.getAlimento());
         a.setCantidad(req.getCantidad());
         a.setObservaciones(req.getObservaciones());
-        Date now = new Date();
         a.setCreatedAt(now);
         a.setUpdatedAt(now);
         a.setEliminado(false);
@@ -30,7 +30,7 @@ public class AlimentacionMapper {
 
     public static void copyToEntity(AlimentacionRequest req, Alimentacion a) {
         a.setTipo(req.getTipo());
-        a.setFechaHora(req.getFechaHora());
+        a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : a.getFechaHora());
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLeche(req.getTipoLeche());

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
@@ -61,4 +61,22 @@ class AlimentacionControllerTest {
                 .content(json))
                 .andExpect(status().isCreated());
     }
+
+    @Test
+    void crearSinFechaHoraDevuelveCreated() throws Exception {
+        AlimentacionRequest req = new AlimentacionRequest();
+        req.setTipo(TipoAlimentacion.BIBERON);
+        req.setCantidadMl(100);
+        AlimentacionResponse resp = new AlimentacionResponse();
+        resp.setId(1L);
+        resp.setFechaHora(new Date());
+        when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
+
+        String json = mapper.writeValueAsString(req).replace("BIBERON", "biberon");
+
+        mockMvc.perform(post("/api/v1/alimentacion/usuario/1/bebe/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isCreated());
+    }
 }

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.babytrackmaster.api_alimentacion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,6 +44,22 @@ class AlimentacionServiceImplTest {
 
         AlimentacionResponse resp = service.crear(1L, 2L, req);
         assertEquals(5L, resp.getId());
+        verify(repo).save(any(Alimentacion.class));
+    }
+
+    @Test
+    void crearConFechaHoraNullAsignaFechaActual() {
+        AlimentacionRequest req = new AlimentacionRequest();
+        req.setTipo(TipoAlimentacion.BIBERON);
+        req.setCantidadMl(80);
+
+        Alimentacion saved = AlimentacionMapper.toEntity(req, 1L, 2L);
+        saved.setId(6L);
+
+        when(repo.save(any(Alimentacion.class))).thenReturn(saved);
+
+        AlimentacionResponse resp = service.crear(1L, 2L, req);
+        assertNotNull(resp.getFechaHora());
         verify(repo).save(any(Alimentacion.class));
     }
 }


### PR DESCRIPTION
## Summary
- make `fechaHora` optional in `AlimentacionRequest`
- default `fechaHora` to current time when missing
- add tests for creating alimentacion without `fechaHora`

## Testing
- `./mvnw -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd4bfe7348327a6c3242e3b68abfc