### PR TITLE
feat: set spanish pagination defaults

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/dataDisplay.js
+++ b/frontend-baby/src/shared-theme/customizations/dataDisplay.js
@@ -239,6 +239,10 @@ export const dataDisplayCustomizations = {
     },
   },
   MuiTablePagination: {
+    defaultProps: {
+      labelRowsPerPage: 'Filas por página:',
+      labelDisplayedRows: ({ from, to, count }) => `${from}–${to} de ${count !== -1 ? count : `más de ${to}`}`,
+    },
     styleOverrides: {
       root: ({ theme }) => ({
         backgroundColor: '#ffffff',


### PR DESCRIPTION
## Summary
- default Spanish labels for table pagination through theme
- verified table pages use new defaults without overrides

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bef5b325388327b5f4a30740ef9140