### PR TITLE
fix: parse birth date correctly

### DIFF
--- a/frontend-baby/src/dashboard/components/WelcomeBanner.js
+++ b/frontend-baby/src/dashboard/components/WelcomeBanner.js
@@ -30,7 +30,10 @@ export default function WelcomeBanner() {
   let birthdayMessage;
 
   if (activeBaby) {
-    const [y, m, d] = activeBaby.fechaNacimiento.split('-').map(Number);
+    const [y, m, d] = activeBaby.fechaNacimiento
+      .slice(0, 10)
+      .split('-')
+      .map(Number);
     const birthDate = new Date(y, m - 1, d);
 
     const todayDate = new Date(


### PR DESCRIPTION
## Summary
- slice birth date string before splitting so it returns valid y/m/d values

## Testing
- `CI=true npm test -- --runTestsByPath src/dashboard/components/QuickStatsCard.test.js`
- `CI=true npm test -- --runTestsByPath src/dashboard/components/UpcomingAppointmentsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c171ff15cc832786de9df20fe74f5c