### PR TITLE
feat: add crecimiento tracking page

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -20,6 +20,7 @@ import Acerca from "./dashboard/pages/Acerca";
 import AnadirBebe from "./dashboard/pages/AnadirBebe";
 import EditarBebe from "./dashboard/pages/EditarBebe";
 import InicioSinBebe from "./dashboard/pages/InicioSinBebe";
+import Crecimiento from "./dashboard/pages/Crecimiento";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
@@ -45,6 +46,7 @@ function App() {
             >
               <Route index element={<MainGrid />} />
               <Route path="cuidados" element={<Cuidados />} />
+              <Route path="crecimiento" element={<Crecimiento />} />
               <Route path="gastos" element={<Gastos />} />
               <Route path="diario" element={<Diario />} />
               <Route path="alimentacion" element={<Alimentacion />} />

--- a/frontend-baby/src/dashboard/components/CrecimientoForm.js
+++ b/frontend-baby/src/dashboard/components/CrecimientoForm.js
@@ -1,0 +1,156 @@
+import React, { useState, useEffect } from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import { DatePicker } from '@mui/x-date-pickers';
+import dayjs from 'dayjs';
+import { listarTipos } from '../../services/crecimientoService';
+import { saveButton, cancelButton } from '../../theme/buttonStyles';
+
+export default function CrecimientoForm({ open, onClose, onSubmit, initialData }) {
+  const [formData, setFormData] = useState({
+    fecha: null,
+    tipoId: '',
+    valor: '',
+    unidad: '',
+    observaciones: '',
+  });
+  const [tipoOptions, setTipoOptions] = useState([]);
+
+  useEffect(() => {
+    if (initialData) {
+      setFormData({
+        fecha: initialData.fecha ? dayjs(initialData.fecha) : null,
+        tipoId: initialData.tipoId || '',
+        valor: initialData.valor || '',
+        unidad: initialData.unidad || '',
+        observaciones: initialData.observaciones || '',
+      });
+    } else {
+      setFormData({
+        fecha: null,
+        tipoId: '',
+        valor: '',
+        unidad: '',
+        observaciones: '',
+      });
+    }
+  }, [initialData, open]);
+
+  useEffect(() => {
+    listarTipos()
+      .then((res) => setTipoOptions(res.data))
+      .catch((err) => console.error('Error fetching tipos crecimiento:', err));
+  }, []);
+
+  const getUnidad = (tipoId) => {
+    const tipo = tipoOptions.find((t) => t.id == tipoId);
+    if (!tipo) return '';
+    const nombre = tipo.nombre.toLowerCase();
+    if (nombre.includes('peso')) return 'kg';
+    if (nombre.includes('talla') || nombre.includes('perímetro') || nombre.includes('perimetro')) return 'cm';
+    return '';
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === 'tipoId' ? { unidad: getUnidad(value) } : {}),
+    }));
+  };
+
+  const handleFechaChange = (newValue) => {
+    setFormData((prev) => ({ ...prev, fecha: newValue }));
+  };
+
+  const handleSubmit = () => {
+    const payload = {
+      ...formData,
+      fecha: formData.fecha ? formData.fecha.format('YYYY-MM-DD') : '',
+      valor: formData.valor ? parseFloat(formData.valor) : null,
+    };
+    onSubmit(payload);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>
+        {initialData && initialData.id ? 'Editar registro' : 'Añadir registro'}
+      </DialogTitle>
+      <DialogContent>
+        <Stack sx={{ mt: 1 }}>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Fecha</FormLabel>
+            <DatePicker
+              value={formData.fecha}
+              onChange={handleFechaChange}
+              slotProps={{ textField: { fullWidth: true } }}
+            />
+          </FormControl>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Tipo</FormLabel>
+            <TextField
+              select
+              name="tipoId"
+              value={formData.tipoId}
+              onChange={handleChange}
+            >
+              {tipoOptions.map((option) => (
+                <MenuItem key={option.id} value={option.id}>
+                  {option.nombre}
+                </MenuItem>
+              ))}
+            </TextField>
+          </FormControl>
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Valor</FormLabel>
+            <TextField
+              type="number"
+              name="valor"
+              value={formData.valor}
+              onChange={handleChange}
+              inputProps={{ min: 0, step: 'any' }}
+            />
+          </FormControl>
+          {formData.unidad && (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Unidad</FormLabel>
+              <TextField
+                name="unidad"
+                value={formData.unidad}
+                onChange={handleChange}
+              />
+            </FormControl>
+          )}
+          <FormControl fullWidth sx={{ mb: 2 }}>
+            <FormLabel sx={{ mb: 1 }}>Observaciones</FormLabel>
+            <TextField
+              multiline
+              rows={3}
+              name="observaciones"
+              value={formData.observaciones}
+              onChange={handleChange}
+            />
+          </FormControl>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button variant="contained" onClick={onClose} sx={cancelButton}>
+          Cancelar
+        </Button>
+        <Button variant="contained" onClick={handleSubmit} sx={saveButton}>
+          Guardar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -8,6 +8,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
 import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import MedicalServicesRoundedIcon from '@mui/icons-material/MedicalServicesRounded';
+import TrendingUpRoundedIcon from '@mui/icons-material/TrendingUpRounded';
 import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded';
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import RamenDiningRoundedIcon from '@mui/icons-material/RamenDiningRounded';
@@ -20,6 +21,7 @@ import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 const mainListItems = [
   { text: 'Inicio', icon: <HomeRoundedIcon />, to: '/dashboard' },
   { text: 'Cuidados', icon: <MedicalServicesRoundedIcon />, to: '/dashboard/cuidados' },
+  { text: 'Crecimiento', icon: <TrendingUpRoundedIcon />, to: '/dashboard/crecimiento' },
   { text: 'Gastos', icon: <MonetizationOnRoundedIcon />, to: '/dashboard/gastos' },
   { text: 'Diario', icon: <MenuBookRoundedIcon />, to: '/dashboard/diario' },
   { text: 'Alimentación', icon: <RamenDiningRoundedIcon />, to: '/dashboard/alimentacion' },

--- a/frontend-baby/src/dashboard/pages/Crecimiento.js
+++ b/frontend-baby/src/dashboard/pages/Crecimiento.js
@@ -1,0 +1,274 @@
+import React, { useEffect, useState, useMemo } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import TablePagination from "@mui/material/TablePagination";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
+import TextField from "@mui/material/TextField";
+import dayjs from "dayjs";
+import AddIcon from "@mui/icons-material/Add";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { LineChart } from "@mui/x-charts/LineChart";
+import {
+  listarPorBebe,
+  crearRegistro,
+  actualizarRegistro,
+  eliminarRegistro,
+  listarTipos,
+} from "../../services/crecimientoService";
+import CrecimientoForm from "../components/CrecimientoForm";
+import { BabyContext } from "../../context/BabyContext";
+import { AuthContext } from "../../context/AuthContext";
+import { addButton } from "../../theme/buttonStyles";
+
+export default function Crecimiento() {
+  const [tab, setTab] = useState(0);
+  const [registros, setRegistros] = useState([]);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [openForm, setOpenForm] = useState(false);
+  const [selectedRegistro, setSelectedRegistro] = useState(null);
+  const [tipos, setTipos] = useState([]);
+  const { activeBaby } = React.useContext(BabyContext);
+  const { user } = React.useContext(AuthContext);
+  const bebeId = activeBaby?.id;
+  const usuarioId = user?.id;
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const filteredRegistros = useMemo(() => {
+    let data =
+      tipos[tab]
+        ? registros.filter(
+            (r) => Number(r.tipoId) === Number(tipos[tab].id),
+          )
+        : [];
+    if (startDate) {
+      data = data.filter((r) =>
+        dayjs(r.fecha).isAfter(dayjs(startDate).subtract(1, "day")),
+      );
+    }
+    if (endDate) {
+      data = data.filter((r) =>
+        dayjs(r.fecha).isBefore(dayjs(endDate).add(1, "day")),
+      );
+    }
+    return data;
+  }, [registros, tab, tipos, startDate, endDate]);
+
+  const chartData = filteredRegistros.map((r) => ({
+    x: dayjs(r.fecha).format("DD/MM"),
+    y: r.valor,
+    p: r.percentil,
+  }));
+
+  const fetchRegistros = () => {
+    if (!bebeId || !usuarioId) return;
+    listarPorBebe(usuarioId, bebeId)
+      .then((res) => setRegistros(res.data))
+      .catch((err) => console.error("Error fetching crecimiento:", err));
+  };
+
+  useEffect(() => {
+    if (bebeId) {
+      fetchRegistros();
+      listarTipos()
+        .then((res) => setTipos(res.data))
+        .catch((err) =>
+          console.error("Error fetching tipos crecimiento:", err),
+        );
+    }
+  }, [bebeId]);
+
+  const handleTabChange = (event, newValue) => {
+    setTab(newValue);
+    setPage(0);
+  };
+
+  const handleAdd = () => {
+    setSelectedRegistro(null);
+    setOpenForm(true);
+  };
+
+  const handleEdit = (registro) => {
+    setSelectedRegistro(registro);
+    setOpenForm(true);
+  };
+
+  const handleDelete = (id) => {
+    if (!bebeId || !usuarioId) return;
+    if (window.confirm("¿Eliminar registro?")) {
+      eliminarRegistro(usuarioId, id)
+        .then(() => fetchRegistros())
+        .catch((err) => console.error("Error deleting registro:", err));
+    }
+  };
+
+  const handleFormSubmit = (data) => {
+    if (!bebeId || !usuarioId) return;
+    const payload = { ...data, bebeId };
+    const request = selectedRegistro
+      ? actualizarRegistro(usuarioId, selectedRegistro.id, payload)
+      : crearRegistro(usuarioId, payload);
+
+    request
+      .then(() => {
+        setOpenForm(false);
+        setSelectedRegistro(null);
+        fetchRegistros();
+      })
+      .catch((err) => console.error("Error saving registro:", err));
+  };
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  return (
+    <Box sx={{ width: "100%" }}>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="flex-start"
+        alignItems={{ xs: "stretch", sm: "center" }}
+        spacing={2}
+        mb={2}
+      >
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          sx={{ alignSelf: "flex-start", ...addButton }}
+          onClick={handleAdd}
+        >
+          Añadir registro
+        </Button>
+        <TextField
+          label="Desde"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <TextField
+          label="Hasta"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+      </Stack>
+
+      <Typography variant="h4" gutterBottom>
+        Crecimiento
+      </Typography>
+      <Tabs value={tab} onChange={handleTabChange} sx={{ mb: 2 }}>
+        {tipos.map((t) => (
+          <Tab key={t.id} label={t.nombre} />
+        ))}
+      </Tabs>
+
+      <TableContainer sx={{ mb: 4 }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Fecha</TableCell>
+              <TableCell>Tipo</TableCell>
+              <TableCell>Valor</TableCell>
+              <TableCell>Nota</TableCell>
+              <TableCell align="center">Acciones</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filteredRegistros
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map((registro) => (
+                <TableRow key={registro.id}>
+                  <TableCell>
+                    {dayjs(registro.fecha).format("DD/MM/YYYY")}
+                  </TableCell>
+                  <TableCell>{registro.tipoNombre}</TableCell>
+                  <TableCell sx={{ fontWeight: 600 }}>
+                    {registro.valor} {registro.unidad || ""}
+                  </TableCell>
+                  <TableCell>{registro.observaciones}</TableCell>
+                  <TableCell align="center">
+                    <IconButton
+                      size="small"
+                      aria-label="edit"
+                      onClick={() => handleEdit(registro)}
+                      sx={{ color: "#0d6efd" }}
+                    >
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      size="small"
+                      aria-label="delete"
+                      onClick={() => handleDelete(registro.id)}
+                      sx={{ color: "#dc3545" }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+        <TablePagination
+          component="div"
+          count={filteredRegistros.length}
+          page={page}
+          onPageChange={handleChangePage}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+        />
+      </TableContainer>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Evolución
+          </Typography>
+          <LineChart
+            height={300}
+            xAxis={[
+              {
+                scaleType: "point",
+                data: chartData.map((d) => d.x),
+              },
+            ]}
+            series={[
+              { data: chartData.map((d) => d.y), label: "Valor" },
+              ...(chartData.some((d) => d.p !== undefined)
+                ? [{ data: chartData.map((d) => d.p), label: "Percentil OMS" }]
+                : []),
+            ]}
+            margin={{ left: 40, right: 20, top: 20, bottom: 20 }}
+            grid={{ horizontal: true }}
+          />
+        </CardContent>
+      </Card>
+      <CrecimientoForm
+        open={openForm}
+        onClose={() => setOpenForm(false)}
+        onSubmit={handleFormSubmit}
+        initialData={selectedRegistro}
+      />
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add Crecimiento page for tracking weight, height and head circumference
- create growth registration form
- expose new route and sidebar link

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68befcd275208327a22263b989a79f64