### PR TITLE
Remove unused Date import from DataInitializer

### DIFF
--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/config/DataInitializer.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/config/DataInitializer.java
@@ -1,6 +1,5 @@
 package com.babytrackmaster.api_crecimiento.config;
 
-import java.util.Date;
 import java.util.List;
 
 import org.springframework.boot.CommandLineRunner;


### PR DESCRIPTION
## Summary
- remove unused `java.util.Date` import from `DataInitializer`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4ddadfcc8327ae1eb22e0521207b