### PR TITLE
feat: improve upcoming appointments display

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -40,19 +40,19 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
               const today = dayjs();
               let formattedDate;
               if (appointmentDate.isSame(today, 'day')) {
-                formattedDate = 'Hoy';
+                formattedDate = `Hoy ${appointmentDate.format('hh:mm A')}`;
               } else if (appointmentDate.diff(today, 'day') === 1) {
-                formattedDate = 'Mañana';
+                formattedDate = `Mañana ${appointmentDate.format('hh:mm A')}`;
               } else {
-                formattedDate = appointmentDate.format('DD/MM/YYYY HH:mm');
+                formattedDate = appointmentDate.format('DD/MM/YYYY hh:mm A');
               }
               return (
                 <Card key={c.id} variant="outlined" sx={{ bgcolor: 'success.light', mb: 1 }}>
                   <CardContent sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                     <Box>
-                      <Typography variant="body1">{c.motivo}</Typography>
+                      <Typography variant="body1">{formattedDate}</Typography>
                       <Typography variant="body2" color="text.secondary">
-                        {formattedDate}
+                        {c.motivo}
                       </Typography>
                     </Box>
                     <Chip label={c.tipoNombre} color={getTipoColor(c.tipoNombre)} size="small" />


### PR DESCRIPTION
## Summary
- show day and time first in upcoming appointments
- display appointment reason below date
- use MUI Chip for appointment type with color

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0b2569b0083278e7cbbbb19960da0