### PR TITLE
feat: agregar duracion en cuidados

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
@@ -16,6 +16,7 @@ public class CuidadoRequest {
     @NotNull private Date inicio;
 
     private Date fin;
+    private String duracion;
     private Integer cantidadMl;
     private String tipoPanal;
     private String medicamento;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
@@ -18,6 +18,7 @@ public class CuidadoResponse {
     private String tipoNombre;
     private Date inicio;
     private Date fin;
+    private String duracion;
     @Schema(example = "120")
     private Integer cantidadMl;
     private String tipoPanal;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
@@ -33,6 +33,9 @@ public class Cuidado {
     @Temporal(TemporalType.TIMESTAMP)
     private Date fin;
 
+    @Column(name="duracion", length=50)
+    private String duracion;
+
     @Column(name="cantidad_ml")
     private Integer cantidadMl;
 

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -19,6 +19,7 @@ public class CuidadoMapper {
         c.setTipo(tipo);
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
+        c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
         c.setTipoPanal(req.getTipoPanal());
         c.setMedicamento(req.getMedicamento());
@@ -39,6 +40,7 @@ public class CuidadoMapper {
         c.setTipo(tipo);
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
+        c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
         c.setTipoPanal(req.getTipoPanal());
         c.setMedicamento(req.getMedicamento());
@@ -58,6 +60,7 @@ public class CuidadoMapper {
         }
         r.setInicio(c.getInicio());
         r.setFin(c.getFin());
+        r.setDuracion(c.getDuracion());
         r.setCantidadMl(c.getCantidadMl());
         r.setTipoPanal(c.getTipoPanal());
         r.setMedicamento(c.getMedicamento());

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -116,31 +116,32 @@ public class CuidadoServiceImpl implements CuidadoService {
         cal.add(Calendar.DAY_OF_MONTH, 1);
         Date fin = cal.getTime();
 
-        List<Cuidado> suenos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Sueño", inicio, fin);
-        List<Cuidado> numBanos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Baño", inicio, fin);
-        List<Cuidado> numPanales = repo
-                .findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pañal",
-                        inicio, fin);
-        //long panales = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Pañal", inicio, fin);
-        //long banos = repo.countByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId, usuarioId, "Baño", inicio, fin);
+        List<Cuidado> suenos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId,
+                usuarioId, "Sueño", inicio, fin);
+        List<Cuidado> numBanos = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId,
+                usuarioId, "Baño", inicio, fin);
+        List<Cuidado> numPanales = repo.findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(bebeId,
+                usuarioId, "Pañal", inicio, fin);
 
-        double minutosSueno = 0d;
-        int horasSueno = 0;
+        double horasSueno = 0d;
         for (Cuidado c : suenos) {
-        	horasSueno += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
-        
+            if (c.getDuracion() != null) {
+                try {
+                    horasSueno += Double.parseDouble(c.getDuracion()) / 60d;
+                } catch (NumberFormatException e) {
+                    if (c.getInicio() != null && c.getFin() != null) {
+                        long diff = c.getFin().getTime() - c.getInicio().getTime();
+                        horasSueno += diff / (1000d * 60d * 60d);
+                    }
+                }
+            } else if (c.getInicio() != null && c.getFin() != null) {
+                long diff = c.getFin().getTime() - c.getInicio().getTime();
+                horasSueno += diff / (1000d * 60d * 60d);
+            }
+        }
 
-        }
-        
-        int numBanosTotal = 0;
-        for (Cuidado c : numBanos) {
-            numBanosTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
-        }
-
-        int numPanalesTotal = 0;
-        for (Cuidado c : numPanales) {
-            numPanalesTotal += (c.getCantidadMl() != null) ? c.getCantidadMl() : 0;
-        }
+        int numBanosTotal = numBanos.size();
+        int numPanalesTotal = numPanales.size();
 
         QuickStatsResponse resp = new QuickStatsResponse();
         resp.setHorasSueno(horasSueno);

--- a/api-cuidados/src/main/resources/schema.sql
+++ b/api-cuidados/src/main/resources/schema.sql
@@ -14,5 +14,8 @@ INSERT INTO tipo_cuidado (nombre, created_at, updated_at) VALUES
 ('PASEO', NOW(), NOW());
 
 ALTER TABLE cuidados
+    ADD COLUMN duracion VARCHAR(50);
+
+ALTER TABLE cuidados
     ADD CONSTRAINT fk_cuidados_tipo FOREIGN KEY (tipo) REFERENCES tipo_cuidado(id);
 

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -42,8 +42,8 @@ class CuidadoServiceImplTest {
         TipoCuidado panal = saveTipo("Pa\u00f1al");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
 
-        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,4,0), 120);
-        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,10,30), 90);
+        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
+        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,10,30), "90");
         createCuidado(sueno, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
         createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
         createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
@@ -54,7 +54,7 @@ class CuidadoServiceImplTest {
     @Test
     void testObtenerEstadisticasRapidas() {
         QuickStatsResponse resp = service.obtenerEstadisticasRapidas(1L,1L, baseDate);
-        assertEquals(210.0, resp.getHorasSueno(), 0.001);
+        assertEquals(5.5, resp.getHorasSueno(), 0.001);
         assertEquals(3, resp.getPanales());
         assertEquals(1, resp.getBanos());
     }
@@ -68,14 +68,14 @@ class CuidadoServiceImplTest {
         return tipoRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin, Integer cantidad) {
+    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin, String duracion) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
         c.setTipo(tipo);
         c.setInicio(inicio);
         c.setFin(fin);
-        c.setCantidadMl(cantidad);
+        c.setDuracion(duracion);
         Date now = new Date();
         c.setCreatedAt(now);
         c.setUpdatedAt(now);


### PR DESCRIPTION
## Summary
- add `duracion` field to care entity and DTOs
- compute daily sleep hours from `duracion` or time range
- update schema and tests for new attribute

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf60b2030883279207a8d022247fd3