### PR TITLE
fix: read fechaHora when editing feeding entry

### DIFF
--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -36,7 +36,7 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
     if (initialData) {
       setFormData({
         tipo: initialData.tipo || 'lactancia',
-        inicio: initialData.inicio ? dayjs(initialData.inicio) : null,
+        inicio: initialData.fechaHora ? dayjs(initialData.fechaHora) : null,
         lado: initialData.lado || '',
         duracionMin: initialData.duracionMin || '',
         tipoLeche: initialData.tipoLeche || '',


### PR DESCRIPTION
## Summary
- fix AlimentacionForm to load date/time from `fechaHora`

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bcdf9eb3a48327b12e39d3f0399982