### PR TITLE
feat: update button colors

### DIFF
--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -220,8 +220,18 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button onClick={handleSubmit} variant="contained">
+        <Button
+          variant="contained"
+          onClick={onClose}
+          sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+        >
+          Cancelar
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+        >
           Guardar
         </Button>
       </DialogActions>

--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -151,8 +151,18 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button variant="contained" onClick={handleSubmit}>
+          <Button
+            variant="contained"
+            onClick={onClose}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSubmit}
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
             Guardar
           </Button>
         </DialogActions>

--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -144,8 +144,18 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSubmit} variant="contained">
+          <Button
+            variant="contained"
+            onClick={onClose}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
             Guardar
           </Button>
         </DialogActions>

--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -133,8 +133,20 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSubmit} variant="contained">Guardar</Button>
+          <Button
+            variant="contained"
+            onClick={onClose}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
+            Guardar
+          </Button>
         </DialogActions>
       </Dialog>
   );

--- a/frontend-baby/src/dashboard/components/RutinaForm.js
+++ b/frontend-baby/src/dashboard/components/RutinaForm.js
@@ -111,8 +111,19 @@ export default function RutinaForm({ open, onClose, onSubmit, initialData }) {
           </Stack>
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancelar</Button>
-          <Button onClick={handleSubmit} variant="contained" disabled={!isValid}>
+          <Button
+            variant="contained"
+            onClick={onClose}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant="contained"
+            disabled={!isValid}
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
             Guardar rutina
           </Button>
         </DialogActions>

--- a/frontend-baby/src/dashboard/pages/Acerca.js
+++ b/frontend-baby/src/dashboard/pages/Acerca.js
@@ -106,7 +106,7 @@ export default function Acerca() {
           </Typography>
           <Button
             variant="contained"
-            sx={{ mt: 1, alignSelf: 'flex-start' }}
+            sx={{ mt: 1, alignSelf: 'flex-start', bgcolor: '#0d6efd', '&:hover': { bgcolor: '#0b5ed7' } }}
             href="mailto:soporte@babytrackmaster.com"
           >
             Contáctanos

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -213,7 +213,7 @@ export default function Alimentacion() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start' }}
+          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
           onClick={handleAdd}
         >
           Añadir registro
@@ -280,6 +280,7 @@ export default function Alimentacion() {
                       size="small"
                       aria-label="delete"
                       onClick={() => handleDelete(r.id)}
+                      sx={{ color: '#dc3545' }}
                     >
                       <DeleteIcon fontSize="small" />
                     </IconButton>

--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -489,6 +489,10 @@ export default function AnadirBebe() {
                   variant="contained"
                   onClick={() => fileInputRef.current && fileInputRef.current.click()}
                   disabled={loading}
+                  sx={{
+                    bgcolor: '#0d6efd',
+                    '&:hover': { bgcolor: '#0b5ed7' },
+                  }}
                 >
                   Subir foto
                 </Button>
@@ -498,10 +502,20 @@ export default function AnadirBebe() {
         </Grid>
 
         <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ mt: 2 }}>
-          <Button onClick={() => navigate(-1)} disabled={loading}>
+          <Button
+            variant="contained"
+            onClick={() => navigate(-1)}
+            disabled={loading}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
             Cancelar
           </Button>
-          <Button type="submit" variant="contained" disabled={loading}>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={loading}
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>
         </Stack>

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -268,7 +268,7 @@ export default function Citas() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start' }}
+          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
           onClick={handleAdd}
         >
           Añadir cita
@@ -525,7 +525,13 @@ export default function Citas() {
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleRecordatorioClose}>Cancelar</Button>
+          <Button
+            variant="contained"
+            onClick={handleRecordatorioClose}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
+            Cancelar
+          </Button>
           <Button onClick={handleRecordatorioConfirm} variant="contained">
             Enviar
           </Button>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -206,7 +206,7 @@ export default function Cuidados() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start' }}
+          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
           onClick={handleAdd}
         >
           Añadir nuevo cuidado
@@ -256,6 +256,7 @@ export default function Cuidados() {
                     size="small"
                     aria-label="delete"
                     onClick={() => handleDelete(cuidado.id)}
+                    sx={{ color: '#dc3545' }}
                   >
                     <DeleteIcon fontSize="small" />
                   </IconButton>

--- a/frontend-baby/src/dashboard/pages/Diario.js
+++ b/frontend-baby/src/dashboard/pages/Diario.js
@@ -142,7 +142,11 @@ export default function Diario() {
                 />
               ))}
             </Stack>
-              <Button variant="contained" onClick={handleAdd}>
+              <Button
+                variant="contained"
+                onClick={handleAdd}
+                sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+              >
                 Guardar entrada
               </Button>
             </Stack>

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -524,6 +524,10 @@ export default function EditarBebe() {
                   variant="contained"
                   onClick={() => fileInputRef.current && fileInputRef.current.click()}
                   disabled={loading}
+                  sx={{
+                    bgcolor: '#0d6efd',
+                    '&:hover': { bgcolor: '#0b5ed7' },
+                  }}
                 >
                   Subir foto
                 </Button>
@@ -533,13 +537,28 @@ export default function EditarBebe() {
         </Grid>
 
         <Stack direction="row" spacing={2} justifyContent="flex-end" sx={{ mt: 2 }}>
-          <Button onClick={() => navigate(-1)} disabled={loading}>
+          <Button
+            variant="contained"
+            onClick={() => navigate(-1)}
+            disabled={loading}
+            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+          >
             Cancelar
           </Button>
-          <Button color="error" onClick={handleDelete} disabled={loading}>
+          <Button
+            variant="contained"
+            onClick={handleDelete}
+            disabled={loading}
+            sx={{ bgcolor: '#dc3545', '&:hover': { bgcolor: '#bb2d3b' } }}
+          >
             Eliminar bebé
           </Button>
-          <Button type="submit" variant="contained" disabled={loading}>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={loading}
+            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+          >
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>
         </Stack>

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -216,7 +216,7 @@ export default function Gastos() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start' }}
+          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
           onClick={handleAdd}
         >
           Añadir gasto
@@ -288,14 +288,15 @@ export default function Gastos() {
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>
-                    <IconButton
-                      size="small"
-                      aria-label="delete"
-                      onClick={() => handleDelete(gasto.id)}
-                    >
-                      <DeleteIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
+        <IconButton
+          size="small"
+          aria-label="delete"
+          onClick={() => handleDelete(gasto.id)}
+          sx={{ color: '#dc3545' }}
+        >
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+      </TableCell>
                 </TableRow>
               ))}
           </TableBody>

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -162,7 +162,7 @@ export default function Rutinas() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start' }}
+          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
           onClick={handleAdd}
         >
           Añadir rutina
@@ -247,6 +247,7 @@ export default function Rutinas() {
                         size="small"
                         aria-label="delete"
                         onClick={() => handleDelete(rutina.id)}
+                        sx={{ color: '#dc3545' }}
                       >
                         <DeleteIcon fontSize="small" />
                       </IconButton>


### PR DESCRIPTION
## Summary
- adjust button colors for consistent theme across dashboard pages
- style delete actions in red and add actions in teal
- ensure photo upload and contact buttons use blue accents

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bed0cb30608327b687851d058a9ade