### PR TITLE
Remove default bottle and breast care types

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
@@ -24,8 +24,6 @@ public class DataInitializer {
         return args -> {
             if (tipoCuidadoRepository.count() == 0) {
                 tipoCuidadoRepository.saveAll(List.of(
-                    createTipoCuidado("Biberón"),
-                    createTipoCuidado("Pecho"),
                     createTipoCuidado("Pañal"),
                     createTipoCuidado("Sueño"),
                     createTipoCuidado("Baño")


### PR DESCRIPTION
## Summary
- Remove `Biberón` and `Pecho` entries from the data initializer so the API no longer seeds these care types

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5726e39883278cea8f45301630c1