### PR TITLE
feat: add dashboard greeting card

### DIFF
--- a/frontend-baby/src/dashboard/components/HighlightedCard.js
+++ b/frontend-baby/src/dashboard/components/HighlightedCard.js
@@ -1,41 +1,74 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
-import InsightsRoundedIcon from '@mui/icons-material/InsightsRounded';
+import WavingHandRoundedIcon from '@mui/icons-material/WavingHandRounded';
+import Box from '@mui/material/Box';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
 
 export default function HighlightedCard() {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
+  const navigate = useNavigate();
+  const { user } = useContext(AuthContext);
+  const { activeBaby } = useContext(BabyContext);
+
+  const getGreeting = () => {
+    const hour = new Date().getHours();
+    if (hour < 12) return 'Buenos días';
+    if (hour < 18) return 'Buenas tardes';
+    return 'Buenas noches';
+  };
+
+  const greeting = `${getGreeting()}, ${user?.nombreCompleto || 'bienvenido'}`;
+
+  const today = new Date();
+  const formattedDate = today.toLocaleDateString('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+  });
+
+  const summary = activeBaby
+    ? `Hoy es ${formattedDate}. Recuerda las actividades de ${activeBaby.nombre}.`
+    : `Hoy es ${formattedDate}.`;
 
   return (
-    <Card sx={{ height: '100%' }}>
-      <CardContent>
-        <InsightsRoundedIcon />
-        <Typography
-          component="h2"
-          variant="subtitle2"
-          gutterBottom
-          sx={{ fontWeight: '600' }}
+    <Card sx={{ height: '100%', background: 'none', boxShadow: 'none' }}>
+      <CardContent sx={{ p: 0 }}>
+        <Box
+          sx={{
+            background: 'linear-gradient(135deg, #6a11cb 0%, #2575fc 100%)',
+            borderRadius: 4,
+            color: 'common.white',
+            p: 2,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+          }}
         >
-          Explora tus datos
-        </Typography>
-        <Typography sx={{ color: 'text.secondary', mb: '8px' }}>
-          Descubre el rendimiento y la información de visitantes con nuestra magia de datos.
-        </Typography>
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          endIcon={<ChevronRightRoundedIcon />}
-          fullWidth={isSmallScreen}
-        >
-          Obtener información
-        </Button>
+          <WavingHandRoundedIcon />
+          <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 600 }}>
+            {greeting}
+          </Typography>
+          <Typography sx={{ mb: 1 }}>{summary}</Typography>
+          <Button
+            variant="contained"
+            size="small"
+            color="secondary"
+            endIcon={<ChevronRightRoundedIcon />}
+            onClick={() => navigate('/dashboard/diario')}
+            fullWidth={isSmallScreen}
+          >
+            Ver día
+          </Button>
+        </Box>
       </CardContent>
     </Card>
   );

--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -7,6 +7,7 @@ import DailyRoutinesCard from './DailyRoutinesCard';
 import UpcomingAppointmentsCard from './UpcomingAppointmentsCard';
 import RecentCareCard from './RecentCareCard';
 import QuickStatsCard from './QuickStatsCard';
+import HighlightedCard from './HighlightedCard';
 import { BabyContext } from '../../context/BabyContext';
 
 export default function MainGrid() {
@@ -19,6 +20,9 @@ export default function MainGrid() {
   return (
     <Box sx={{ width: '100%', maxWidth: { sm: '100%', md: '1700px' } }}>
       <Grid container spacing={2}>
+        <Grid size={{ xs: 12 }}>
+          <HighlightedCard />
+        </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <DailyRoutinesCard />
         </Grid>


### PR DESCRIPTION
## Summary
- show dynamic greeting and daily summary on HighlightedCard
- render HighlightedCard at top of main dashboard grid

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bcee0b5274832794b533bf3eb1d08d