### PR TITLE
feat: agrega paleta pastel para gráficos

### DIFF
--- a/frontend-baby/src/dashboard/theme/customizations/charts.js
+++ b/frontend-baby/src/dashboard/theme/customizations/charts.js
@@ -1,9 +1,14 @@
 import { axisClasses, legendClasses, chartsGridClasses } from '@mui/x-charts';
 
-import { gray } from '../../../shared-theme/themePrimitives';
+import { gray, chartPastel } from '../../../shared-theme/themePrimitives';
 
 /* eslint-disable import/prefer-default-export */
 export const chartsCustomizations = {
+  MuiCharts: {
+    defaultProps: {
+      colors: Object.values(chartPastel),
+    },
+  },
   MuiChartsAxis: {
     styleOverrides: {
       root: ({ theme }) => ({

--- a/frontend-baby/src/dashboard/theme/customizations/charts.ts
+++ b/frontend-baby/src/dashboard/theme/customizations/charts.ts
@@ -1,10 +1,15 @@
 import { Theme } from '@mui/material/styles';
 import { axisClasses, legendClasses, chartsGridClasses } from '@mui/x-charts';
 import type { ChartsComponents } from '@mui/x-charts/themeAugmentation';
-import { gray } from '../../../shared-theme/themePrimitives';
+import { gray, chartPastel } from '../../../shared-theme/themePrimitives';
 
 /* eslint-disable import/prefer-default-export */
 export const chartsCustomizations: ChartsComponents<Theme> = {
+  MuiCharts: {
+    defaultProps: {
+      colors: Object.values(chartPastel),
+    },
+  },
   MuiChartsAxis: {
     styleOverrides: {
       root: ({ theme }) => ({

--- a/frontend-baby/src/shared-theme/themePrimitives.js
+++ b/frontend-baby/src/shared-theme/themePrimitives.js
@@ -69,6 +69,13 @@ export const red = {
   900: 'hsl(0, 93%, 6%)',
 };
 
+export const chartPastel = {
+  babyBlue: '#A2D2FF',
+  babyPink: '#FFC6FF',
+  mint: '#CDEAC0',
+  softYellow: '#FFF5BA',
+};
+
 export const getDesignTokens = (mode) => {
   customShadows[1] =
     mode === 'dark'
@@ -135,6 +142,7 @@ export const getDesignTokens = (mode) => {
       grey: {
         ...gray,
       },
+      chart: chartPastel,
       divider: mode === 'dark' ? alpha(gray[700], 0.6) : alpha(gray[300], 0.4),
       background: {
         default: 'hsl(0, 0%, 99%)',

--- a/frontend-baby/src/shared-theme/themePrimitives.ts
+++ b/frontend-baby/src/shared-theme/themePrimitives.ts
@@ -21,8 +21,21 @@ declare module '@mui/material/styles' {
 
   interface PaletteColor extends ColorRange {}
 
+  interface ChartPalette {
+    babyBlue: string;
+    babyPink: string;
+    mint: string;
+    softYellow: string;
+  }
+
   interface Palette {
     baseShadow: string;
+    chart: ChartPalette;
+  }
+
+  interface PaletteOptions {
+    baseShadow?: string;
+    chart?: ChartPalette;
   }
 }
 
@@ -95,6 +108,13 @@ export const red = {
   900: 'hsl(0, 93%, 6%)',
 };
 
+export const chartPastel: ChartPalette = {
+  babyBlue: '#A2D2FF',
+  babyPink: '#FFC6FF',
+  mint: '#CDEAC0',
+  softYellow: '#FFF5BA',
+};
+
 export const getDesignTokens = (mode: PaletteMode) => {
   customShadows[1] =
     mode === 'dark'
@@ -161,6 +181,7 @@ export const getDesignTokens = (mode: PaletteMode) => {
       grey: {
         ...gray,
       },
+      chart: chartPastel,
       divider: mode === 'dark' ? alpha(gray[700], 0.6) : alpha(gray[300], 0.4),
       background: {
         default: 'hsl(0, 0%, 99%)',


### PR DESCRIPTION
## Summary
- define paleta `chartPastel` y la integra al theme
- aplica la paleta como colores por defecto en series de charts

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c025ab970883279f512dd9f809724b