### PR TITLE
refactor: derive stats card background from theme

### DIFF
--- a/frontend-baby/src/dashboard/components/StatsOverview.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.js
@@ -17,10 +17,9 @@ import { listarRecientes as listarAlimentacionRecientes } from '../../services/a
 
 export default function StatsOverview() {
   const theme = useTheme();
-  const cardBg =
-    theme.palette.mode === 'light'
-      ? theme.palette.grey[50]
-      : theme.palette.grey[900];
+  const cardBg = theme.vars
+    ? `rgba(${theme.vars.palette.background.paperChannel} / 1)`
+    : theme.palette.background.paper;
 
   const { user } = useContext(AuthContext);
   const { activeBaby } = useContext(BabyContext);


### PR DESCRIPTION
## Summary
- use theme paper background for StatsOverview cards and keep primary text color

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68bebefaf3fc8327b32dc7137b5f5899