### PR TITLE
Use citasService for upcoming appointments in dashboard

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
@@ -9,9 +9,26 @@ import HighlightedCard from './HighlightedCard';
 import QuickActionsCard from './QuickActionsCard';
 import StatsOverview from './StatsOverview';
 import { BabyContext } from '../../context/BabyContext';
+import { listarProximas } from '../../services/citasService';
 
 export default function MainGrid() {
-  const { babies } = useContext(BabyContext);
+  const { babies, activeBaby } = useContext(BabyContext);
+  const [appointments, setAppointments] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!activeBaby?.id) return;
+    listarProximas(activeBaby.id)
+      .then((response) => {
+        setAppointments(response.data);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error('Error fetching citas:', err);
+        setError('Error al cargar las citas.');
+        setAppointments([]);
+      });
+  }, [activeBaby]);
 
   if (babies.length === 0) {
     return <Navigate to="/dashboard/inicio" replace />;
@@ -42,7 +59,7 @@ export default function MainGrid() {
               <RecentCareCard />
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
-              <UpcomingAppointmentsCard />
+              <UpcomingAppointmentsCard appointments={appointments} error={error} />
             </Grid>
           </Grid>
         </Grid>

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
@@ -8,28 +8,9 @@ import Button from '@mui/material/Button';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
-import { BabyContext } from '../../context/BabyContext';
-import { listarProximas } from '../../services/citasService';
 
-export default function UpcomingAppointmentsCard() {
-  const [appointments, setAppointments] = useState([]);
-  const [error, setError] = useState(null);
-  const { activeBaby } = React.useContext(BabyContext);
+export default function UpcomingAppointmentsCard({ appointments = [], error }) {
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!activeBaby?.id) return;
-    listarProximas(activeBaby.id)
-      .then((response) => {
-        setAppointments(response.data);
-        setError(null);
-      })
-      .catch((err) => {
-        console.error('Error fetching citas:', err);
-        setError('Error al cargar las citas.');
-        setAppointments([]);
-      });
-  }, [activeBaby]);
 
   const getTipoColor = (tipo) => {
     switch (tipo?.toLowerCase()) {


### PR DESCRIPTION
## Summary
- fetch upcoming appointments for active baby using `citasService.listarProximas`
- display fetched appointments and errors through `UpcomingAppointmentsCard`
- remove obsolete home service usage

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0a990f9ac8327904ab24e564e87ec