### PR TITLE
Expand sidebar logo size

### DIFF
--- a/frontend-baby/src/dashboard/components/SideMenu.js
+++ b/frontend-baby/src/dashboard/components/SideMenu.js
@@ -51,7 +51,7 @@ export default function SideMenu() {
             component="img"
             src="/baby-logo.png"
             alt="BabyTrackMaster"
-            sx={{ width: 56, height: 56 }}
+            sx={{ width: 120, height: 'auto' }}
           />
         </Box>
         <SelectContent />


### PR DESCRIPTION
## Summary
- widen sidebar logo and scale height automatically for better visibility

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0c695e7a48327b1c7d89a15832562