### PR TITLE
feat: improve HighlightedCard theme colors

### DIFF
--- a/frontend-baby/src/dashboard/components/HighlightedCard.js
+++ b/frontend-baby/src/dashboard/components/HighlightedCard.js
@@ -34,7 +34,10 @@ export default function HighlightedCard() {
       <CardContent sx={{ p: 0 }}>
         <Box
           sx={(theme) => ({
-            backgroundColor: theme.palette.background.paper,
+            bgcolor: theme.vars
+              ? `rgba(${theme.vars.palette.background.paperChannel} / 1)`
+              : theme.palette.background.paper,
+            color: theme.palette.text.primary,
             borderRadius: 2,
             p: 2,
             display: 'flex',


### PR DESCRIPTION
## Summary
- ensure HighlightedCard uses theme-aware background and text colors

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bebe0f6cac832786075d2b18884d71