### PR TITLE
Centralize button styles across frontend

### DIFF
--- a/frontend-baby/README.md
+++ b/frontend-baby/README.md
@@ -13,3 +13,13 @@ Pantallas de autenticación, dashboard, cuidados, gastos, hitos, diario, citas y
 - **jwt-decode**
 - Gestión de estado con Context / useReducer
 - Herramientas: Create React App (o Vite), ESLint/Prettier (opcional)
+
+## Estilos de botones
+Para mantener la coherencia en los colores de la interfaz, los componentes deben importar los estilos de `src/theme/buttonStyles.js` en lugar de definir el `sx` inline.
+
+```jsx
+import { saveButton, cancelButton } from '../theme/buttonStyles';
+
+<Button sx={saveButton}>Guardar</Button>
+<Button sx={cancelButton}>Cancelar</Button>
+```

--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -11,6 +11,7 @@ import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 const tipos = [
   { value: 'lactancia', label: 'Lactancia' },
@@ -220,18 +221,10 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
         </Stack>
       </DialogContent>
       <DialogActions>
-        <Button
-          variant="contained"
-          onClick={onClose}
-          sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
-        >
+        <Button variant="contained" onClick={onClose} sx={cancelButton}>
           Cancelar
         </Button>
-        <Button
-          onClick={handleSubmit}
-          variant="contained"
-          sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
-        >
+        <Button onClick={handleSubmit} variant="contained" sx={saveButton}>
           Guardar
         </Button>
       </DialogActions>

--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -12,6 +12,7 @@ import FormLabel from '@mui/material/FormLabel';
 import dayjs from 'dayjs';
 import { DatePicker, TimePicker } from '@mui/x-date-pickers';
 import { listarTipos, listarEstados } from '../../services/citasService';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function CitaForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -154,14 +155,14 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
           <Button
             variant="contained"
             onClick={onClose}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
           <Button
             variant="contained"
             onClick={handleSubmit}
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             Guardar
           </Button>

--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -12,6 +12,7 @@ import FormLabel from '@mui/material/FormLabel';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { listarTipos } from '../../services/cuidadosService';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -147,14 +148,14 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
           <Button
             variant="contained"
             onClick={onClose}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
           <Button
             onClick={handleSubmit}
             variant="contained"
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             Guardar
           </Button>

--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -13,6 +13,7 @@ import dayjs from 'dayjs';
 import { DatePicker } from '@mui/x-date-pickers';
 
 import { listarCategorias } from '../../services/gastosService';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function GastoForm({ open, onClose, onSubmit, initialData }) {
   const [formData, setFormData] = useState({
@@ -136,14 +137,14 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
           <Button
             variant="contained"
             onClick={onClose}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
           <Button
             onClick={handleSubmit}
             variant="contained"
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             Guardar
           </Button>

--- a/frontend-baby/src/dashboard/components/RutinaForm.js
+++ b/frontend-baby/src/dashboard/components/RutinaForm.js
@@ -11,6 +11,7 @@ import Stack from '@mui/material/Stack';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import { TimePicker } from '@mui/x-date-pickers';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 const diasOptions = [
   { value: 'L', label: 'Lunes' },
@@ -114,7 +115,7 @@ export default function RutinaForm({ open, onClose, onSubmit, initialData }) {
           <Button
             variant="contained"
             onClick={onClose}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
@@ -122,7 +123,7 @@ export default function RutinaForm({ open, onClose, onSubmit, initialData }) {
             onClick={handleSubmit}
             variant="contained"
             disabled={!isValid}
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             Guardar rutina
           </Button>

--- a/frontend-baby/src/dashboard/pages/Acerca.js
+++ b/frontend-baby/src/dashboard/pages/Acerca.js
@@ -4,6 +4,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Link from '@mui/material/Link';
+import { primaryButton } from '../../theme/buttonStyles';
 
 export default function Acerca() {
   return (
@@ -106,7 +107,7 @@ export default function Acerca() {
           </Typography>
           <Button
             variant="contained"
-            sx={{ mt: 1, alignSelf: 'flex-start', bgcolor: '#0d6efd', '&:hover': { bgcolor: '#0b5ed7' } }}
+            sx={{ mt: 1, alignSelf: 'flex-start', ...primaryButton }}
             href="mailto:soporte@babytrackmaster.com"
           >
             Contáctanos

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -32,6 +32,7 @@ import {
   actualizarRegistro,
   eliminarRegistro,
 } from '../../services/alimentacionService';
+import { addButton } from '../../theme/buttonStyles';
 import AlimentacionForm from '../components/AlimentacionForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
@@ -213,7 +214,7 @@ export default function Alimentacion() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
+          sx={{ alignSelf: 'flex-start', ...addButton }}
           onClick={handleAdd}
         >
           Añadir registro

--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -23,6 +23,7 @@ import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import { saveButton, cancelButton, primaryButton } from '../../theme/buttonStyles';
 
 export default function AnadirBebe() {
   const navigate = useNavigate();
@@ -489,10 +490,7 @@ export default function AnadirBebe() {
                   variant="contained"
                   onClick={() => fileInputRef.current && fileInputRef.current.click()}
                   disabled={loading}
-                  sx={{
-                    bgcolor: '#0d6efd',
-                    '&:hover': { bgcolor: '#0b5ed7' },
-                  }}
+                  sx={primaryButton}
                 >
                   Subir foto
                 </Button>
@@ -506,7 +504,7 @@ export default function AnadirBebe() {
             variant="contained"
             onClick={() => navigate(-1)}
             disabled={loading}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
@@ -514,7 +512,7 @@ export default function AnadirBebe() {
             type="submit"
             variant="contained"
             disabled={loading}
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -28,6 +28,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import dayjs from 'dayjs';
+import { addButton, cancelButton } from '../../theme/buttonStyles';
 import { DateCalendar, PickersDay } from '@mui/x-date-pickers';
 import {
   listar,
@@ -268,7 +269,7 @@ export default function Citas() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
+          sx={{ alignSelf: 'flex-start', ...addButton }}
           onClick={handleAdd}
         >
           Añadir cita
@@ -528,7 +529,7 @@ export default function Citas() {
           <Button
             variant="contained"
             onClick={handleRecordatorioClose}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -34,6 +34,7 @@ import {
 import CuidadoForm from '../components/CuidadoForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
+import { addButton } from '../../theme/buttonStyles';
 
 export default function Cuidados() {
   const [tab, setTab] = useState(0);
@@ -206,7 +207,7 @@ export default function Cuidados() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
+          sx={{ alignSelf: 'flex-start', ...addButton }}
           onClick={handleAdd}
         >
           Añadir nuevo cuidado

--- a/frontend-baby/src/dashboard/pages/Diario.js
+++ b/frontend-baby/src/dashboard/pages/Diario.js
@@ -18,6 +18,7 @@ import { DatePicker } from '@mui/x-date-pickers';
 import { listarEntradas, crearEntrada } from '../../services/diarioService';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
+import { saveButton } from '../../theme/buttonStyles';
 
 const emociones = [
   { value: 'happy', label: '😊 Feliz' },
@@ -145,7 +146,7 @@ export default function Diario() {
               <Button
                 variant="contained"
                 onClick={handleAdd}
-                sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+                sx={saveButton}
               >
                 Guardar entrada
               </Button>

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -23,6 +23,7 @@ import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import { saveButton, cancelButton, deleteButton, primaryButton } from '../../theme/buttonStyles';
 
 export default function EditarBebe() {
   const navigate = useNavigate();
@@ -524,10 +525,7 @@ export default function EditarBebe() {
                   variant="contained"
                   onClick={() => fileInputRef.current && fileInputRef.current.click()}
                   disabled={loading}
-                  sx={{
-                    bgcolor: '#0d6efd',
-                    '&:hover': { bgcolor: '#0b5ed7' },
-                  }}
+                  sx={primaryButton}
                 >
                   Subir foto
                 </Button>
@@ -541,7 +539,7 @@ export default function EditarBebe() {
             variant="contained"
             onClick={() => navigate(-1)}
             disabled={loading}
-            sx={{ bgcolor: '#6c757d', '&:hover': { bgcolor: '#5c636a' } }}
+            sx={cancelButton}
           >
             Cancelar
           </Button>
@@ -549,7 +547,7 @@ export default function EditarBebe() {
             variant="contained"
             onClick={handleDelete}
             disabled={loading}
-            sx={{ bgcolor: '#dc3545', '&:hover': { bgcolor: '#bb2d3b' } }}
+            sx={deleteButton}
           >
             Eliminar bebé
           </Button>
@@ -557,7 +555,7 @@ export default function EditarBebe() {
             type="submit"
             variant="contained"
             disabled={loading}
-            sx={{ bgcolor: '#198754', '&:hover': { bgcolor: '#157347' } }}
+            sx={saveButton}
           >
             {loading ? <CircularProgress size={24} /> : 'Guardar'}
           </Button>

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -33,6 +33,7 @@ import {
   eliminarGasto,
   listarCategorias,
 } from '../../services/gastosService';
+import { addButton } from '../../theme/buttonStyles';
 import GastoForm from '../components/GastoForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
@@ -216,7 +217,7 @@ export default function Gastos() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
+          sx={{ alignSelf: 'flex-start', ...addButton }}
           onClick={handleAdd}
         >
           Añadir gasto

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -28,6 +28,7 @@ import {
   eliminarRutina,
   duplicarRutina,
 } from '../../services/rutinasService';
+import { addButton } from '../../theme/buttonStyles';
 import RutinaForm from '../components/RutinaForm';
 import { BabyContext } from '../../context/BabyContext';
 import { AuthContext } from '../../context/AuthContext';
@@ -162,7 +163,7 @@ export default function Rutinas() {
         <Button
           variant="contained"
           startIcon={<AddIcon />}
-          sx={{ alignSelf: 'flex-start', bgcolor: '#20c997', '&:hover': { bgcolor: '#1aa179' } }}
+          sx={{ alignSelf: 'flex-start', ...addButton }}
           onClick={handleAdd}
         >
           Añadir rutina

--- a/frontend-baby/src/theme/buttonStyles.js
+++ b/frontend-baby/src/theme/buttonStyles.js
@@ -1,0 +1,24 @@
+export const saveButton = {
+  bgcolor: '#198754',
+  '&:hover': { bgcolor: '#157347' },
+};
+
+export const cancelButton = {
+  bgcolor: '#6c757d',
+  '&:hover': { bgcolor: '#5c636a' },
+};
+
+export const deleteButton = {
+  bgcolor: '#dc3545',
+  '&:hover': { bgcolor: '#bb2d3b' },
+};
+
+export const addButton = {
+  bgcolor: '#20c997',
+  '&:hover': { bgcolor: '#1aa179' },
+};
+
+export const primaryButton = {
+  bgcolor: '#0d6efd',
+  '&:hover': { bgcolor: '#0b5ed7' },
+};


### PR DESCRIPTION
## Summary
- centralize save, cancel, add, delete and primary button styles in `src/theme/buttonStyles.js`
- reuse shared `sx` objects across forms and pages to replace inline color definitions
- document shared button styling guidelines in README

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bee6bef2d08327bcf8b0857f8e5e5b