### PR TITLE
Make highlighted dashboard card full width

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -20,13 +20,13 @@ export default function MainGrid() {
     <Box
       sx={{
         width: '100%',
-        maxWidth: { sm: '100%', md: '1700px' },
+        maxWidth: '100%',
         mx: 'auto',
         p: 2,
       }}
     >
       <Grid container spacing={2}>
-        <Grid size={{ xs: 12, md: 6 }}>
+        <Grid size={{ xs: 12 }}>
           <HighlightedCard />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>


### PR DESCRIPTION
## Summary
- allow highlighted dashboard card to span the full grid width
- remove 1700px width cap for dashboard container

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bd513de0848327a59b90cf27c144ac