### PR TITLE
chore: style data grid

### DIFF
--- a/frontend-baby/src/dashboard/components/CustomizedDataGrid.js
+++ b/frontend-baby/src/dashboard/components/CustomizedDataGrid.js
@@ -1,48 +1,58 @@
 import * as React from 'react';
 import { DataGrid } from '@mui/x-data-grid';
+import { ThemeProvider, createTheme, useTheme } from '@mui/material/styles';
 import { columns, rows } from '../internals/data/gridData';
+import { dataGridCustomizations } from '../theme/customizations';
 
 export default function CustomizedDataGrid() {
+  const outerTheme = useTheme();
+  const theme = React.useMemo(
+    () => createTheme(outerTheme, { components: { ...dataGridCustomizations } }),
+    [outerTheme],
+  );
+
   return (
-    <DataGrid
-      checkboxSelection
-      rows={rows}
-      columns={columns}
-      getRowClassName={(params) =>
-        params.indexRelativeToCurrentPage % 2 === 0 ? 'even' : 'odd'
-      }
-      initialState={{
-        pagination: { paginationModel: { pageSize: 20 } },
-      }}
-      pageSizeOptions={[10, 20, 50]}
-      disableColumnResize
-      density="compact"
-      slotProps={{
-        filterPanel: {
-          filterFormProps: {
-            logicOperatorInputProps: {
-              variant: 'outlined',
-              size: 'small',
-            },
-            columnInputProps: {
-              variant: 'outlined',
-              size: 'small',
-              sx: { mt: 'auto' },
-            },
-            operatorInputProps: {
-              variant: 'outlined',
-              size: 'small',
-              sx: { mt: 'auto' },
-            },
-            valueInputProps: {
-              InputComponentProps: {
+    <ThemeProvider theme={theme}>
+      <DataGrid
+        checkboxSelection
+        rows={rows}
+        columns={columns}
+        getRowClassName={(params) =>
+          params.indexRelativeToCurrentPage % 2 === 0 ? 'even' : 'odd'
+        }
+        initialState={{
+          pagination: { paginationModel: { pageSize: 20 } },
+        }}
+        pageSizeOptions={[10, 20, 50]}
+        disableColumnResize
+        density="compact"
+        slotProps={{
+          filterPanel: {
+            filterFormProps: {
+              logicOperatorInputProps: {
                 variant: 'outlined',
                 size: 'small',
               },
+              columnInputProps: {
+                variant: 'outlined',
+                size: 'small',
+                sx: { mt: 'auto' },
+              },
+              operatorInputProps: {
+                variant: 'outlined',
+                size: 'small',
+                sx: { mt: 'auto' },
+              },
+              valueInputProps: {
+                InputComponentProps: {
+                  variant: 'outlined',
+                  size: 'small',
+                },
+              },
             },
           },
-        },
-      }}
-    />
+        }}
+      />
+    </ThemeProvider>
   );
 }

--- a/frontend-baby/src/dashboard/theme/customizations/dataGrid.js
+++ b/frontend-baby/src/dashboard/theme/customizations/dataGrid.js
@@ -17,13 +17,10 @@ export const dataGridCustomizations = {
       root: ({ theme }) => ({
         '--DataGrid-overlayHeight': '300px',
         overflow: 'clip',
-        borderColor: (theme.vars || theme).palette.divider,
-        backgroundColor: (theme.vars || theme).palette.background.default,
-        [`& .${gridClasses.columnHeader}`]: {
-          backgroundColor: (theme.vars || theme).palette.background.paper,
-        },
+        borderColor: '#e9ecef',
+        backgroundColor: '#f8f9fa',
         [`& .${gridClasses.footerContainer}`]: {
-          backgroundColor: (theme.vars || theme).palette.background.paper,
+          backgroundColor: '#f8f9fa',
         },
         [`& .${checkboxClasses.root}`]: {
           padding: theme.spacing(0.5),
@@ -64,18 +61,29 @@ export const dataGridCustomizations = {
       }),
       row: ({ theme }) => ({
         '&:last-of-type': {
-          borderBottom: `1px solid ${(theme.vars || theme).palette.divider}`,
+          borderBottom: '1px solid #e9ecef',
+        },
+        '&.even': {
+          backgroundColor: '#fdfdfd',
+        },
+        '&.odd': {
+          backgroundColor: '#f8f9fa',
         },
         '&:hover': {
-          backgroundColor: (theme.vars || theme).palette.action.hover,
+          backgroundColor: '#f1f9ff',
         },
+        color: '#212529',
         '&.Mui-selected': {
           background: (theme.vars || theme).palette.action.selected,
           '&:hover': {
-            backgroundColor: (theme.vars || theme).palette.action.hover,
+            backgroundColor: '#f1f9ff',
           },
         },
       }),
+      columnHeader: {
+        backgroundColor: '#e3f2fd',
+        borderBottom: '1px solid #dee2e6',
+      },
       iconButtonContainer: ({ theme }) => ({
         [`& .${iconButtonClasses.root}`]: {
           border: 'none',


### PR DESCRIPTION
## Summary
- style data grid root and rows for consistent palette
- add header styling and integrate theme in customized data grid component

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68beee1152908327b9a27dbc3d6ad895