### PR TITLE
feat: apply consistent table styling

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -5,7 +5,6 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import IconButton from '@mui/material/IconButton';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
@@ -230,7 +229,7 @@ export default function Alimentacion() {
         ))}
       </Tabs>
 
-      <TableContainer component={Paper} sx={{ mb: 4 }}>
+      <TableContainer sx={{ mb: 4 }}>
         <Table size="small">
           <TableHead>
             <TableRow>

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -2,7 +2,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -355,7 +354,7 @@ export default function Citas() {
           )}
         </>
       ) : (
-        <TableContainer component={Paper} sx={{ mb: 4 }}>
+        <TableContainer sx={{ mb: 4 }}>
           <Table size="small">
             <TableHead>
               <TableRow>
@@ -418,7 +417,7 @@ export default function Citas() {
         </TableContainer>
       )}
 
-      <TableContainer component={Paper} sx={{ mb: 4 }}>
+      <TableContainer sx={{ mb: 4 }}>
         <Table size="small">
           <TableHead>
             <TableRow>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -5,7 +5,6 @@ import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import IconButton from "@mui/material/IconButton";
-import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Tab from "@mui/material/Tab";
 import Table from "@mui/material/Table";
@@ -228,7 +227,7 @@ export default function Cuidados() {
         ))}
       </Tabs>
 
-      <TableContainer component={Paper} sx={{ mb: 4 }}>
+      <TableContainer sx={{ mb: 4 }}>
         <Table size="small">
           <TableHead>
             <TableRow>

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -7,7 +7,6 @@ import IconButton from "@mui/material/IconButton";
 import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
-import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -258,7 +257,7 @@ export default function Gastos() {
         Total del mes: {totalMes.toFixed(2)}
       </Typography>
 
-      <TableContainer component={Paper} sx={{ mb: 4 }}>
+      <TableContainer sx={{ mb: 4 }}>
         <Table size="small">
           <TableHead>
             <TableRow>

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -5,7 +5,6 @@ import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
-import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -211,7 +210,7 @@ export default function Rutinas() {
         Rutinas
       </Typography>
 
-      <TableContainer component={Paper} sx={{ mb: 4 }}>
+      <TableContainer sx={{ mb: 4 }}>
         <Table size="small">
           <TableHead>
             <TableRow>

--- a/frontend-baby/src/shared-theme/customizations/dataDisplay.js
+++ b/frontend-baby/src/shared-theme/customizations/dataDisplay.js
@@ -197,6 +197,47 @@ export const dataDisplayCustomizations = {
       }),
     },
   },
+  MuiTable: {
+    styleOverrides: {
+      root: {
+        backgroundColor: '#f8f9fa',
+      },
+    },
+  },
+  MuiTableHead: {
+    styleOverrides: {
+      root: {
+        backgroundColor: '#e3f2fd',
+        '& .MuiTableCell-root': {
+          color: '#212529',
+        },
+      },
+    },
+  },
+  MuiTableRow: {
+    styleOverrides: {
+      root: {
+        '&:not(.MuiTableRow-head)': {
+          '&:nth-of-type(odd)': {
+            backgroundColor: '#ffffff',
+          },
+          '&:nth-of-type(even)': {
+            backgroundColor: '#f8f9fa',
+          },
+          '&:hover': {
+            backgroundColor: '#f1f9ff',
+          },
+        },
+      },
+    },
+  },
+  MuiTableCell: {
+    styleOverrides: {
+      root: {
+        borderBottom: '1px solid #e9ecef',
+      },
+    },
+  },
   MuiTablePagination: {
     styleOverrides: {
       actions: {


### PR DESCRIPTION
## Summary
- add shared theme overrides for tables with unified backgrounds, headers, rows and borders
- remove Paper wrappers so page tables consume theme styles

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68beef2914308327bde42205b9c9b702