### PR TITLE
feat: enhance appointment type chip colors

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -12,16 +12,15 @@ import dayjs from 'dayjs';
 export default function UpcomingAppointmentsCard({ appointments = [], error }) {
   const navigate = useNavigate();
 
-  const getTipoColor = (tipo) => {
-    switch (tipo?.toLowerCase()) {
-      case 'consulta':
-        return 'success';
-      case 'vacuna':
-        return 'warning';
-      default:
-        return 'default';
-    }
+  const COLOR_BY_TIPO = {
+    consulta: 'success',
+    vacuna: 'warning',
+    urgencia: 'error',
+    // agregar más según catálogos de la API
   };
+
+  const getTipoColor = (tipo) =>
+    COLOR_BY_TIPO[tipo?.toLowerCase()] || 'default';
 
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
@@ -60,7 +59,7 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
                     </Box>
                     <Chip
                       label={c.tipoNombre || c.tipo?.nombre}
-                      color={getTipoColor(c.tipoNombre)}
+                      color={getTipoColor(c.tipoNombre || c.tipo?.nombre)}
                       size="small"
                     />
                   </CardContent>


### PR DESCRIPTION
## Summary
- use a configurable color map for appointment types
- ensure chip color matches appointment type label

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0bf81427c8327942b0809f81f2940