### PR TITLE
Rename feeding fields

### DIFF
--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -24,8 +24,8 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
     inicio: null,
     lado: '',
     duracionMin: '',
-    biberonTipo: '',
-    cantidad: '',
+    tipoLeche: '',
+    cantidadMl: '',
     alimento: '',
     observaciones: '',
   });
@@ -39,8 +39,8 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
         inicio: initialData.inicio ? dayjs(initialData.inicio) : null,
         lado: initialData.lado || '',
         duracionMin: initialData.duracionMin || '',
-        biberonTipo: initialData.biberonTipo || '',
-        cantidad: initialData.cantidad || '',
+        tipoLeche: initialData.tipoLeche || '',
+        cantidadMl: initialData.cantidadMl || '',
         alimento: initialData.alimento || '',
         observaciones: initialData.observaciones || '',
       });
@@ -50,8 +50,8 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
         inicio: null,
         lado: '',
         duracionMin: '',
-        biberonTipo: '',
-        cantidad: '',
+        tipoLeche: '',
+        cantidadMl: '',
         alimento: '',
         observaciones: '',
       });
@@ -76,12 +76,12 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
       if (!formData.duracionMin) newErrors.duracionMin = 'Requerido';
     }
     if (formData.tipo === 'biberon') {
-      if (!formData.biberonTipo) newErrors.biberonTipo = 'Requerido';
-      if (!formData.cantidad) newErrors.cantidad = 'Requerido';
+      if (!formData.tipoLeche) newErrors.tipoLeche = 'Requerido';
+      if (!formData.cantidadMl) newErrors.cantidadMl = 'Requerido';
     }
     if (formData.tipo === 'solidos') {
       if (!formData.alimento) newErrors.alimento = 'Requerido';
-      if (!formData.cantidad) newErrors.cantidad = 'Requerido';
+      if (!formData.cantidadMl) newErrors.cantidadMl = 'Requerido';
     }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -159,11 +159,11 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
                 <FormLabel sx={{ mb: 1 }}>Tipo</FormLabel>
                 <TextField
                   select
-                  name="biberonTipo"
-                  value={formData.biberonTipo}
+                  name="tipoLeche"
+                  value={formData.tipoLeche}
                   onChange={handleChange}
-                  error={!!errors.biberonTipo}
-                  helperText={errors.biberonTipo}
+                  error={!!errors.tipoLeche}
+                  helperText={errors.tipoLeche}
                 >
                   <MenuItem value="leche_materna">Leche materna extraída</MenuItem>
                   <MenuItem value="formula">Fórmula</MenuItem>
@@ -173,11 +173,11 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
                 <FormLabel sx={{ mb: 1 }}>Cantidad (ml)</FormLabel>
                 <TextField
                   type="number"
-                  name="cantidad"
-                  value={formData.cantidad}
+                  name="cantidadMl"
+                  value={formData.cantidadMl}
                   onChange={handleChange}
-                  error={!!errors.cantidad}
-                  helperText={errors.cantidad}
+                  error={!!errors.cantidadMl}
+                  helperText={errors.cantidadMl}
                   inputProps={{ min: 0 }}
                 />
               </FormControl>
@@ -198,11 +198,11 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
               <FormControl fullWidth sx={{ mb: 2 }}>
                 <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
                 <TextField
-                  name="cantidad"
-                  value={formData.cantidad}
+                  name="cantidadMl"
+                  value={formData.cantidadMl}
                   onChange={handleChange}
-                  error={!!errors.cantidad}
-                  helperText={errors.cantidad}
+                  error={!!errors.cantidadMl}
+                  helperText={errors.cantidadMl}
                 />
               </FormControl>
             </>

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -152,9 +152,9 @@ export default function Alimentacion() {
         return [...base, r.lado, r.duracionMin, r.observaciones || ''];
       }
       if (current === 'biberon') {
-        return [...base, r.biberonTipo, r.cantidad, r.observaciones || ''];
+        return [...base, r.tipoLeche, r.cantidadMl, r.observaciones || ''];
       }
-      return [...base, r.alimento, r.cantidad, r.observaciones || ''];
+      return [...base, r.alimento, r.cantidadMl, r.observaciones || ''];
     });
     const csvContent = [headers, ...rows].map((e) => e.join(',')).join('\n');
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
@@ -176,9 +176,9 @@ export default function Alimentacion() {
         return [...base, r.lado, r.duracionMin, r.observaciones || ''];
       }
       if (current === 'biberon') {
-        return [...base, r.biberonTipo, r.cantidad, r.observaciones || ''];
+        return [...base, r.tipoLeche, r.cantidadMl, r.observaciones || ''];
       }
-      return [...base, r.alimento, r.cantidad, r.observaciones || ''];
+      return [...base, r.alimento, r.cantidadMl, r.observaciones || ''];
     });
     const doc = new jsPDF();
     autoTable(doc, {
@@ -243,15 +243,15 @@ export default function Alimentacion() {
                   )}
                   {tabValues[tab] === 'biberon' && (
                     <>
-                      <TableCell>{r.biberonTipo}</TableCell>
-                      <TableCell>{r.cantidad}</TableCell>
+                      <TableCell>{r.tipoLeche}</TableCell>
+                      <TableCell>{r.cantidadMl}</TableCell>
                       <TableCell>{r.observaciones}</TableCell>
                     </>
                   )}
                   {tabValues[tab] === 'solidos' && (
                     <>
                       <TableCell>{r.alimento}</TableCell>
-                      <TableCell>{r.cantidad}</TableCell>
+                      <TableCell>{r.cantidadMl}</TableCell>
                       <TableCell>{r.observaciones}</TableCell>
                     </>
                   )}


### PR DESCRIPTION
## Summary
- rename biberonTipo to tipoLeche and cantidad to cantidadMl in AlimentacionForm
- adjust validation and form submission for new fields
- display tipoLeche and cantidadMl in Alimentacion tables and exports

## Testing
- `cd frontend-baby && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcdcedab4483279b96bbfcc0fc0ec1