### PR TITLE
feat: add sleep duration field to cuidados

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -20,6 +20,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     inicio: null,
     tipoId: "",
     cantidadMl: "",
+    duracion: "",
     observaciones: "",
   });
   const [tipoOptions, setTipoOptions] = useState([]);
@@ -30,6 +31,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         inicio: initialData.inicio ? dayjs(initialData.inicio) : null,
         tipoId: initialData.tipoId || "",
         cantidadMl: initialData.cantidadMl || "",
+        duracion: initialData.duracion || "",
         observaciones: initialData.observaciones || "",
       });
     } else {
@@ -37,6 +39,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         inicio: null,
         tipoId: "",
         cantidadMl: "",
+        duracion: "",
         observaciones: "",
       });
     }
@@ -51,7 +54,9 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   const handleChange = (e) => {
     const { name, value } = e.target;
     const sanitizedValue =
-      name === "cantidadMl" ? String(Math.max(0, Number(value))) : value;
+      ["cantidadMl", "duracion"].includes(name)
+        ? String(Math.max(0, Number(value)))
+        : value;
     setFormData((prev) => ({
       ...prev,
       [name]: sanitizedValue,
@@ -69,6 +74,11 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     };
     onSubmit(payload);
   };
+
+  const selectedTipo = tipoOptions.find(
+    (option) => Number(option.id) === Number(formData.tipoId),
+  );
+  const isSueno = selectedTipo?.nombre === "Sueño";
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
@@ -102,16 +112,29 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
               ))}
             </TextField>
           </FormControl>
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
-            <TextField
-              type="number"
-              name="cantidadMl"
-              value={formData.cantidadMl}
-              onChange={handleChange}
-              inputProps={{ min: 0 }}
-            />
-          </FormControl>
+          {isSueno ? (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Duración</FormLabel>
+              <TextField
+                type="number"
+                name="duracion"
+                value={formData.duracion}
+                onChange={handleChange}
+                inputProps={{ min: 0 }}
+              />
+            </FormControl>
+          ) : (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
+              <TextField
+                type="number"
+                name="cantidadMl"
+                value={formData.cantidadMl}
+                onChange={handleChange}
+                inputProps={{ min: 0 }}
+              />
+            </FormControl>
+          )}
           <FormControl fullWidth sx={{ mb: 2 }}>
             <FormLabel sx={{ mb: 1 }}>Observaciones</FormLabel>
             <TextField

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -58,6 +58,8 @@ export default function Cuidados() {
     [cuidados, tab, tipos],
   );
 
+  const isSueno = tipos[tab]?.nombre === "Sueño";
+
   useEffect(() => {
     const stats = Array(7).fill(0);
     filteredCuidados.forEach((cuidado) => {
@@ -155,11 +157,18 @@ export default function Cuidados() {
   };
   // Exporta datos con las mismas columnas para todos los tipos.
   const handleExportCsv = () => {
-    const headers = ["Hora", "Tipo", "Cantidad", "Nota"];
+    const headers = [
+      "Hora",
+      "Tipo",
+      isSueno ? "Duración" : "Cantidad",
+      "Nota",
+    ];
     const rows = filteredCuidados.map((cuidado) => [
       dayjs(cuidado.inicio).format("DD/MM/YYYY HH:mm"),
       cuidado.tipoNombre,
-      cuidado.cantidadMl ?? "-",
+      cuidado.tipoNombre === "Sueño"
+        ? cuidado.duracion ?? "-"
+        : cuidado.cantidadMl ?? "-",
       cuidado.observaciones ?? "",
     ]);
     const csvContent = [headers, ...rows].map((e) => e.join(",")).join("\n");
@@ -181,13 +190,15 @@ export default function Cuidados() {
     const tableColumn = [
       "Hora",
       "Tipo",
-      "Cantidad",
+      isSueno ? "Duración" : "Cantidad",
       "Nota",
     ];
     const tableRows = filteredCuidados.map((cuidado) => [
       dayjs(cuidado.inicio).format("DD/MM/YYYY HH:mm"),
       cuidado.tipoNombre,
-      cuidado.cantidadMl ?? "-",
+      cuidado.tipoNombre === "Sueño"
+        ? cuidado.duracion ?? "-"
+        : cuidado.cantidadMl ?? "-",
       cuidado.observaciones ?? "",
     ]);
     autoTable(doc, {
@@ -231,7 +242,7 @@ export default function Cuidados() {
             <TableRow>
               <TableCell>Hora</TableCell>
               <TableCell>Tipo</TableCell>
-              <TableCell>Cantidad</TableCell>
+              <TableCell>{isSueno ? "Duración" : "Cantidad"}</TableCell>
               <TableCell>Nota</TableCell>
               <TableCell align="center">Acciones</TableCell>
             </TableRow>
@@ -246,7 +257,9 @@ export default function Cuidados() {
                   </TableCell>
                   <TableCell>{cuidado.tipoNombre}</TableCell>
                   <TableCell sx={{ fontWeight: 600 }}>
-                    {cuidado.cantidadMl ?? "-"}
+                    {cuidado.tipoNombre === "Sueño"
+                      ? cuidado.duracion ?? "-"
+                      : cuidado.cantidadMl ?? "-"}
                   </TableCell>
                   <TableCell>{cuidado.observaciones}</TableCell>
                   <TableCell align="center">


### PR DESCRIPTION
## Summary
- add `duracion` field to care form and conditionally render duration or quantity
- display duration for sleep entries in tables and exports

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf61e5c1f083279498afdb2abe3ea7