### PR TITLE
feat(frontend): use relative time in quick actions

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import dayjs from 'dayjs';
 import 'dayjs/locale/es';
+import relativeTime from 'dayjs/plugin/relativeTime';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import SignInSide from "./sign-in-side/SignInSide";
@@ -22,6 +23,7 @@ import InicioSinBebe from "./dashboard/pages/InicioSinBebe";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
+dayjs.extend(relativeTime);
 dayjs.locale('es');
 
 function App() {

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -156,7 +156,7 @@ export default function QuickActionsCard() {
           {actions.map((action) => {
             const Icon = action.icon;
             const info = actionsData[action.key];
-            const last = info.last ? info.last.format('HH:mm') : '-';
+            const last = info.last ? info.last.fromNow() : '-';
             const today = `${info.today}${action.unit}`;
 
             return (


### PR DESCRIPTION
## Summary
- enable dayjs relativeTime plugin with Spanish locale
- show last action timestamp relative to now

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68be8cf24118832780271029d6ec9eba