### PR TITLE
feat: redesign upcoming appointments card

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -2,11 +2,12 @@ import React, { useEffect, useState } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 import { BabyContext } from '../../context/BabyContext';
 import { listarProximas } from '../../services/citasService';
@@ -14,6 +15,7 @@ import { listarProximas } from '../../services/citasService';
 export default function UpcomingAppointmentsCard() {
   const [appointments, setAppointments] = useState([]);
   const { activeBaby } = React.useContext(BabyContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!activeBaby?.id) return;
@@ -27,6 +29,17 @@ export default function UpcomingAppointmentsCard() {
       });
   }, [activeBaby]);
 
+  const getTipoColor = (tipo) => {
+    switch (tipo?.toLowerCase()) {
+      case 'consulta':
+        return 'primary';
+      case 'vacuna':
+        return 'secondary';
+      default:
+        return 'default';
+    }
+  };
+
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>
@@ -34,39 +47,39 @@ export default function UpcomingAppointmentsCard() {
           Próximas Citas
         </Typography>
         {appointments.length > 0 ? (
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Fecha</TableCell>
-                <TableCell>Hora</TableCell>
-                <TableCell>Motivo</TableCell>
-                <TableCell>Tipo</TableCell>
-                <TableCell>Estado</TableCell>
-                <TableCell>Centro médico</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {appointments.map((c) => (
-                <TableRow key={c.id}>
-                  <TableCell>
-                    {dayjs(c.fecha).format('DD/MM/YYYY')}
-                  </TableCell>
-                  <TableCell>
-                    {dayjs(`${c.fecha}T${c.hora}`).format('HH:mm')}
-                  </TableCell>
-                  <TableCell>{c.motivo}</TableCell>
-                  <TableCell>{c.tipoNombre}</TableCell>
-                  <TableCell>{c.estadoNombre}</TableCell>
-                  <TableCell>{c.centroMedico}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <List>
+            {appointments.map((c) => (
+              <ListItem
+                key={c.id}
+                disableGutters
+                secondaryAction={
+                  <Chip
+                    label={c.tipoNombre}
+                    color={getTipoColor(c.tipoNombre)}
+                    size="small"
+                  />
+                }
+              >
+                <ListItemText
+                  primary={dayjs(`${c.fecha}T${c.hora}`).format('DD/MM/YYYY HH:mm')}
+                  secondary={`${c.motivo} · ${c.centroMedico} · ${c.estadoNombre}`}
+                  primaryTypographyProps={{ variant: 'body2' }}
+                  secondaryTypographyProps={{
+                    variant: 'caption',
+                    color: 'text.secondary',
+                  }}
+                />
+              </ListItem>
+            ))}
+          </List>
         ) : (
           <Typography variant="body2" color="text.secondary">
             No hay citas próximas.
           </Typography>
         )}
+        <Button size="small" sx={{ mt: 2 }} onClick={() => navigate('/dashboard/citas')}>
+          Ver todas las citas
+        </Button>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- replace table layout with MUI List and ListItem for upcoming appointments
- show appointment type with colored chips
- display date and time together and add link to full appointments page

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcc532d908327b5ea92faf54a89f1