### PR TITLE
Expand dashboard cards to full width

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -33,13 +33,13 @@ export default function MainGrid() {
         <Grid size={{ xs: 12 }}>
           <StatsOverview />
         </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
+        <Grid size={{ xs: 12 }}>
           <QuickActionsCard />
         </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
+        <Grid size={{ xs: 12 }}>
           <RecentCareCard />
         </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
+        <Grid size={{ xs: 12 }}>
           <UpcomingAppointmentsCard />
         </Grid>
       </Grid>

--- a/frontend-baby/src/dashboard/components/StatsOverview.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.js
@@ -76,7 +76,7 @@ export default function StatsOverview() {
 
   return (
     <Grid container spacing={2}>
-      <Grid item xs={12} sm={6} md={3}>
+      <Grid item xs={12}>
         <Card sx={{ backgroundColor: cardBg, color: theme.palette.text.primary }}>
           <CardContent>
             <Stack direction="row" spacing={2} alignItems="center">
@@ -89,7 +89,7 @@ export default function StatsOverview() {
           </CardContent>
         </Card>
       </Grid>
-      <Grid item xs={12} sm={6} md={3}>
+      <Grid item xs={12}>
         <Card sx={{ backgroundColor: cardBg, color: theme.palette.text.primary }}>
           <CardContent>
             <Stack direction="row" spacing={2} alignItems="center">
@@ -102,7 +102,7 @@ export default function StatsOverview() {
           </CardContent>
         </Card>
       </Grid>
-      <Grid item xs={12} sm={6} md={3}>
+      <Grid item xs={12}>
         <Card sx={{ backgroundColor: cardBg, color: theme.palette.text.primary }}>
           <CardContent>
             <Stack direction="row" spacing={2} alignItems="center">
@@ -120,7 +120,7 @@ export default function StatsOverview() {
           </CardContent>
         </Card>
       </Grid>
-      <Grid item xs={12} sm={6} md={3}>
+      <Grid item xs={12}>
         <Card sx={{ backgroundColor: cardBg, color: theme.palette.text.primary }}>
           <CardContent>
             <Stack direction="row" spacing={2} alignItems="center">


### PR DESCRIPTION
## Summary
- Make all StatsOverview cards full width on small screens
- Use Grid v2 API and set dashboard cards to full width

## Testing
- `CI=true npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdbab6e22083279146e5bcad34cd61