### PR TITLE
Refine quick care stats after removing feedings

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
-@Schema(name = "QuickStatsResponse", description = "Estadísticas rápidas de cuidados para un día")
+@Schema(name = "QuickStatsResponse", description = "Estadísticas rápidas de cuidados para un día (sueño, pañales y baños)")
 public class QuickStatsResponse {
     @Schema(example = "8.0", description = "Horas totales de sueño")
     private double horasSueno;
     @Schema(example = "5", description = "Cantidad de pañales")
-    private long panales;
+    private int panales;
     @Schema(example = "1", description = "Cantidad de baños")
-    private long banos;
+    private int banos;
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -133,19 +133,13 @@ public class CuidadoServiceImpl implements CuidadoService {
         }
         
         int numBanosTotal = 0;
-        
         for (Cuidado c : numBanos) {
-        	numBanosTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
-        
-
+            numBanosTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
         }
-        
-        int numPanalesTotal = 0;
-        
-        for (Cuidado c : numPanales) {
-        	numPanalesTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
-        
 
+        int numPanalesTotal = 0;
+        for (Cuidado c : numPanales) {
+            numPanalesTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
         }
 
         QuickStatsResponse resp = new QuickStatsResponse();


### PR DESCRIPTION
## Summary
- Tighten QuickStatsResponse schema and use int counts
- Simplify consumer code after dropping feeding stat

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf59714a108327bfe8f9e44440730c