### PR TITLE
Ensure dashboard cards span full width

### DIFF
--- a/frontend-baby/src/dashboard/Dashboard.js
+++ b/frontend-baby/src/dashboard/Dashboard.js
@@ -47,7 +47,8 @@ export default function Dashboard(props) {
             <Stack
               spacing={2}
               sx={{
-                alignItems: 'center',
+                alignItems: 'stretch',
+                width: '100%',
                 mx: 3,
                 pb: 5,
                 mt: { xs: 8, md: 0 },


### PR DESCRIPTION
## Summary
- Stretch main dashboard Stack to full width to stop centering cards

## Testing
- `npm test -- --watchAll=false`
- `npm run build` *(fails: Module not found: Error: Can't resolve '@mui/material/Grid2')*

------
https://chatgpt.com/codex/tasks/task_e_68bdb8b47c908327a36dfe8334bec2b3