### PR TITLE
Add specialty link to appointments

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
@@ -44,6 +44,10 @@ public class CitaCreateDTO {
     @NotNull
     private Long tipoId;
 
+    @Schema(example = "1")
+    @NotNull
+    private Long tipoEspecialidadId;
+
     @Schema(example = "30")
     private Integer recordatorioMinutos;
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaResponseDTO.java
@@ -1,6 +1,7 @@
 package com.babytrackmaster.api_citas.dto;
 
 import com.babytrackmaster.api_citas.dto.EstadoCitaResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
 import lombok.*;
 
 @Getter @Setter @Builder
@@ -15,6 +16,7 @@ public class CitaResponseDTO {
     private String centroMedico;
     private String medico;
     private TipoCitaResponseDTO tipo;
+    private TipoEspecialidadResponseDTO tipoEspecialidad;
     private EstadoCitaResponseDTO estado;
     private Integer recordatorioMinutos;
     private String creadoEn;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaUpdateDTO.java
@@ -31,6 +31,8 @@ public class CitaUpdateDTO {
 
     private Long tipoId;
 
+    private Long tipoEspecialidadId;
+
     private Integer recordatorioMinutos;
 
     private Long estadoId;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadResponseDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadResponseDTO.java
@@ -1,0 +1,13 @@
+package com.babytrackmaster.api_citas.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class TipoEspecialidadResponseDTO {
+    private Long id;
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/Cita.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import com.babytrackmaster.api_citas.entity.EstadoCita;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -68,6 +69,10 @@ public class Cita {
     @ManyToOne
     @JoinColumn(name = "estado", nullable = false)
     private EstadoCita estado;
+
+    @ManyToOne
+    @JoinColumn(name = "tipo_especialidad")
+    private TipoEspecialidad tipoEspecialidad;
 
     // recordatorio en minutos antes de la cita (ej. 30, 60, 1440)
     private Integer recordatorioMinutos;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoEspecialidad.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/entity/TipoEspecialidad.java
@@ -1,0 +1,21 @@
+package com.babytrackmaster.api_citas.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "tipo_especialidad")
+public class TipoEspecialidad {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 100)
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/CitaMapper.java
@@ -4,14 +4,16 @@ import com.babytrackmaster.api_citas.dto.*;
 import com.babytrackmaster.api_citas.entity.Cita;
 import com.babytrackmaster.api_citas.entity.TipoCita;
 import com.babytrackmaster.api_citas.entity.EstadoCita;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
 import com.babytrackmaster.api_citas.mapper.EstadoCitaMapper;
+import com.babytrackmaster.api_citas.mapper.TipoEspecialidadMapper;
 import java.time.*;
 
 public class CitaMapper {
 
     private CitaMapper() {}
 
-    public static Cita toEntity(CitaCreateDTO dto, Long usuarioId, TipoCita tipo, EstadoCita estado) {
+    public static Cita toEntity(CitaCreateDTO dto, Long usuarioId, TipoCita tipo, EstadoCita estado, TipoEspecialidad tipoEspecialidad) {
         Cita c = new Cita();
         c.setUsuarioId(usuarioId);
         c.setBebeId(dto.getBebeId());
@@ -22,13 +24,14 @@ public class CitaMapper {
         c.setCentroMedico(dto.getCentroMedico());
         c.setMedico(dto.getMedico());
         c.setTipo(tipo);
+        c.setTipoEspecialidad(tipoEspecialidad);
         c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
         c.setEstado(estado);
         c.setEliminado(Boolean.FALSE);
         return c;
     }
 
-    public static void applyUpdate(Cita c, CitaUpdateDTO dto, TipoCita tipo, EstadoCita estado) {
+    public static void applyUpdate(Cita c, CitaUpdateDTO dto, TipoCita tipo, EstadoCita estado, TipoEspecialidad tipoEspecialidad) {
         if (dto.getMotivo() != null) c.setMotivo(dto.getMotivo());
         if (dto.getDescripcion() != null) c.setDescripcion(dto.getDescripcion());
         if (dto.getFecha() != null) c.setFecha(LocalDate.parse(dto.getFecha()));
@@ -37,6 +40,7 @@ public class CitaMapper {
         if (dto.getMedico() != null) c.setMedico(dto.getMedico());
         if (dto.getBebeId() != null) c.setBebeId(dto.getBebeId());
         if (tipo != null) c.setTipo(tipo);
+        if (tipoEspecialidad != null) c.setTipoEspecialidad(tipoEspecialidad);
         if (dto.getRecordatorioMinutos() != null) c.setRecordatorioMinutos(dto.getRecordatorioMinutos());
         if (estado != null) c.setEstado(estado);
     }
@@ -54,6 +58,9 @@ public class CitaMapper {
         b.medico(c.getMedico());
         if (c.getTipo() != null) {
             b.tipo(TipoCitaMapper.toDTO(c.getTipo()));
+        }
+        if (c.getTipoEspecialidad() != null) {
+            b.tipoEspecialidad(TipoEspecialidadMapper.toDTO(c.getTipoEspecialidad()));
         }
         if (c.getEstado() != null) {
             b.estado(EstadoCitaMapper.toDTO(c.getEstado()));

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoEspecialidadMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoEspecialidadMapper.java
@@ -1,0 +1,17 @@
+package com.babytrackmaster.api_citas.mapper;
+
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
+
+public class TipoEspecialidadMapper {
+
+    private TipoEspecialidadMapper() {}
+
+    public static TipoEspecialidadResponseDTO toDTO(TipoEspecialidad entity) {
+        if (entity == null) return null;
+        return TipoEspecialidadResponseDTO.builder()
+                .id(entity.getId())
+                .nombre(entity.getNombre())
+                .build();
+    }
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoEspecialidadRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/TipoEspecialidadRepository.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_citas.repository;
+
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipoEspecialidadRepository extends JpaRepository<TipoEspecialidad, Long> {
+    boolean existsByNombreIgnoreCase(String nombre);
+}


### PR DESCRIPTION
## Summary
- relate appointments with medical specialties
- expose specialty identifiers across appointment DTOs
- load and validate specialty in appointment service

## Testing
- `mvn -q -f api-citas/pom.xml test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf68cf6c90832790878b8212295172