### PR TITLE
Use proximas citas endpoint and handle dashboard errors

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -13,17 +13,20 @@ import { listarProximas } from '../../services/citasService';
 
 export default function UpcomingAppointmentsCard() {
   const [appointments, setAppointments] = useState([]);
+  const [error, setError] = useState(null);
   const { activeBaby } = React.useContext(BabyContext);
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!activeBaby?.id) return;
     listarProximas(activeBaby.id)
-      .then((data) => {
-        setAppointments(data);
+      .then((response) => {
+        setAppointments(response.data);
+        setError(null);
       })
       .catch((err) => {
         console.error('Error fetching citas:', err);
+        setError('Error al cargar las citas.');
         setAppointments([]);
       });
   }, [activeBaby]);
@@ -45,7 +48,11 @@ export default function UpcomingAppointmentsCard() {
         <Typography variant="h6" component="h2" gutterBottom>
           <CalendarMonthIcon sx={{ mr: 1 }} /> Próximas Citas
         </Typography>
-        {appointments.length > 0 ? (
+        {error ? (
+          <Typography variant="body2" color="error">
+            {error}
+          </Typography>
+        ) : appointments.length > 0 ? (
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             {appointments.map((c) => {
               const appointmentDate = dayjs(`${c.fecha}T${c.hora}`);

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import dayjs from 'dayjs';
 import { API_CITAS_URL } from '../config';
 
 const API_CITAS_ENDPOINT = `${API_CITAS_URL}/api/v1/citas`;
@@ -14,27 +13,12 @@ export const listar = (bebeId, page, size) => {
   return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`, { params });
 };
 
-export const listarProximas = (bebeId, limite = 10) => {
-  return listar(bebeId, 0, 100).then((response) => {
-    const items = Array.isArray(response.data)
-      ? response.data
-      : response.data?.content;
-    if (!Array.isArray(items)) return [];
-    const now = dayjs();
-    return items
-      .map((c) => ({
-        ...c,
-        tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
-        estadoNombre: c.estado?.nombre ?? c.estadoNombre,
-        tipoEspecialidadNombre:
-          c.tipoEspecialidad?.nombre ?? c.tipoEspecialidadNombre,
-        tipoEspecialidadId: c.tipoEspecialidad?.id ?? c.tipoEspecialidadId,
-      }))
-      .filter((c) => dayjs(`${c.fecha}T${c.hora}`) >= now)
-      .sort((a, b) =>
-        dayjs(`${a.fecha}T${a.hora}`).diff(dayjs(`${b.fecha}T${b.hora}`))
-      )
-      .slice(0, limite);
+export const listarProximas = (usuarioId, limite = 10) => {
+  return axios.get(`${API_CITAS_ENDPOINT}/proximas`, {
+    params: {
+      usuarioId,
+      limit: limite,
+    },
   });
 };
 


### PR DESCRIPTION
## Summary
- Fetch upcoming appointments from `/api/v1/citas/proximas` with `usuarioId` and `limit`
- Display server-provided upcoming appointments without client filtering and show explicit error messages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c063a5eb888327a3f8395a23a0a7ad