### PR TITLE
Use LocalDateTime for feeding records

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -1,6 +1,6 @@
 package com.babytrackmaster.api_alimentacion.dto;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
@@ -15,7 +15,7 @@ public class AlimentacionRequest {
     @NotNull
     @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
     private TipoAlimentacion tipo;
-    private Date fechaHora;
+    private LocalDateTime fechaHora;
 
     // Lactancia
     private String lado;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
@@ -1,6 +1,6 @@
 package com.babytrackmaster.api_alimentacion.dto;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
@@ -16,7 +16,7 @@ public class AlimentacionResponse {
     private Long bebeId;
     @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
     private TipoAlimentacion tipo;
-    private Date fechaHora;
+    private LocalDateTime fechaHora;
     private String lado;
     private Integer duracionMin;
     private TipoLactancia tipoLactancia;
@@ -27,6 +27,6 @@ public class AlimentacionResponse {
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
     private String observaciones;
-    private Date createdAt;
-    private Date updatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -26,9 +26,8 @@ public class Alimentacion {
     @Column(nullable = false, length = 20)
     private TipoAlimentacion tipo;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "fecha_hora", nullable = false)
-    private Date fechaHora;
+    private LocalDateTime fechaHora;
 
     // Lactancia
     private String lado; // IZQ/DER
@@ -52,11 +51,24 @@ public class Alimentacion {
     @Column(nullable = false)
     private Boolean eliminado = false;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "created_at", nullable = false)
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(name = "updated_at", nullable = false)
-    private Date updatedAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (fechaHora == null) {
+            fechaHora = now;
+        }
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
@@ -1,6 +1,5 @@
 package com.babytrackmaster.api_alimentacion.mapper;
 
-import java.util.Date;
 
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
@@ -13,8 +12,7 @@ public class AlimentacionMapper {
         a.setUsuarioId(usuarioId);
         a.setBebeId(bebeId);
         a.setTipo(req.getTipo());
-        Date now = new Date();
-        a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : now);
+        a.setFechaHora(req.getFechaHora());
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLactancia(req.getTipoLactancia());
@@ -25,15 +23,15 @@ public class AlimentacionMapper {
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setObservaciones(req.getObservaciones());
-        a.setCreatedAt(now);
-        a.setUpdatedAt(now);
         a.setEliminado(false);
         return a;
     }
 
     public static void copyToEntity(AlimentacionRequest req, Alimentacion a) {
         a.setTipo(req.getTipo());
-        a.setFechaHora(req.getFechaHora() != null ? req.getFechaHora() : a.getFechaHora());
+        if (req.getFechaHora() != null) {
+            a.setFechaHora(req.getFechaHora());
+        }
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLactancia(req.getTipoLactancia());
@@ -44,7 +42,6 @@ public class AlimentacionMapper {
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setObservaciones(req.getObservaciones());
-        a.setUpdatedAt(new Date());
     }
 
     public static AlimentacionResponse toResponse(Alimentacion a) {

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
@@ -1,6 +1,6 @@
 package com.babytrackmaster.api_alimentacion.repository;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +12,6 @@ import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 public interface AlimentacionRepository extends JpaRepository<Alimentacion, Long> {
     Optional<Alimentacion> findByIdAndUsuarioIdAndBebeIdAndEliminadoFalse(Long id, Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaHoraDesc(Long usuarioId, Long bebeId);
-    List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, Date desde, Date hasta);
-    long countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipo, Date desde, Date hasta);
+    List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, LocalDateTime desde, LocalDateTime hasta);
+    long countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipo, LocalDateTime desde, LocalDateTime hasta);
 }

--- a/api-alimentacion/src/main/resources/schema.sql
+++ b/api-alimentacion/src/main/resources/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS alimentacion (
     usuario_id BIGINT NOT NULL,
     bebe_id BIGINT NOT NULL,
     tipo VARCHAR(20) NOT NULL,
-    fecha_hora TIMESTAMP NOT NULL,
+    fecha_hora TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     lado VARCHAR(10),
     duracion_min INT,
     tipo_lactancia_id BIGINT,
@@ -29,6 +29,6 @@ CREATE TABLE IF NOT EXISTS alimentacion (
     cantidad_otros_alimentos INT,
     observaciones VARCHAR(255),
     eliminado BOOLEAN NOT NULL,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## Summary
- replace `Date` fields in Alimentacion with `LocalDateTime` and auto-manage timestamps
- update DTOs, mapper, repository and service to rely on `LocalDateTime`
- set default timestamps in schema

## Testing
- `mvn -q -f api-alimentacion/pom.xml test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c179350ff0832784492f5be47068be