### PR TITLE
Replace icons with emoji typography

### DIFF
--- a/frontend-baby/public/index.html
+++ b/frontend-baby/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link href="https://fonts.cdnfonts.com/css/comic-sans-ms" rel="stylesheet" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/frontend-baby/src/dashboard/components/HighlightedCard.js
+++ b/frontend-baby/src/dashboard/components/HighlightedCard.js
@@ -2,10 +2,8 @@ import React, { useContext } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import WavingHandRoundedIcon from '@mui/icons-material/WavingHandRounded';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import { BabyContext } from '../../context/BabyContext';
 
 export default function HighlightedCard() {
@@ -46,14 +44,20 @@ export default function HighlightedCard() {
           })}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <WavingHandRoundedIcon />
-            <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 600 }}>
+            <Typography component="span" sx={{ fontSize: '2rem' }}>👋</Typography>
+            <Typography
+              component="h2"
+              variant="subtitle2"
+              sx={{ fontWeight: 600, fontFamily: '"Comic Sans MS", cursive' }}
+            >
               {greeting}
             </Typography>
-            <Typography>{summary}</Typography>
+            <Typography sx={{ fontFamily: '"Comic Sans MS", cursive' }}>
+              {summary}
+            </Typography>
           </Box>
           <IconButton>
-            <FavoriteBorderIcon />
+            <Typography component="span" sx={{ fontSize: '1.5rem' }}>❤️</Typography>
           </IconButton>
         </Box>
       </CardContent>


### PR DESCRIPTION
## Summary
- swap greeting wave and heart icons for emoji typography
- apply playful Comic Sans font to greeting and summary text
- load Comic Sans web font in index.html

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bebb3e8f608327ac936a5ccfd3cdfb