### PR TITLE
Filtrar próximas citas por bebé

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/controller/CitaController.java
@@ -122,8 +122,8 @@ public class CitaController {
 
         @Operation(summary = "Listar próximas citas")
         @GetMapping("/proximas")
-        public ResponseEntity<List<CitaResponseDTO>> proximas(@RequestParam int limit) {
+        public ResponseEntity<List<CitaResponseDTO>> proximas(@RequestParam Long bebeId, @RequestParam int limit) {
                 Long usuarioId = jwtService.resolveUserId();
-                return ResponseEntity.ok(service.proximas(usuarioId, limit));
+                return ResponseEntity.ok(service.proximas(usuarioId, bebeId, limit));
         }
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/repository/CitaRepository.java
@@ -47,10 +47,11 @@ public interface CitaRepository extends JpaRepository<Cita, Long> {
                              @Param("bebeId") Long bebeId,
                              Pageable pageable);
 
-    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.eliminado = false and " +
+    @Query("select c from Cita c where c.usuarioId = :usuarioId and c.bebeId = :bebeId and c.eliminado = false and " +
            "(c.fecha > :hoy or (c.fecha = :hoy and c.hora >= :hora)) " +
            "order by c.fecha asc, c.hora asc")
     List<Cita> proximas(@Param("usuarioId") Long usuarioId,
+                        @Param("bebeId") Long bebeId,
                         @Param("hoy") LocalDate hoy,
                         @Param("hora") LocalTime hora);
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/CitaService.java
@@ -18,5 +18,5 @@ public interface CitaService {
     Page<CitaResponseDTO> listarPorMedico(Long usuarioId, String medico, int page, int size);
     Page<CitaResponseDTO> listarPorBebe(Long usuarioId, Long bebeId, int page, int size);
     void enviarRecordatorio(Long id, Long usuarioId, Integer minutosAntelacion);
-    List<CitaResponseDTO> proximas(Long usuarioId, int limit);
+    List<CitaResponseDTO> proximas(Long usuarioId, Long bebeId, int limit);
 }

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -201,8 +201,8 @@ public class CitaServiceImpl implements CitaService {
     }
 
     @Override
-    public List<CitaResponseDTO> proximas(Long usuarioId, int limit) {
-        List<Cita> citas = repo.proximas(usuarioId, LocalDate.now(), LocalTime.now());
+    public List<CitaResponseDTO> proximas(Long usuarioId, Long bebeId, int limit) {
+        List<Cita> citas = repo.proximas(usuarioId, bebeId, LocalDate.now(), LocalTime.now());
         if (limit > 0 && citas.size() > limit) {
             citas = citas.subList(0, limit);
         }

--- a/frontend-baby/src/services/citasService.js
+++ b/frontend-baby/src/services/citasService.js
@@ -13,10 +13,10 @@ export const listar = (bebeId, page, size) => {
   return axios.get(`${API_CITAS_ENDPOINT}/bebe/${bebeId}`, { params });
 };
 
-export const listarProximas = (usuarioId, limite = 10) => {
+export const listarProximas = (bebeId, limite = 10) => {
   return axios.get(`${API_CITAS_ENDPOINT}/proximas`, {
     params: {
-      usuarioId,
+      bebeId,
       limit: limite,
     },
   });


### PR DESCRIPTION
## Summary
- Filtra las próximas citas por bebé en el repositorio y el servicio.
- Ajusta el endpoint y servicio para recibir `bebeId` y reenvía el parámetro al repositorio.
- Actualiza el servicio de frontend para solicitar las próximas citas solo con el `bebeId`.

## Testing
- ⚠️ `bash ./mvnw -q test` (falló: Non-resolvable parent POM, Network is unreachable)
- ✅ `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c09fbeb6b08327ae8264cd5e4ef217