### PR TITLE
feat: style action icons consistently

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -273,6 +273,7 @@ export default function Alimentacion() {
                       size="small"
                       aria-label="edit"
                       onClick={() => handleEdit(r)}
+                      sx={{ color: '#0d6efd' }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -392,6 +392,7 @@ export default function Citas() {
                       size="small"
                       aria-label="reminder"
                       onClick={() => handleRecordatorio(cita.id)}
+                      sx={{ color: '#6c757d' }}
                     >
                       <NotificationsActiveIcon fontSize="small" />
                     </IconButton>
@@ -399,6 +400,7 @@ export default function Citas() {
                       size="small"
                       aria-label="edit"
                       onClick={() => handleEdit(cita)}
+                      sx={{ color: '#0d6efd' }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>
@@ -406,6 +408,7 @@ export default function Citas() {
                       size="small"
                       aria-label="estado"
                       onClick={(e) => handleOpenEstadoMenu(e, cita.id)}
+                      sx={{ color: '#6c757d' }}
                     >
                       <MoreVertIcon fontSize="small" />
                     </IconButton>
@@ -459,6 +462,7 @@ export default function Citas() {
                       size="small"
                       aria-label="reminder"
                       onClick={() => handleRecordatorio(cita.id)}
+                      sx={{ color: '#6c757d' }}
                     >
                       <NotificationsActiveIcon fontSize="small" />
                     </IconButton>
@@ -466,6 +470,7 @@ export default function Citas() {
                       size="small"
                       aria-label="edit"
                       onClick={() => handleEdit(cita)}
+                      sx={{ color: '#0d6efd' }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>
@@ -473,6 +478,7 @@ export default function Citas() {
                       size="small"
                       aria-label="estado"
                       onClick={(e) => handleOpenEstadoMenu(e, cita.id)}
+                      sx={{ color: '#6c757d' }}
                     >
                       <MoreVertIcon fontSize="small" />
                     </IconButton>

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -258,6 +258,7 @@ export default function Cuidados() {
                       size="small"
                       aria-label="edit"
                       onClick={() => handleEdit(cuidado)}
+                      sx={{ color: '#0d6efd' }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>
@@ -265,7 +266,7 @@ export default function Cuidados() {
                       size="small"
                       aria-label="delete"
                       onClick={() => handleDelete(cuidado.id)}
-                      sx={{ color: "#dc3545" }}
+                      sx={{ color: '#dc3545' }}
                     >
                       <DeleteIcon fontSize="small" />
                     </IconButton>

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -289,6 +289,7 @@ export default function Gastos() {
                       size="small"
                       aria-label="edit"
                       onClick={() => handleEdit(gasto)}
+                      sx={{ color: '#0d6efd' }}
                     >
                       <EditIcon fontSize="small" />
                     </IconButton>

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -240,6 +240,7 @@ export default function Rutinas() {
                         size="small"
                         aria-label="edit"
                         onClick={() => handleEdit(rutina)}
+                        sx={{ color: '#0d6efd' }}
                       >
                         <EditIcon fontSize="small" />
                       </IconButton>
@@ -255,6 +256,7 @@ export default function Rutinas() {
                         size="small"
                         aria-label="duplicate"
                         onClick={() => handleDuplicate(rutina.id)}
+                        sx={{ color: '#6c757d' }}
                       >
                         <ContentCopyIcon fontSize="small" />
                       </IconButton>


### PR DESCRIPTION
## Summary
- Colorize edit, delete, reminder, duplicate, and menu icons across dashboard pages for consistent cues

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bef03df3688327a3e94bc010b51d47