### PR TITLE
Prefill cuidado type from navigation

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -104,7 +104,7 @@ export default function Cuidados() {
         (t) => t.nombre.toLowerCase() === location.state.tipo.toLowerCase(),
       );
       if (tipo) {
-        setSelectedCuidado({ tipoId: tipo.id });
+        setSelectedCuidado({ tipoId: tipo.id, disableTipo: true });
         setOpenForm(true);
       }
     }


### PR DESCRIPTION
## Summary
- Preselect cuidado type when coming from navigation and lock type field

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c044b43a088327af6e2a11291b783f