### PR TITLE
feat: add breastfeeding type tracking

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -85,5 +86,11 @@ public class AlimentacionController {
             @PathVariable Long usuarioId,
             @PathVariable Long bebeId) {
         return ResponseEntity.ok(service.stats(usuarioId, bebeId));
+    }
+
+    @Operation(summary = "Listar tipos de lactancia")
+    @GetMapping("/tipos-lactancia")
+    public ResponseEntity<List<TipoLactancia>> tiposLactancia() {
+        return ResponseEntity.ok(service.listarTiposLactancia());
     }
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -3,6 +3,7 @@ package com.babytrackmaster.api_alimentacion.dto;
 import java.util.Date;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -19,13 +20,16 @@ public class AlimentacionRequest {
     // Lactancia
     private String lado;
     private Integer duracionMin;
+    private TipoLactancia tipoLactancia;
 
     // Biberon
     private String tipoLeche;
     private Integer cantidadMl;
+    private Integer cantidadLecheFormula;
 
     // Solidos
     private String alimento;
     private String cantidad;
+    private Integer cantidadOtrosAlimentos;
     private String observaciones;
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
@@ -3,6 +3,7 @@ package com.babytrackmaster.api_alimentacion.dto;
 import java.util.Date;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -18,10 +19,13 @@ public class AlimentacionResponse {
     private Date fechaHora;
     private String lado;
     private Integer duracionMin;
+    private TipoLactancia tipoLactancia;
     private String tipoLeche;
     private Integer cantidadMl;
+    private Integer cantidadLecheFormula;
     private String alimento;
     private String cantidad;
+    private Integer cantidadOtrosAlimentos;
     private String observaciones;
     private Date createdAt;
     private Date updatedAt;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
@@ -34,13 +34,19 @@ public class Alimentacion {
     private String lado; // IZQ/DER
     private Integer duracionMin;
 
+    @ManyToOne
+    @JoinColumn(name = "tipo_lactancia_id")
+    private TipoLactancia tipoLactancia;
+
     // Biberon
     private String tipoLeche;
     private Integer cantidadMl;
+    private Integer cantidadLecheFormula;
 
     // Solidos
     private String alimento;
     private String cantidad;
+    private Integer cantidadOtrosAlimentos;
     private String observaciones;
 
     @Column(nullable = false)

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoLactancia.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoLactancia.java
@@ -1,0 +1,19 @@
+package com.babytrackmaster.api_alimentacion.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "tipo_lactancia")
+public class TipoLactancia {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String nombre;
+}

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
@@ -17,10 +17,13 @@ public class AlimentacionMapper {
         a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : now);
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
+        a.setTipoLactancia(req.getTipoLactancia());
         a.setTipoLeche(req.getTipoLeche());
         a.setCantidadMl(req.getCantidadMl());
+        a.setCantidadLecheFormula(req.getCantidadLecheFormula());
         a.setAlimento(req.getAlimento());
         a.setCantidad(req.getCantidad());
+        a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setObservaciones(req.getObservaciones());
         a.setCreatedAt(now);
         a.setUpdatedAt(now);
@@ -33,10 +36,13 @@ public class AlimentacionMapper {
         a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : a.getFechaHora());
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
+        a.setTipoLactancia(req.getTipoLactancia());
         a.setTipoLeche(req.getTipoLeche());
         a.setCantidadMl(req.getCantidadMl());
+        a.setCantidadLecheFormula(req.getCantidadLecheFormula());
         a.setAlimento(req.getAlimento());
         a.setCantidad(req.getCantidad());
+        a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setObservaciones(req.getObservaciones());
         a.setUpdatedAt(new Date());
     }
@@ -50,10 +56,13 @@ public class AlimentacionMapper {
         r.setFechaHora(a.getFechaHora());
         r.setLado(a.getLado());
         r.setDuracionMin(a.getDuracionMin());
+        r.setTipoLactancia(a.getTipoLactancia());
         r.setTipoLeche(a.getTipoLeche());
         r.setCantidadMl(a.getCantidadMl());
+        r.setCantidadLecheFormula(a.getCantidadLecheFormula());
         r.setAlimento(a.getAlimento());
         r.setCantidad(a.getCantidad());
+        r.setCantidadOtrosAlimentos(a.getCantidadOtrosAlimentos());
         r.setObservaciones(a.getObservaciones());
         r.setCreatedAt(a.getCreatedAt());
         r.setUpdatedAt(a.getUpdatedAt());

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoLactanciaRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoLactanciaRepository.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_alimentacion.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+
+public interface TipoLactanciaRepository extends JpaRepository<TipoLactancia, Long> {
+}

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
 
 public interface AlimentacionService {
     AlimentacionResponse crear(Long usuarioId, Long bebeId, AlimentacionRequest request);
@@ -13,4 +14,5 @@ public interface AlimentacionService {
     AlimentacionResponse obtener(Long usuarioId, Long bebeId, Long id);
     List<AlimentacionResponse> listar(Long usuarioId, Long bebeId);
     AlimentacionStatsResponse stats(Long usuarioId, Long bebeId);
+    List<TipoLactancia> listarTiposLactancia();
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
@@ -13,8 +13,10 @@ import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
 import com.babytrackmaster.api_alimentacion.entity.Alimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
 import com.babytrackmaster.api_alimentacion.mapper.AlimentacionMapper;
 import com.babytrackmaster.api_alimentacion.repository.AlimentacionRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoLactanciaRepository;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 @Service
@@ -22,9 +24,11 @@ import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 public class AlimentacionServiceImpl implements AlimentacionService {
 
     private final AlimentacionRepository repo;
+    private final TipoLactanciaRepository tipoLactanciaRepo;
 
-    public AlimentacionServiceImpl(AlimentacionRepository repo) {
+    public AlimentacionServiceImpl(AlimentacionRepository repo, TipoLactanciaRepository tipoLactanciaRepo) {
         this.repo = repo;
+        this.tipoLactanciaRepo = tipoLactanciaRepo;
     }
 
     public AlimentacionResponse crear(Long usuarioId, Long bebeId, AlimentacionRequest request) {
@@ -64,6 +68,11 @@ public class AlimentacionServiceImpl implements AlimentacionService {
             resp.add(AlimentacionMapper.toResponse(a));
         }
         return resp;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TipoLactancia> listarTiposLactancia() {
+        return tipoLactanciaRepo.findAll();
     }
 
     @Transactional(readOnly = true)

--- a/api-alimentacion/src/main/resources/schema.sql
+++ b/api-alimentacion/src/main/resources/schema.sql
@@ -1,3 +1,17 @@
+CREATE TABLE IF NOT EXISTS tipo_lactancia (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(50) NOT NULL UNIQUE
+);
+
+INSERT INTO tipo_lactancia (id, nombre) VALUES
+    (1,'complementaria'),
+    (2,'diferida'),
+    (3,'directa'),
+    (4,'tandem'),
+    (5,'exclusiva'),
+    (6,'mixta'),
+    (7,'predominante');
+
 CREATE TABLE IF NOT EXISTS alimentacion (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     usuario_id BIGINT NOT NULL,
@@ -6,10 +20,13 @@ CREATE TABLE IF NOT EXISTS alimentacion (
     fecha_hora TIMESTAMP NOT NULL,
     lado VARCHAR(10),
     duracion_min INT,
+    tipo_lactancia_id BIGINT,
     tipo_leche VARCHAR(30),
     cantidad_ml INT,
+    cantidad_leche_formula INT,
     alimento VARCHAR(100),
     cantidad VARCHAR(50),
+    cantidad_otros_alimentos INT,
     observaciones VARCHAR(255),
     eliminado BOOLEAN NOT NULL,
     created_at TIMESTAMP NOT NULL,

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
@@ -45,6 +45,13 @@ class AlimentacionControllerTest {
     }
 
     @Test
+    void tiposLactanciaDevuelveOk() throws Exception {
+        when(service.listarTiposLactancia()).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/alimentacion/tipos-lactancia"))
+               .andExpect(status().isOk());
+    }
+
+    @Test
     void crearDevuelveCreated() throws Exception {
         AlimentacionRequest req = new AlimentacionRequest();
         req.setTipo(TipoAlimentacion.BIBERON);

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
@@ -19,6 +19,7 @@ import com.babytrackmaster.api_alimentacion.entity.Alimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.mapper.AlimentacionMapper;
 import com.babytrackmaster.api_alimentacion.repository.AlimentacionRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoLactanciaRepository;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 @SpringBootTest
@@ -26,6 +27,9 @@ class AlimentacionServiceImplTest {
 
     @MockBean
     private AlimentacionRepository repo;
+
+    @MockBean
+    private TipoLactanciaRepository tipoLactanciaRepo;
 
     @Autowired
     private AlimentacionService service;


### PR DESCRIPTION
## Summary
- create TipoLactancia entity with repository
- extend Alimentacion with lactation type and new quantity fields
- expose endpoint to list breast feeding types and update schema

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7db4b1a483278c691e6b1cc87b1e