### PR TITLE
feat: add specialty support for citas

### DIFF
--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -11,7 +11,11 @@ import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import dayjs from 'dayjs';
 import { DatePicker, TimePicker } from '@mui/x-date-pickers';
-import { listarTipos, listarEstados } from '../../services/citasService';
+import {
+  listarTipos,
+  listarEstados,
+  listarEspecialidades,
+} from '../../services/citasService';
 import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function CitaForm({ open, onClose, onSubmit, initialData }) {
@@ -22,9 +26,11 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
     tipoId: '',
     centroMedico: '',
     estadoId: '',
+    especialidadId: '',
   });
   const [tipos, setTipos] = useState([]);
   const [estados, setEstados] = useState([]);
+  const [especialidades, setEspecialidades] = useState([]);
 
   useEffect(() => {
     if (initialData) {
@@ -35,6 +41,7 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
         tipoId: initialData.tipoId || '',
         centroMedico: initialData.centroMedico || '',
         estadoId: initialData.estadoId || '',
+        especialidadId: initialData.tipoEspecialidadId || '',
       });
     } else {
       setFormData({
@@ -44,6 +51,7 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
         tipoId: '',
         centroMedico: '',
         estadoId: '',
+        especialidadId: '',
       });
     }
   }, [initialData, open]);
@@ -59,12 +67,36 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
     }
   }, [initialData]);
 
+  useEffect(() => {
+    const selectedTipo = tipos.find(
+      (t) => Number(t.id) === Number(formData.tipoId)
+    );
+    if (selectedTipo && selectedTipo.nombre?.toLowerCase() === 'especialista') {
+      listarEspecialidades()
+        .then((response) => setEspecialidades(response.data))
+        .catch((err) =>
+          console.error('Error fetching tipos especialidad:', err)
+        );
+    } else {
+      setEspecialidades([]);
+      setFormData((prev) => ({ ...prev, especialidadId: '' }));
+    }
+  }, [formData.tipoId, tipos]);
+
   const handleChange = (name, value) => {
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   const handleSubmit = () => {
-    const { fecha, hora, motivo, tipoId, centroMedico, estadoId } = formData;
+    const {
+      fecha,
+      hora,
+      motivo,
+      tipoId,
+      centroMedico,
+      estadoId,
+      especialidadId,
+    } = formData;
     const data = {
       fecha: fecha ? fecha.format('YYYY-MM-DD') : '',
       hora: hora ? hora.format('HH:mm') : '',
@@ -72,6 +104,9 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
       tipoId,
       centroMedico,
     };
+    if (especialidadId) {
+      data.tipoEspecialidadId = especialidadId;
+    }
     if (initialData && initialData.id) {
       data.estadoId = estadoId;
     }
@@ -124,6 +159,23 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
                 ))}
               </TextField>
             </FormControl>
+            {especialidades.length > 0 && (
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Especialidad</FormLabel>
+                <TextField
+                  select
+                  name="especialidadId"
+                  value={formData.especialidadId}
+                  onChange={(e) => handleChange('especialidadId', e.target.value)}
+                >
+                  {especialidades.map((e) => (
+                    <MenuItem key={e.id} value={e.id}>
+                      {e.nombre}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </FormControl>
+            )}
             <FormControl fullWidth sx={{ mb: 2 }}>
               <FormLabel sx={{ mb: 1 }}>Centro médico (opcional)</FormLabel>
               <TextField

--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -86,6 +86,10 @@ export default function Citas() {
               tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
               estadoId: c.estado?.id ?? c.estadoId,
               estadoNombre: c.estado?.nombre ?? c.estadoNombre,
+              tipoEspecialidadId:
+                c.tipoEspecialidad?.id ?? c.tipoEspecialidadId,
+              tipoEspecialidadNombre:
+                c.tipoEspecialidad?.nombre ?? c.tipoEspecialidadNombre,
             }))
           );
         } else {

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -5,6 +5,7 @@ import { API_CITAS_URL } from '../config';
 const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
 const API_TIPOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-cita`;
 const API_ESTADOS_CITA_ENDPOINT = `${API_CITAS_URL}/api/v1/estados-cita`;
+const API_TIPOS_ESPECIALIDAD_ENDPOINT = `${API_CITAS_URL}/api/v1/tipos-especialidad`;
 
 export const listar = (bebeId, page, size) => {
   const params = {};
@@ -25,6 +26,9 @@ export const listarProximas = (bebeId, limite = 10) => {
         ...c,
         tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
         estadoNombre: c.estado?.nombre ?? c.estadoNombre,
+        tipoEspecialidadNombre:
+          c.tipoEspecialidad?.nombre ?? c.tipoEspecialidadNombre,
+        tipoEspecialidadId: c.tipoEspecialidad?.id ?? c.tipoEspecialidadId,
       }))
       .filter((c) => dayjs(`${c.fecha}T${c.hora}`) >= now)
       .sort((a, b) =>
@@ -68,6 +72,10 @@ export const listarTipos = () => {
 
 export const listarEstados = () => {
   return axios.get(`${API_ESTADOS_CITA_ENDPOINT}`);
+};
+
+export const listarEspecialidades = () => {
+  return axios.get(`${API_TIPOS_ESPECIALIDAD_ENDPOINT}`);
 };
 
 export const enviarRecordatorio = (id, minutosAntelacion) => {


### PR DESCRIPTION
## Summary
- include specialty endpoints and mapping in citas service
- allow selecting and submitting specialties in cita form
- map specialty data when fetching citas for editing

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68bf6abc98648327b3e55a488817d808