### PR TITLE
feat: add consistent colors to dashboard menu

### DIFF
--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -46,8 +46,13 @@ export default function MenuContent() {
             >
               {({ isActive }) => (
                 <ListItemButton selected={isActive}>
-                  <ListItemIcon>{item.icon}</ListItemIcon>
-                  <ListItemText primary={item.text} />
+                  <ListItemIcon sx={{ color: 'primary.main' }}>
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={item.text}
+                    primaryTypographyProps={{ sx: { color: 'primary.main' } }}
+                  />
                 </ListItemButton>
               )}
             </NavLink>
@@ -64,8 +69,13 @@ export default function MenuContent() {
             >
               {({ isActive }) => (
                 <ListItemButton selected={isActive}>
-                  <ListItemIcon>{item.icon}</ListItemIcon>
-                  <ListItemText primary={item.text} />
+                  <ListItemIcon sx={{ color: 'success.main' }}>
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={item.text}
+                    primaryTypographyProps={{ sx: { color: 'success.main' } }}
+                  />
                 </ListItemButton>
               )}
             </NavLink>


### PR DESCRIPTION
## Summary
- color main menu icons and text with primary theme
- color secondary menu icons and text with success theme

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bec9af085483278350f6f4fc137178