### PR TITLE
feat: add quick actions card

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -8,6 +8,7 @@ import UpcomingAppointmentsCard from './UpcomingAppointmentsCard';
 import RecentCareCard from './RecentCareCard';
 import QuickStatsCard from './QuickStatsCard';
 import HighlightedCard from './HighlightedCard';
+import QuickActionsCard from './QuickActionsCard';
 import { BabyContext } from '../../context/BabyContext';
 
 export default function MainGrid() {
@@ -22,6 +23,9 @@ export default function MainGrid() {
       <Grid container spacing={2}>
         <Grid size={{ xs: 12 }}>
           <HighlightedCard />
+        </Grid>
+        <Grid size={{ xs: 12 }}>
+          <QuickActionsCard />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <DailyRoutinesCard />

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import Button from '@mui/material/Button';
+import LocalDrinkIcon from '@mui/icons-material/LocalDrink';
+import BabyChangingStationIcon from '@mui/icons-material/BabyChangingStation';
+import HotelIcon from '@mui/icons-material/Hotel';
+import BathtubIcon from '@mui/icons-material/Bathtub';
+import { useNavigate } from 'react-router-dom';
+
+export default function QuickActionsCard() {
+  const navigate = useNavigate();
+
+  const handleNavigate = (path, state) => () => {
+    navigate(path, { state });
+  };
+
+  return (
+    <Card variant="outlined" sx={{ height: '100%' }}>
+      <CardContent>
+        <Grid container spacing={2}>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<LocalDrinkIcon />}
+              onClick={handleNavigate('/dashboard/alimentacion', { tipo: 'biberon' })}
+            >
+              Biberón
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<BabyChangingStationIcon />}
+              onClick={handleNavigate('/dashboard/cuidados', { tipo: 'Pañal' })}
+            >
+              Pañal
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<HotelIcon />}
+              onClick={handleNavigate('/dashboard/cuidados', { tipo: 'Sueño' })}
+            >
+              Sueño
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              fullWidth
+              startIcon={<BathtubIcon />}
+              onClick={handleNavigate('/dashboard/cuidados', { tipo: 'Baño' })}
+            >
+              Baño
+            </Button>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -49,6 +50,7 @@ export default function Alimentacion() {
   const bebeId = activeBaby?.id;
   const usuarioId = user?.id;
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
+  const location = useLocation();
 
   const filtered = useMemo(
     () => registros.filter((r) => r.tipo === tabValues[tab]),
@@ -89,6 +91,17 @@ export default function Alimentacion() {
       fetchEstadisticas();
     }
   }, [bebeId]);
+
+  useEffect(() => {
+    if (location.state?.tipo) {
+      const index = tabValues.indexOf(location.state.tipo);
+      if (index !== -1) {
+        setTab(index);
+        setSelected({ tipo: location.state.tipo });
+        setOpenForm(true);
+      }
+    }
+  }, [location.state]);
 
   const handleAdd = () => {
     setSelected({ tipo: tabValues[tab] });

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -47,6 +48,7 @@ export default function Cuidados() {
   const usuarioId = user?.id;
   const bebeId = activeBaby?.id;
   const [weeklyStats, setWeeklyStats] = useState(Array(7).fill(0));
+  const location = useLocation();
 
   const filteredCuidados = useMemo(
     () =>
@@ -93,6 +95,18 @@ export default function Cuidados() {
         .catch((error) => console.error('Error fetching tipos cuidado:', error));
     }
   }, [bebeId]);
+
+  useEffect(() => {
+    if (location.state?.tipo && tipos.length > 0) {
+      const tipo = tipos.find(
+        (t) => t.nombre.toLowerCase() === location.state.tipo.toLowerCase()
+      );
+      if (tipo) {
+        setSelectedCuidado({ tipoId: tipo.id });
+        setOpenForm(true);
+      }
+    }
+  }, [location.state, tipos]);
 
   const handleAdd = () => {
     setSelectedCuidado(null);


### PR DESCRIPTION
## Summary
- add quick actions card with navigation buttons for bottle, diaper, sleep and bath
- open specific forms when quick action navigation is used
- show quick actions card on main dashboard

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bcef28c264832790de792833910eb9