### PR TITLE
feat: expose baby selector in mobile navbar

### DIFF
--- a/frontend-baby/src/dashboard/components/AppNavbar.js
+++ b/frontend-baby/src/dashboard/components/AppNavbar.js
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import MuiToolbar from '@mui/material/Toolbar';
 import { tabsClasses } from '@mui/material/Tabs';
-import Typography from '@mui/material/Typography';
+import SelectContent from './SelectContent';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import SideMenuMobile from './SideMenuMobile';
 import MenuButton from './MenuButton';
@@ -61,12 +61,12 @@ export default function AppNavbar() {
           <Stack
             direction="row"
             spacing={1}
-            sx={{ justifyContent: 'center', mr: 'auto', alignItems: 'center' }}
+            sx={{ justifyContent: 'center', mr: 'auto', alignItems: 'center', flexGrow: 1 }}
           >
             <CustomIcon />
-            <Typography variant="h4" component="h1" sx={{ color: 'text.primary' }}>
-              Panel
-            </Typography>
+            <Box sx={{ flexGrow: 1 }}>
+              <SelectContent />
+            </Box>
           </Stack>
           <ColorModeIconDropdown />
           <MenuButton aria-label="menú" onClick={toggleDrawer(true)}>

--- a/frontend-baby/src/dashboard/components/SelectContent.js
+++ b/frontend-baby/src/dashboard/components/SelectContent.js
@@ -39,10 +39,9 @@ export default function SelectContent() {
       onChange={handleChange}
       displayEmpty
       inputProps={{ 'aria-label': 'Seleccionar bebé' }}
-      fullWidth
       sx={{
         maxHeight: 56,
-        width: 215,
+        width: { xs: 150, sm: 215 },
         '&.MuiList-root': {
           p: '8px',
         },


### PR DESCRIPTION
## Summary
- replace static Panel title with SelectContent component in mobile AppNavbar
- make SelectContent width responsive for small screens

## Testing
- `npm test -- --watchAll=false`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0ca78e4cc8327a26dcffaee443af4