### PR TITLE
Show appointment types in upcoming appointments

### DIFF
--- a/frontend-baby/src/dashboard/components/MainGrid.js
+++ b/frontend-baby/src/dashboard/components/MainGrid.js
@@ -20,7 +20,13 @@ export default function MainGrid() {
     if (!activeBaby?.id) return;
     listarProximas(activeBaby.id)
       .then((response) => {
-        setAppointments(response.data);
+        setAppointments(
+          response.data.map((c) => ({
+            ...c,
+            tipoNombre: c.tipo?.nombre ?? c.tipoNombre,
+            tipoId: c.tipo?.id ?? c.tipoId,
+          }))
+        );
         setError(null);
       })
       .catch((err) => {

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -58,7 +58,11 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
                         {formattedDate}
                       </Typography>
                     </Box>
-                    <Chip label={c.tipoNombre} color={getTipoColor(c.tipoNombre)} size="small" />
+                    <Chip
+                      label={c.tipoNombre || c.tipo?.nombre}
+                      color={getTipoColor(c.tipoNombre)}
+                      size="small"
+                    />
                   </CardContent>
                 </Card>
               );


### PR DESCRIPTION
## Summary
- Map upcoming appointment response to include tipoNombre and tipoId fallback fields
- Support displaying appointment type via tipoNombre or nested tipo in chip

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c0bed8ca2083279a138487e40f3c46