### PR TITLE
feat: show weekday for same-week appointments

### DIFF
--- a/frontend-baby/src/App.js
+++ b/frontend-baby/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import dayjs from 'dayjs';
 import 'dayjs/locale/es';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import weekOfYear from 'dayjs/plugin/weekOfYear';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import SignInSide from "./sign-in-side/SignInSide";
@@ -26,6 +27,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import { AuthProvider } from "./context/AuthContext";
 
 dayjs.extend(relativeTime);
+dayjs.extend(weekOfYear);
 dayjs.locale('es');
 
 function App() {

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -43,6 +43,9 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
                 formattedDate = `Hoy ${appointmentDate.format('hh:mm A')}`;
               } else if (appointmentDate.isSame(today.add(1, 'day'), 'day')) {
                 formattedDate = `Mañana ${appointmentDate.format('hh:mm A')}`;
+              } else if (appointmentDate.isSame(today, 'week')) {
+                formattedDate = appointmentDate.format('dddd hh:mm A');
+                formattedDate = formattedDate.charAt(0).toUpperCase() + formattedDate.slice(1);
               } else {
                 formattedDate = appointmentDate.format('DD/MM/YYYY hh:mm A');
               }


### PR DESCRIPTION
## Summary
- show weekday and time for upcoming appointments within the current week
- enable dayjs weekOfYear plugin to support same-week comparison

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0bc2dcf388327970358d08811f1d9