### PR TITLE
feat(frontend): allow disabling tipo field in CuidadoForm

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -16,6 +16,7 @@ import { listarTipos } from '../../services/cuidadosService';
 import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
+  const disableTipo = initialData?.disableTipo;
   const [formData, setFormData] = useState({
     inicio: null,
     tipoId: "",
@@ -104,6 +105,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
               name="tipoId"
               value={formData.tipoId}
               onChange={handleChange}
+              disabled={disableTipo}
             >
               {tipoOptions.map((option) => (
                 <MenuItem key={option.id} value={option.id}>


### PR DESCRIPTION
## Summary
- use optional `disableTipo` flag from initial data
- pass `disableTipo` to tipo selector to disable selection when needed

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c042daa9388327b7eafc4ab6d9d45c