### PR TITLE
Allow creating citas without specialty

### DIFF
--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/dto/CitaCreateDTO.java
@@ -44,8 +44,7 @@ public class CitaCreateDTO {
     @NotNull
     private Long tipoId;
 
-    @Schema(example = "1")
-    @NotNull
+    @Schema(example = "1", description = "Identificador del tipo de especialidad (opcional)")
     private Long tipoEspecialidadId;
 
     @Schema(example = "30")

--- a/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
+++ b/api-citas/src/main/java/com/babytrackmaster/api_citas/service/impl/CitaServiceImpl.java
@@ -32,8 +32,11 @@ public class CitaServiceImpl implements CitaService {
     public CitaResponseDTO crear(CitaCreateDTO dto, Long usuarioId) {
         TipoCita tipo = tipoRepo.findById(dto.getTipoId())
                 .orElseThrow(() -> new NotFoundException("Tipo de cita no encontrado"));
-        TipoEspecialidad tipoEspecialidad = especialidadRepo.findById(dto.getTipoEspecialidadId())
-                .orElseThrow(() -> new NotFoundException("Tipo de especialidad no encontrado"));
+        TipoEspecialidad tipoEspecialidad = null;
+        if (dto.getTipoEspecialidadId() != null) {
+            tipoEspecialidad = especialidadRepo.findById(dto.getTipoEspecialidadId())
+                    .orElseThrow(() -> new NotFoundException("Tipo de especialidad no encontrado"));
+        }
         EstadoCita estado = estadoRepo.findByNombreIgnoreCase("Programada")
                 .orElseThrow(() -> new NotFoundException("Estado de cita por defecto no encontrado"));
         Cita c = CitaMapper.toEntity(dto, usuarioId, tipo, estado, tipoEspecialidad);

--- a/api-citas/src/test/java/com/babytrackmaster/api_citas/service/CitaServiceImplTest.java
+++ b/api-citas/src/test/java/com/babytrackmaster/api_citas/service/CitaServiceImplTest.java
@@ -1,0 +1,115 @@
+package com.babytrackmaster.api_citas.service;
+
+import com.babytrackmaster.api_citas.dto.CitaCreateDTO;
+import com.babytrackmaster.api_citas.dto.CitaResponseDTO;
+import com.babytrackmaster.api_citas.entity.Cita;
+import com.babytrackmaster.api_citas.entity.EstadoCita;
+import com.babytrackmaster.api_citas.entity.TipoCita;
+import com.babytrackmaster.api_citas.entity.TipoEspecialidad;
+import com.babytrackmaster.api_citas.exception.NotFoundException;
+import com.babytrackmaster.api_citas.repository.CitaRepository;
+import com.babytrackmaster.api_citas.repository.EstadoCitaRepository;
+import com.babytrackmaster.api_citas.repository.TipoCitaRepository;
+import com.babytrackmaster.api_citas.repository.TipoEspecialidadRepository;
+import com.babytrackmaster.api_citas.service.impl.CitaServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CitaServiceImplTest {
+
+    @Mock
+    private CitaRepository repo;
+    @Mock
+    private TipoCitaRepository tipoRepo;
+    @Mock
+    private EstadoCitaRepository estadoRepo;
+    @Mock
+    private TipoEspecialidadRepository especialidadRepo;
+
+    @InjectMocks
+    private CitaServiceImpl service;
+
+    private CitaCreateDTO buildDto() {
+        CitaCreateDTO dto = new CitaCreateDTO();
+        dto.setMotivo("Chequeo");
+        dto.setFecha("2025-01-01");
+        dto.setHora("10:00");
+        dto.setBebeId(1L);
+        dto.setTipoId(2L);
+        return dto;
+    }
+
+    private void mockCommonDependencies() {
+        TipoCita tipo = new TipoCita();
+        tipo.setId(2L);
+        tipo.setNombre("General");
+        when(tipoRepo.findById(2L)).thenReturn(Optional.of(tipo));
+
+        EstadoCita estado = new EstadoCita();
+        estado.setId(3L);
+        estado.setNombre("Programada");
+        when(estadoRepo.findByNombreIgnoreCase("Programada")).thenReturn(Optional.of(estado));
+
+        when(repo.save(any(Cita.class))).thenAnswer(inv -> {
+            Cita c = inv.getArgument(0);
+            c.setId(99L);
+            return c;
+        });
+    }
+
+    @Test
+    void crearSinEspecialidad() {
+        CitaCreateDTO dto = buildDto();
+        mockCommonDependencies();
+
+        CitaResponseDTO res = service.crear(dto, 10L);
+
+        ArgumentCaptor<Cita> captor = ArgumentCaptor.forClass(Cita.class);
+        verify(repo).save(captor.capture());
+        assertNull(captor.getValue().getTipoEspecialidad());
+        assertNull(res.getTipoEspecialidad());
+    }
+
+    @Test
+    void crearConEspecialidad() {
+        CitaCreateDTO dto = buildDto();
+        dto.setTipoEspecialidadId(5L);
+        mockCommonDependencies();
+
+        TipoEspecialidad esp = new TipoEspecialidad();
+        esp.setId(5L);
+        esp.setNombre("Pediatría");
+        when(especialidadRepo.findById(5L)).thenReturn(Optional.of(esp));
+
+        CitaResponseDTO res = service.crear(dto, 10L);
+
+        ArgumentCaptor<Cita> captor = ArgumentCaptor.forClass(Cita.class);
+        verify(repo).save(captor.capture());
+        assertNotNull(captor.getValue().getTipoEspecialidad());
+        assertNotNull(res.getTipoEspecialidad());
+        assertEquals(5L, res.getTipoEspecialidad().getId());
+    }
+
+    @Test
+    void crearEspecialidadNoEncontradaLanzaExcepcion() {
+        CitaCreateDTO dto = buildDto();
+        dto.setTipoEspecialidadId(7L);
+        mockCommonDependencies();
+
+        when(especialidadRepo.findById(7L)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> service.crear(dto, 10L));
+    }
+}
+


### PR DESCRIPTION
## Summary
- make `tipoEspecialidadId` optional in `CitaCreateDTO`
- load `TipoEspecialidad` in `CitaServiceImpl.crear` only when provided
- add unit tests covering cita creation with and without specialty

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aba8a2b88327b820a0db1dab233a