### PR TITLE
Enfatizar cantidades en tablas del dashboard

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -250,21 +250,21 @@ export default function Alimentacion() {
                   {tabValues[tab] === 'lactancia' && (
                     <>
                       <TableCell>{r.lado}</TableCell>
-                      <TableCell>{r.duracionMin}</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>{r.duracionMin}</TableCell>
                       <TableCell>{r.observaciones}</TableCell>
                     </>
                   )}
                   {tabValues[tab] === 'biberon' && (
                     <>
                       <TableCell>{r.tipoLeche}</TableCell>
-                      <TableCell>{r.cantidadMl}</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>{r.cantidadMl}</TableCell>
                       <TableCell>{r.observaciones}</TableCell>
                     </>
                   )}
                   {tabValues[tab] === 'solidos' && (
                     <>
                       <TableCell>{r.alimento}</TableCell>
-                      <TableCell>{r.cantidadMl}</TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>{r.cantidadMl}</TableCell>
                       <TableCell>{r.observaciones}</TableCell>
                     </>
                   )}

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -247,7 +247,7 @@ export default function Cuidados() {
                     {dayjs(cuidado.inicio).format("DD/MM/YYYY HH:mm")}
                   </TableCell>
                   <TableCell>{cuidado.tipoNombre}</TableCell>
-                  <TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
                     {esPecho
                       ? (cuidado.pecho ?? "-")
                       : (cuidado.cantidadMl ?? "-")}

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -283,7 +283,9 @@ export default function Gastos() {
                       )?.nombre}
                   </TableCell>
                   <TableCell>{gasto.descripcion}</TableCell>
-                  <TableCell>{Number(gasto.cantidad).toFixed(2)}</TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {Number(gasto.cantidad).toFixed(2)}
+                  </TableCell>
                   <TableCell align="center">
                     <IconButton
                       size="small"


### PR DESCRIPTION
## Summary
- Resaltar cantidad en página de gastos
- Resaltar cantidad en página de cuidados
- Resaltar duración/cantidad en página de alimentación

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bef0f4f9448327ba69afff74e8a832