### PR TITLE
feat: use feeding service in summary card

### DIFF
--- a/frontend-baby/src/dashboard/components/StatusSummaryCard.js
+++ b/frontend-baby/src/dashboard/components/StatusSummaryCard.js
@@ -11,7 +11,12 @@ import BathtubIcon from '@mui/icons-material/Bathtub';
 import dayjs from 'dayjs';
 import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
-import { listarRecientes } from '../../services/cuidadosService';
+import {
+  listarRecientes as listarCuidadosRecientes,
+} from '../../services/cuidadosService';
+import {
+  listarRecientes as listarAlimentacionRecientes,
+} from '../../services/alimentacionService';
 
 export default function StatusSummaryCard() {
   const { user } = useContext(AuthContext);
@@ -25,16 +30,19 @@ export default function StatusSummaryCard() {
 
   useEffect(() => {
     if (user?.id && activeBaby?.id) {
-      listarRecientes(user.id, activeBaby.id, 20)
-        .then(({ data }) => {
-          const findByName = (names) =>
+      Promise.all([
+        listarCuidadosRecientes(user.id, activeBaby.id, 20),
+        listarAlimentacionRecientes(user.id, activeBaby.id, 20),
+      ])
+        .then(([cuidados, alimentacion]) => {
+          const findByName = (data, names) =>
             data.find((item) => names.includes(item.tipoNombre));
 
           setEvents({
-            feeding: findByName(['Pecho', 'Biberón', 'Toma', 'Alimentación']),
-            diaper: findByName(['Pañal']),
-            sleep: findByName(['Sueño', 'Dormir']),
-            bath: findByName(['Baño', 'Bañar']),
+            feeding: findByName(alimentacion.data, ['Pecho', 'Biberón']),
+            diaper: findByName(cuidados.data, ['Pañal']),
+            sleep: findByName(cuidados.data, ['Sueño', 'Dormir']),
+            bath: findByName(cuidados.data, ['Baño', 'Bañar']),
           });
         })
         .catch(() =>


### PR DESCRIPTION
## Summary
- fetch latest feeding events from alimentacionService instead of cuidadosService
- restrict feeding lookup to current feeding types only

## Testing
- `CI=true npm test -- --runTestsByPath src/dashboard/components/QuickStatsCard.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf5dd0f04c832790fd31401984467d