### PR TITLE
Add TipoEspecialidad CRUD to citas service

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/config/DataInitializer.java
@@ -10,8 +10,10 @@ import lombok.RequiredArgsConstructor;
 
 import com.babytrackmaster.api_citas.entity.TipoCita;
 import com.babytrackmaster.api_citas.entity.EstadoCita;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
 import com.babytrackmaster.api_citas.repository.TipoCitaRepository;
 import com.babytrackmaster.api_citas.repository.EstadoCitaRepository;
+import com.babytrackmaster.api_citas.repository.TipoEspecialidadRepository;
 
 @Configuration
 @RequiredArgsConstructor
@@ -19,6 +21,7 @@ public class DataInitializer {
 
     private final TipoCitaRepository tipoCitaRepository;
     private final EstadoCitaRepository estadoCitaRepository;
+    private final TipoEspecialidadRepository tipoEspecialidadRepository;
 
     @Bean
     public CommandLineRunner loadInitialData() {
@@ -45,6 +48,16 @@ public class DataInitializer {
                     createEstadoCita("No asistida")
                 ));
             }
+            if (tipoEspecialidadRepository.count() == 0) {
+                tipoEspecialidadRepository.saveAll(List.of(
+                    createTipoEspecialidad("Pediatría general"),
+                    createTipoEspecialidad("Dermatología pediátrica"),
+                    createTipoEspecialidad("Cardiología pediátrica"),
+                    createTipoEspecialidad("Neurología pediátrica"),
+                    createTipoEspecialidad("Gastroenterología pediátrica"),
+                    createTipoEspecialidad("Otorrinolaringología pediátrica")
+                ));
+            }
         };
     }
 
@@ -59,5 +72,10 @@ public class DataInitializer {
         estado.setNombre(nombre);
         return estado;
     }
-}
 
