### PR TITLE
fix: use fechaHora for feeding record dates

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -147,7 +147,7 @@ export default function Alimentacion() {
     const current = tabValues[tab];
     const headers = headersMap[current];
     const rows = filtered.map((r) => {
-      const base = [dayjs(r.inicio).format('DD/MM/YYYY HH:mm')];
+      const base = [dayjs(r.fechaHora).format('DD/MM/YYYY HH:mm')];
       if (current === 'lactancia') {
         return [...base, r.lado, r.duracionMin, r.observaciones || ''];
       }
@@ -171,7 +171,7 @@ export default function Alimentacion() {
     const current = tabValues[tab];
     const headers = headersMap[current];
     const rows = filtered.map((r) => {
-      const base = [dayjs(r.inicio).format('DD/MM/YYYY HH:mm')];
+      const base = [dayjs(r.fechaHora).format('DD/MM/YYYY HH:mm')];
       if (current === 'lactancia') {
         return [...base, r.lado, r.duracionMin, r.observaciones || ''];
       }
@@ -232,7 +232,7 @@ export default function Alimentacion() {
               .map((r) => (
                 <TableRow key={r.id}>
                   <TableCell>
-                    {dayjs(r.inicio).format('DD/MM/YYYY HH:mm')}
+                    {dayjs(r.fechaHora).format('DD/MM/YYYY HH:mm')}
                   </TableCell>
                   {tabValues[tab] === 'lactancia' && (
                     <>


### PR DESCRIPTION
## Summary
- replace references to `inicio` with `fechaHora` in feeding page
- ensure CSV/PDF exports and table display use `fechaHora`

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcddb484948327aa03d143541b0e2a