### PR TITLE
fix: prevent horizontal overflow in dashboard

### DIFF
--- a/frontend-baby/src/dashboard/Dashboard.js
+++ b/frontend-baby/src/dashboard/Dashboard.js
@@ -49,7 +49,7 @@ export default function Dashboard(props) {
               sx={{
                 alignItems: 'stretch',
                 width: '100%',
-                mx: 3,
+                px: 3,
                 pb: 5,
                 mt: { xs: 8, md: 0 },
               }}


### PR DESCRIPTION
## Summary
- use horizontal padding instead of margin in dashboard stack to avoid overflow

## Testing
- `cd frontend-baby && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bdbef93dcc8327938e69186fc4b1df