### PR TITLE
Reorganiza menú principal y elimina icono Trending

### DIFF
--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -8,7 +8,6 @@ import ListItemText from '@mui/material/ListItemText';
 import Stack from '@mui/material/Stack';
 import HomeRoundedIcon from '@mui/icons-material/HomeRounded';
 import MedicalServicesRoundedIcon from '@mui/icons-material/MedicalServicesRounded';
-import TrendingUpRoundedIcon from '@mui/icons-material/TrendingUpRounded';
 import MonetizationOnRoundedIcon from '@mui/icons-material/MonetizationOnRounded';
 import MenuBookRoundedIcon from '@mui/icons-material/MenuBookRounded';
 import RamenDiningRoundedIcon from '@mui/icons-material/RamenDiningRounded';
@@ -21,14 +20,13 @@ import InfoRoundedIcon from '@mui/icons-material/InfoRounded';
 
 const mainListItems = [
   { text: 'Inicio', icon: <HomeRoundedIcon />, to: '/dashboard' },
-  { text: 'Cuidados', icon: <MedicalServicesRoundedIcon />, to: '/dashboard/cuidados' },
-  { text: 'Crecimiento', icon: <TrendingUpRoundedIcon />, to: '/dashboard/crecimiento' },
-  { text: 'Gastos', icon: <MonetizationOnRoundedIcon />, to: '/dashboard/gastos' },
-  { text: 'Diario', icon: <MenuBookRoundedIcon />, to: '/dashboard/diario' },
   { text: 'Alimentación', icon: <RamenDiningRoundedIcon />, to: '/dashboard/alimentacion' },
+  { text: 'Crecimiento', icon: <BarChartRoundedIcon />, to: '/dashboard/crecimiento' },
+  { text: 'Cuidados', icon: <MedicalServicesRoundedIcon />, to: '/dashboard/cuidados' },
+  { text: 'Gastos', icon: <MonetizationOnRoundedIcon />, to: '/dashboard/gastos' },
   { text: 'Citas', icon: <EventRoundedIcon />, to: '/dashboard/citas' },
   { text: 'Rutinas', icon: <ScheduleRoundedIcon />, to: '/dashboard/rutinas' },
-  { text: 'Crecimiento', icon: <BarChartRoundedIcon />, to: '/dashboard/crecimiento' },
+  { text: 'Diario', icon: <MenuBookRoundedIcon />, to: '/dashboard/diario' },
 ];
 
 const secondaryListItems = [


### PR DESCRIPTION
## Summary
- Reordena las opciones del menú principal con el orden solicitado
- Usa BarChartRoundedIcon para el único item "Crecimiento" y elimina TrendingUpRoundedIcon

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c00b3e971483278b5a6364d1ea129b