### PR TITLE
Use theme text color for welcome banner content

### DIFF
--- a/frontend-baby/src/dashboard/components/WelcomeBanner.js
+++ b/frontend-baby/src/dashboard/components/WelcomeBanner.js
@@ -37,6 +37,7 @@ export default function WelcomeBanner() {
         <Box
           sx={(theme) => ({
             backgroundColor: theme.palette.background.paper,
+            color: theme.palette.text.primary,
             borderRadius: 2,
             p: 2,
             display: 'flex',
@@ -46,14 +47,19 @@ export default function WelcomeBanner() {
           })}
         >
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <WavingHandRoundedIcon />
-            <Typography component="h2" variant="subtitle2" sx={{ fontWeight: 600 }}>
+            <WavingHandRoundedIcon color="inherit" />
+            <Typography
+              component="h2"
+              variant="subtitle2"
+              sx={{ fontWeight: 600 }}
+              color="inherit"
+            >
               {greeting}
             </Typography>
-            <Typography>{summary}</Typography>
+            <Typography color="inherit">{summary}</Typography>
           </Box>
-          <IconButton>
-            <FavoriteBorderIcon />
+          <IconButton color="inherit">
+            <FavoriteBorderIcon color="primary" />
           </IconButton>
         </Box>
       </CardContent>


### PR DESCRIPTION
## Summary
- use theme `text.primary` color in `WelcomeBanner` and inherit for content
- highlight favorite icon with primary color for better contrast

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c05087f6988327accdf158270e52ad