### PR TITLE
feat: add inicio validation in cuidado form

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -69,9 +69,12 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   };
 
   const handleSubmit = () => {
+    if (!formData.inicio) return;
     const payload = {
       ...formData,
-      inicio: formData.inicio ? formData.inicio.format("YYYY-MM-DDTHH:mm") : "",
+      inicio: formData.inicio
+        ? formData.inicio.format("YYYY-MM-DDTHH:mm")
+        : "",
     };
     onSubmit(payload);
   };
@@ -95,7 +98,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             <DateTimePicker
               value={formData.inicio}
               onChange={handleInicioChange}
-              slotProps={{ textField: { fullWidth: true } }}
+              slotProps={{ textField: { fullWidth: true, required: true } }}
             />
           </FormControl>
           <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- mark Cuidado form datetime field as required
- avoid submit when inicio datetime is missing

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c04a76d0208327a06d3bd8b976110d