### PR TITLE
Remove feeding stats from quick stats

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
@@ -10,8 +10,6 @@ public class QuickStatsResponse {
     private double horasSueno;
     @Schema(example = "5", description = "Cantidad de pañales")
     private long panales;
-    @Schema(example = "6", description = "Número total de tomas (biberón + pecho)")
-    private long tomas;
     @Schema(example = "1", description = "Cantidad de baños")
     private long banos;
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -118,10 +118,10 @@ public class CuidadoServiceImpl implements CuidadoService {
 
         List<Cuidado> suenos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Sueño", inicio, fin);
         List<Cuidado> numBanos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Baño", inicio, fin);
-        List<Cuidado> numPanales = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pañal", inicio, fin);
+        List<Cuidado> numPanales = repo
+                .findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pañal",
+                        inicio, fin);
         //long panales = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pañal", inicio, fin);
-        long biberones = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Biberon", inicio, fin);
-        long pechos = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pecho", inicio, fin);
         //long banos = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Baño", inicio, fin);
 
         double minutosSueno = 0d;
@@ -151,7 +151,6 @@ public class CuidadoServiceImpl implements CuidadoService {
         QuickStatsResponse resp = new QuickStatsResponse();
         resp.setHorasSueno(horasSueno);
         resp.setPanales(numPanalesTotal);
-        resp.setTomas(biberones + pechos);
         resp.setBanos(numBanosTotal);
         return resp;
     }

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
@@ -44,8 +44,6 @@ class CuidadoControllerTest {
 
         TipoCuidado sueno = saveTipo("Sue\u00f1o");
         TipoCuidado panal = saveTipo("Pa\u00f1al");
-        TipoCuidado biberon = saveTipo("Biberon");
-        TipoCuidado pecho = saveTipo("Pecho");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
 
         createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,2,0));
@@ -53,9 +51,6 @@ class CuidadoControllerTest {
         createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
         createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
         createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
-        createCuidado(biberon, date(2024,3,10,6,0), date(2024,3,10,6,30));
-        createCuidado(biberon, date(2024,3,10,9,0), date(2024,3,10,9,20));
-        createCuidado(pecho, date(2024,3,10,15,0), date(2024,3,10,15,15));
         createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
@@ -66,7 +61,6 @@ class CuidadoControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.horasSueno", closeTo(3.5, 0.01)))
             .andExpect(jsonPath("$.panales").value(3))
-            .andExpect(jsonPath("$.tomas").value(3))
             .andExpect(jsonPath("$.banos").value(1));
     }
 

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -40,8 +40,6 @@ class CuidadoServiceImplTest {
 
         TipoCuidado sueno = saveTipo("Sue\u00f1o");
         TipoCuidado panal = saveTipo("Pa\u00f1al");
-        TipoCuidado biberon = saveTipo("Biberon");
-        TipoCuidado pecho = saveTipo("Pecho");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
 
         createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,4,0), 120);
@@ -50,9 +48,6 @@ class CuidadoServiceImplTest {
         createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
         createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
         createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
-        createCuidado(biberon, date(2024,3,10,6,0), date(2024,3,10,6,30));
-        createCuidado(biberon, date(2024,3,10,9,0), date(2024,3,10,9,20));
-        createCuidado(pecho, date(2024,3,10,15,0), date(2024,3,10,15,15));
         createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
@@ -61,7 +56,6 @@ class CuidadoServiceImplTest {
         QuickStatsResponse resp = service.obtenerEstadisticasRapidas(1L,1L, baseDate);
         assertEquals(210.0, resp.getHorasSueno(), 0.001);
         assertEquals(3, resp.getPanales());
-        assertEquals(3, resp.getTomas());
         assertEquals(1, resp.getBanos());
     }
 

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -41,7 +41,7 @@ export default function QuickActionsCard() {
       obtenerStatsRapidas(usuarioId, bebeId)
         .then(({ data }) =>
           setActionsData((prev) => ({
-            biberon: { ...prev.biberon, today: data.tomas || 0 },
+            ...prev,
             panal: { ...prev.panal, today: data.panales || 0 },
             sueno: { ...prev.sueno, today: data.horasSueno || 0 },
             bano: { ...prev.bano, today: data.banos || 0 },

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.js
@@ -14,7 +14,6 @@ export default function QuickStatsCard() {
   const [stats, setStats] = useState({
     horasSueno: 0,
     panales: 0,
-    tomas: 0,
     banos: 0,
   });
 
@@ -23,7 +22,7 @@ export default function QuickStatsCard() {
       obtenerStatsRapidas(user.id, activeBaby.id)
         .then(({ data }) => setStats(data))
         .catch(() =>
-          setStats({ horasSueno: 0, panales: 0, tomas: 0, banos: 0 })
+          setStats({ horasSueno: 0, panales: 0, banos: 0 })
         );
     }
   }, [user, activeBaby]);
@@ -31,15 +30,13 @@ export default function QuickStatsCard() {
   const statsArray = [
     { label: 'Horas de sueño', value: `${stats.horasSueno}h` },
     { label: 'Pañales', value: `${stats.panales}` },
-    { label: 'Tomas', value: `${stats.tomas}` },
     { label: 'Baños', value: `${stats.banos}` },
   ];
 
   const chartData = [
     { id: 0, value: stats.horasSueno, label: 'Horas de sueño' },
     { id: 1, value: stats.panales, label: 'Pañales' },
-    { id: 2, value: stats.tomas, label: 'Tomas' },
-    { id: 3, value: stats.banos, label: 'Baños' },
+    { id: 2, value: stats.banos, label: 'Baños' },
   ];
 
   const hasStats = Object.values(stats).some((value) => value > 0);

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
@@ -27,7 +27,7 @@ describe('QuickStatsCard', () => {
 
   it('muestra estadísticas obtenidas del servicio', async () => {
     obtenerStatsRapidas.mockResolvedValue({
-      data: { horasSueno: 8, panales: 5, tomas: 6, banos: 1 },
+      data: { horasSueno: 8, panales: 5, banos: 1 },
     });
 
     render(
@@ -43,14 +43,13 @@ describe('QuickStatsCard', () => {
     await waitFor(() => {
       expect(screen.getByText('8h')).toBeInTheDocument();
       expect(screen.getByText('5')).toBeInTheDocument();
-      expect(screen.getByText('6')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
     });
   });
 
   it('muestra mensaje cuando el servicio devuelve valores por defecto', async () => {
     obtenerStatsRapidas.mockResolvedValue({
-      data: { horasSueno: 0, panales: 0, tomas: 0, banos: 0 },
+      data: { horasSueno: 0, panales: 0, banos: 0 },
     });
 
     render(


### PR DESCRIPTION
## Summary
- drop bottle and breast counts from quick statistics service
- remove `tomas` metric from QuickStatsResponse DTO and frontend components
- update related tests accordingly

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bf5796247483278a3fa9e2a3fe1c33