### PR TITLE
Expand app icon and link to dashboard

### DIFF
--- a/frontend-baby/src/dashboard/components/AppNavbar.js
+++ b/frontend-baby/src/dashboard/components/AppNavbar.js
@@ -10,6 +10,7 @@ import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import SideMenuMobile from './SideMenuMobile';
 import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
+import { Link } from 'react-router-dom';
 
 const Toolbar = styled(MuiToolbar)({
   width: '100%',
@@ -80,11 +81,13 @@ export default function AppNavbar() {
 
 export function CustomIcon() {
   return (
-    <Box
-      component="img"
-      src="/baby-logo.png"
-      alt="BabyTrackMaster"
-      sx={{ width: '3rem', height: '3rem' }}
-    />
+    <Box component={Link} to="/dashboard" sx={{ display: 'inline-flex' }}>
+      <Box
+        component="img"
+        src="/baby-logo.png"
+        alt="BabyTrackMaster"
+        sx={{ width: '4rem', height: '4rem' }}
+      />
+    </Box>
   );
 }

--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -10,6 +10,7 @@ import SelectContent from './SelectContent';
 import MenuContent from './MenuContent';
 import OptionsMenu from './OptionsMenu';
 import { AuthContext } from '../../context/AuthContext';
+import { Link } from 'react-router-dom';
 
 const drawerWidth = 240;
 
@@ -45,12 +46,14 @@ export default function SideMenu() {
           p: 1.5,
         }}
       >
-        <Box
-          component="img"
-          src="/baby-logo.png"
-          alt="BabyTrackMaster"
-          sx={{ width: 40, height: 40, mb: 1 }}
-        />
+        <Box component={Link} to="/dashboard" sx={{ mb: 1, display: 'flex' }}>
+          <Box
+            component="img"
+            src="/baby-logo.png"
+            alt="BabyTrackMaster"
+            sx={{ width: 56, height: 56 }}
+          />
+        </Box>
         <SelectContent />
       </Box>
       <Divider />


### PR DESCRIPTION
## Summary
- enlarge logo in navbar and side menu
- make logo clickable to redirect to dashboard

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0c3b4f448832786ed39b770efd653