### PR TITLE
feat: add crecimiento service and config

### DIFF
--- a/frontend-baby/src/config.js
+++ b/frontend-baby/src/config.js
@@ -14,6 +14,8 @@ const API_RUTINAS_URL =
   process.env.REACT_APP_API_RUTINAS_URL || 'http://localhost:8086';
 const API_ALIMENTACION_URL =
   process.env.REACT_APP_API_ALIMENTACION_URL || 'http://localhost:8091';
+const API_CRECIMIENTO_URL =
+  process.env.REACT_APP_API_CRECIMIENTO_URL || 'http://localhost:8092';
 const API_BEBE_URL =
   process.env.REACT_APP_API_BEBE_URL || 'http://localhost:8089';
 
@@ -26,6 +28,7 @@ export {
   API_DIARIO_URL,
   API_RUTINAS_URL,
   API_ALIMENTACION_URL,
+  API_CRECIMIENTO_URL,
   API_BEBE_URL,
 };
 

--- a/frontend-baby/src/services/crecimientoService.js
+++ b/frontend-baby/src/services/crecimientoService.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+import { API_CRECIMIENTO_URL } from '../config';
+
+const API_CRECIMIENTOS_ENDPOINT = `${API_CRECIMIENTO_URL}/api/v1/crecimientos`;
+const API_TIPOS_CRECIMIENTO_ENDPOINT = `${API_CRECIMIENTO_URL}/api/v1/tipos-crecimiento`;
+
+export const listarPorBebe = (usuarioId, bebeId, limit) => {
+  const params = {};
+  if (limit !== undefined) params.limit = limit;
+  return axios.get(
+    `${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
+    { params }
+  );
+};
+
+export const crearRegistro = (usuarioId, data) => {
+  return axios.post(`${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}`, data);
+};
+
+export const actualizarRegistro = (usuarioId, id, data) => {
+  return axios.put(
+    `${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}/${id}`,
+    data
+  );
+};
+
+export const eliminarRegistro = (usuarioId, id) => {
+  return axios.delete(
+    `${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}/${id}`
+  );
+};
+
+export const listarTipos = () => {
+  return axios.get(`${API_TIPOS_CRECIMIENTO_ENDPOINT}`);
+};
+


### PR DESCRIPTION
## Summary
- add API_CRECIMIENTO_URL configuration
- implement frontend crecimiento service for CRUD and type listing

## Testing
- `cd frontend-baby && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68befbfaab3c8327a84d154b92a7fd18