### PR TITLE
Update stats endpoint and weekly stats handling

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -84,7 +84,10 @@ export default function Alimentacion() {
   const fetchEstadisticas = () => {
     if (!bebeId || !usuarioId) return;
     obtenerEstadisticas(usuarioId, bebeId)
-      .then((res) => setWeeklyStats(res.data?.weekly || res.data || Array(7).fill(0)))
+      .then((res) => {
+        const weekly = res.data?.weekly ?? [];
+        setWeeklyStats(Array.from({ length: 7 }, (_, i) => weekly[i] ?? 0));
+      })
       .catch((err) => console.error('Error fetching estadisticas:', err));
   };
 

--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -20,7 +20,7 @@ export const listarRecientes = (usuarioId, bebeId, limit) => {
 
 export const obtenerEstadisticas = (usuarioId, bebeId) => {
   return axios.get(
-    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/estadisticas`
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
   );
 };
 


### PR DESCRIPTION
## Summary
- use `/stats` endpoint for feeding statistics
- read `res.data.weekly` and fill missing days with zeroes

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0cdd865a08327b3e72ca5e4dfee0b