### PR TITLE
Enforce required date in growth form

### DIFF
--- a/frontend-baby/src/dashboard/components/CrecimientoForm.js
+++ b/frontend-baby/src/dashboard/components/CrecimientoForm.js
@@ -73,6 +73,7 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
   };
 
   const handleSubmit = () => {
+    if (!formData.fecha) return;
     const payload = {
       ...formData,
       fecha: formData.fecha ? formData.fecha.format('YYYY-MM-DD') : '',
@@ -93,7 +94,7 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
             <DatePicker
               value={formData.fecha}
               onChange={handleFechaChange}
-              slotProps={{ textField: { fullWidth: true } }}
+              slotProps={{ textField: { fullWidth: true, required: true } }}
             />
           </FormControl>
           <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- set growth DatePicker to required using slotProps
- guard growth form submission when date is missing

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c04b7ffea083278605ed729a012fd1