+    private TipoEspecialidad createTipoEspecialidad(String nombre) {
+        TipoEspecialidad especialidad = new TipoEspecialidad();
+        especialidad.setNombre(nombre);
+        return especialidad;
+    }
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/TipoEspecialidadController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/TipoEspecialidadController.java
@@ -1,0 +1,55 @@
+package com.babytrackmaster.api_citas.controller;
+
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadUpdateDTO;
+import com.babytrackmaster.api_citas.service.TipoEspecialidadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Tipos de Especialidad", description = "Gestión de tipos de especialidad")
+@RestController
+@RequestMapping("/api/v1/tipos-especialidad")
+@RequiredArgsConstructor
+public class TipoEspecialidadController {
+
+    private final TipoEspecialidadService service;
+
+    @Operation(summary = "Crear tipo de especialidad")
+    @PostMapping
+    public ResponseEntity<TipoEspecialidadResponseDTO> crear(@Valid @RequestBody TipoEspecialidadCreateDTO dto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(service.crear(dto));
+    }
+
+    @Operation(summary = "Actualizar tipo de especialidad")
+    @PutMapping("/{id}")
+    public ResponseEntity<TipoEspecialidadResponseDTO> actualizar(@PathVariable Long id,
+            @Valid @RequestBody TipoEspecialidadUpdateDTO dto) {
+        return ResponseEntity.ok(service.actualizar(id, dto));
+    }
+
+    @Operation(summary = "Eliminar tipo de especialidad")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Obtener tipo de especialidad por id")
+    @GetMapping("/{id}")
+    public ResponseEntity<TipoEspecialidadResponseDTO> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtener(id));
+    }
+
+    @Operation(summary = "Listar todos los tipos de especialidad")
+    @GetMapping
+    public ResponseEntity<List<TipoEspecialidadResponseDTO>> listarTodos() {
+        return ResponseEntity.ok(service.listarTodos());
+    }
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadCreateDTO.java
@@ -1,0 +1,17 @@
+package com.babytrackmaster.api_citas.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TipoEspecialidadCreateDTO {
+
+    @Schema(example = "Dermatología pediátrica")
+    @NotBlank
+    @Size(max = 100)
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadUpdateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/TipoEspecialidadUpdateDTO.java
@@ -1,0 +1,13 @@
+package com.babytrackmaster.api_citas.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TipoEspecialidadUpdateDTO {
+
+    @Size(max = 100)
+    private String nombre;
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoEspecialidadMapper.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/mapper/TipoEspecialidadMapper.java
@@ -1,11 +1,25 @@
 package com.babytrackmaster.api_citas.mapper;
 
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadCreateDTO;
 import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadUpdateDTO;
 import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
 
 public class TipoEspecialidadMapper {
 
     private TipoEspecialidadMapper() {}
+
+    public static TipoEspecialidad toEntity(TipoEspecialidadCreateDTO dto) {
+        return TipoEspecialidad.builder()
+                .nombre(dto.getNombre())
+                .build();
+    }
+
+    public static void applyUpdate(TipoEspecialidad entity, TipoEspecialidadUpdateDTO dto) {
+        if (dto.getNombre() != null) {
+            entity.setNombre(dto.getNombre());
+        }
+    }
 
     public static TipoEspecialidadResponseDTO toDTO(TipoEspecialidad entity) {
         if (entity == null) return null;

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/TipoEspecialidadService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/TipoEspecialidadService.java
@@ -1,0 +1,14 @@
+package com.babytrackmaster.api_citas.service;
+
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadUpdateDTO;
+import java.util.List;
+
+public interface TipoEspecialidadService {
+    TipoEspecialidadResponseDTO crear(TipoEspecialidadCreateDTO dto);
+    TipoEspecialidadResponseDTO actualizar(Long id, TipoEspecialidadUpdateDTO dto);
+    void eliminar(Long id);
+    TipoEspecialidadResponseDTO obtener(Long id);
+    List<TipoEspecialidadResponseDTO> listarTodos();
+}

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/TipoEspecialidadServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/TipoEspecialidadServiceImpl.java
@@ -1,0 +1,69 @@
+package com.babytrackmaster.api_citas.service.impl;
+
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadCreateDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadResponseDTO;
+import com.babytrackmaster.api_citas.dto.TipoEspecialidadUpdateDTO;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
+import com.babytrackmaster.api_citas.exception.BadRequestException;
+import com.babytrackmaster.api_citas.exception.NotFoundException;
+import com.babytrackmaster.api_citas.mapper.TipoEspecialidadMapper;
+import com.babytrackmaster.api_citas.repository.TipoEspecialidadRepository;
+import com.babytrackmaster.api_citas.service.TipoEspecialidadService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TipoEspecialidadServiceImpl implements TipoEspecialidadService {
+
+    private final TipoEspecialidadRepository repo;
+
+    @Override
+    public TipoEspecialidadResponseDTO crear(TipoEspecialidadCreateDTO dto) {
+        if (repo.existsByNombreIgnoreCase(dto.getNombre())) {
+            throw new BadRequestException("Tipo de especialidad ya existe");
+        }
+        TipoEspecialidad entity = TipoEspecialidadMapper.toEntity(dto);
+        entity = repo.save(entity);
+        return TipoEspecialidadMapper.toDTO(entity);
+    }
+
+    @Override
+    public TipoEspecialidadResponseDTO actualizar(Long id, TipoEspecialidadUpdateDTO dto) {
+        TipoEspecialidad entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de especialidad no encontrado"));
+        if (dto.getNombre() != null && repo.existsByNombreIgnoreCase(dto.getNombre())
+                && !dto.getNombre().equalsIgnoreCase(entity.getNombre())) {
+            throw new BadRequestException("Tipo de especialidad ya existe");
+        }
+        TipoEspecialidadMapper.applyUpdate(entity, dto);
+        entity = repo.save(entity);
+        return TipoEspecialidadMapper.toDTO(entity);
+    }
+
+    @Override
+    public void eliminar(Long id) {
+        TipoEspecialidad entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de especialidad no encontrado"));
+        repo.delete(entity);
+    }
+
+    @Override
+    public TipoEspecialidadResponseDTO obtener(Long id) {
+        TipoEspecialidad entity = repo.findById(id)
+                .orElseThrow(() -> new NotFoundException("Tipo de especialidad no encontrado"));
+        return TipoEspecialidadMapper.toDTO(entity);
+    }
+
+    @Override
+    public List<TipoEspecialidadResponseDTO> listarTodos() {
+        List<TipoEspecialidad> list = repo.findAll();
+        List<TipoEspecialidadResponseDTO> res = new ArrayList<>();
+        for (int i = 0; i < list.size(); i++) {
+            res.add(TipoEspecialidadMapper.toDTO(list.get(i)));
+        }
+        return res;
+    }
+}


### PR DESCRIPTION
## Summary
- add DTOs, mapper, service and controller for TipoEspecialidad
- seed default specialties in DataInitializer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6a1f16608327832e1d8d4f2aa122