### PR TITLE
feat: organize dashboard layout

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -37,10 +37,14 @@ export default function MainGrid() {
           <QuickActionsCard />
         </Grid>
         <Grid size={{ xs: 12 }}>
-          <RecentCareCard />
-        </Grid>
-        <Grid size={{ xs: 12 }}>
-          <UpcomingAppointmentsCard />
+          <Grid container spacing={2}>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <RecentCareCard />
+            </Grid>
+            <Grid size={{ xs: 12, md: 6 }}>
+              <UpcomingAppointmentsCard />
+            </Grid>
+          </Grid>
         </Grid>
       </Grid>
       <Copyright sx={{ my: 4 }} />


### PR DESCRIPTION
## Summary
- wrap recent care and upcoming appointments cards in a grid row to show side-by-side on larger screens

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bdca4df6448327aae16db3451114a8