### PR TITLE
Fix birthday parsing to avoid timezone issues

### DIFF
--- a/frontend-baby/src/dashboard/components/WelcomeBanner.js
+++ b/frontend-baby/src/dashboard/components/WelcomeBanner.js
@@ -27,7 +27,16 @@ export default function WelcomeBanner() {
     month: 'long',
   });
 
-  const birthDate = activeBaby ? new Date(activeBaby.fechaNacimiento) : null;
+  // Parse birth date manually to avoid timezone shifts when using the
+  // Date constructor with a `YYYY-MM-DD` string. Splitting the string and
+  // creating the date with numeric arguments ensures the local timezone is
+  // respected and allows `getMonth()` and `getDate()` to work as expected.
+  const birthDate = activeBaby
+    ? (() => {
+        const [y, m, d] = activeBaby.fechaNacimiento.split('-').map(Number);
+        return new Date(y, m - 1, d);
+      })()
+    : null;
   let birthdayMessage;
 
   if (activeBaby && birthDate) {


### PR DESCRIPTION
## Summary
- parse active baby's birth date manually to avoid timezone shifts and ensure accurate birthday countdown

## Testing
- `npm test -- --watchAll=false`
- `node -e diff script`

------
https://chatgpt.com/codex/tasks/task_e_68c12c415eb88327949c38d70bfd979e