### PR TITLE
refactor: redesign highlighted dashboard card

### DIFF
--- a/frontend-baby/src/dashboard/components/HighlightedCard.js
+++ b/frontend-baby/src/dashboard/components/HighlightedCard.js
@@ -1,22 +1,14 @@
 import React, { useContext } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import ChevronRightRoundedIcon from '@mui/icons-material/ChevronRightRounded';
 import WavingHandRoundedIcon from '@mui/icons-material/WavingHandRounded';
 import Box from '@mui/material/Box';
-import useMediaQuery from '@mui/material/useMediaQuery';
-import { useTheme } from '@mui/material/styles';
-import { useNavigate } from 'react-router-dom';
-import { AuthContext } from '../../context/AuthContext';
+import IconButton from '@mui/material/IconButton';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { BabyContext } from '../../context/BabyContext';
 
 export default function HighlightedCard() {
-  const theme = useTheme();
-  const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
-  const navigate = useNavigate();
-  const { user } = useContext(AuthContext);
   const { activeBaby } = useContext(BabyContext);
 
   const getGreeting = () => {
@@ -26,7 +18,7 @@ export default function HighlightedCard() {
     return 'Buenas noches';
   };
 
-  const greeting = `${getGreeting()}, ${user?.nombreCompleto || 'bienvenido'}`;
+  const greeting = `¡${getGreeting()}!`;
 
   const today = new Date();
   const formattedDate = today.toLocaleDateString('es-ES', {
@@ -40,34 +32,29 @@ export default function HighlightedCard() {
     : `Hoy es ${formattedDate}.`;
 
   return (
-    <Card sx={{ height: '100%', background: 'none', boxShadow: 'none' }}>
+    <Card sx={{ width: '100%', background: 'none', boxShadow: 'none' }}>
       <CardContent sx={{ p: 0 }}>
         <Box
-          sx={{
-            background: 'linear-gradient(135deg, #6a11cb 0%, #2575fc 100%)',
-            borderRadius: 4,
-            color: 'common.white',
+          sx={(theme) => ({
+            backgroundColor: theme.palette.background.paper,
+            borderRadius: 2,
             p: 2,
             display: 'flex',
-            flexDirection: 'column',
-            gap: 1,
-          }}
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            width: '100%',
+          })}
         >
-          <WavingHandRoundedIcon />
-          <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 600 }}>
-            {greeting}
-          </Typography>
-          <Typography sx={{ mb: 1 }}>{summary}</Typography>
-          <Button
-            variant="contained"
-            size="small"
-            color="secondary"
-            endIcon={<ChevronRightRoundedIcon />}
-            onClick={() => navigate('/dashboard/diario')}
-            fullWidth={isSmallScreen}
-          >
-            Ver día
-          </Button>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            <WavingHandRoundedIcon />
+            <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 600 }}>
+              {greeting}
+            </Typography>
+            <Typography>{summary}</Typography>
+          </Box>
+          <IconButton>
+            <FavoriteBorderIcon />
+          </IconButton>
         </Box>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- simplify HighlightedCard with light background and icon button
- drop navigation button and unused hooks

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd50757588832788fbfc87a682a2b1