### PR TITLE
Filter past appointments in dashboard

### DIFF
--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.js
@@ -22,6 +22,11 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
   const getTipoColor = (tipo) =>
     COLOR_BY_TIPO[tipo?.toLowerCase()] || 'default';
 
+  const now = dayjs();
+  const upcomingAppointments = appointments.filter((c) =>
+    dayjs(`${c.fecha}T${c.hora}`).isAfter(now)
+  );
+
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
       <CardContent>
@@ -32,17 +37,16 @@ export default function UpcomingAppointmentsCard({ appointments = [], error }) {
           <Typography variant="body2" color="error">
             {error}
           </Typography>
-        ) : appointments.length > 0 ? (
+        ) : upcomingAppointments.length > 0 ? (
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-            {appointments.map((c) => {
+            {upcomingAppointments.map((c) => {
               const appointmentDate = dayjs(`${c.fecha}T${c.hora}`);
-              const today = dayjs();
               let formattedDate;
-              if (appointmentDate.isSame(today, 'day')) {
+              if (appointmentDate.isSame(now, 'day')) {
                 formattedDate = `Hoy ${appointmentDate.format('hh:mm A')}`;
-              } else if (appointmentDate.isSame(today.add(1, 'day'), 'day')) {
+              } else if (appointmentDate.isSame(now.add(1, 'day'), 'day')) {
                 formattedDate = `Mañana ${appointmentDate.format('hh:mm A')}`;
-              } else if (appointmentDate.isSame(today, 'week')) {
+              } else if (appointmentDate.isSame(now, 'week')) {
                 formattedDate = appointmentDate.format('dddd hh:mm A');
                 formattedDate = formattedDate.charAt(0).toUpperCase() + formattedDate.slice(1);
               } else {

--- a/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.test.js
+++ b/frontend-baby/src/dashboard/components/UpcomingAppointmentsCard.test.js
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import dayjs from 'dayjs';
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    __esModule: true,
+    useNavigate: () => jest.fn(),
+  }),
+  { virtual: true }
+);
+
+const UpcomingAppointmentsCard = require('./UpcomingAppointmentsCard').default;
+
+describe('UpcomingAppointmentsCard', () => {
+  it('no muestra citas pasadas', () => {
+    const past = dayjs().subtract(1, 'day');
+    const future = dayjs().add(1, 'day');
+    const appointments = [
+      {
+        id: 1,
+        fecha: past.format('YYYY-MM-DD'),
+        hora: past.format('HH:mm'),
+        motivo: 'Pasada',
+        tipoNombre: 'consulta',
+      },
+      {
+        id: 2,
+        fecha: future.format('YYYY-MM-DD'),
+        hora: future.format('HH:mm'),
+        motivo: 'Futura',
+        tipoNombre: 'vacuna',
+      },
+    ];
+
+    render(<UpcomingAppointmentsCard appointments={appointments} />);
+
+    expect(screen.queryByText('Pasada')).not.toBeInTheDocument();
+    expect(screen.getByText('Futura')).toBeInTheDocument();
+  });
+
+  it('muestra mensaje cuando todas las citas son pasadas', () => {
+    const past = dayjs().subtract(1, 'day');
+    const appointments = [
+      {
+        id: 1,
+        fecha: past.format('YYYY-MM-DD'),
+        hora: past.format('HH:mm'),
+        motivo: 'Pasada',
+        tipoNombre: 'consulta',
+      },
+    ];
+
+    render(<UpcomingAppointmentsCard appointments={appointments} />);
+
+    expect(screen.getByText('No hay citas próximas.')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Filter out past appointments and render only upcoming ones
- Add tests ensuring past appointments are not rendered

## Testing
- `npm test -- UpcomingAppointmentsCard.test.js --watchAll=false`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c0cfcbd7848327ac03a359bf80e27c