### PR TITLE
feat(alimentacion): expand feeding catalogs

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
@@ -17,6 +17,9 @@ import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -92,5 +95,23 @@ public class AlimentacionController {
     @GetMapping("/tipos-lactancia")
     public ResponseEntity<List<TipoLactancia>> tiposLactancia() {
         return ResponseEntity.ok(service.listarTiposLactancia());
+    }
+
+    @Operation(summary = "Listar tipos de alimentación")
+    @GetMapping("/tipos-alimentacion")
+    public ResponseEntity<List<TipoAlimentacion>> tiposAlimentacion() {
+        return ResponseEntity.ok(service.listarTiposAlimentacion());
+    }
+
+    @Operation(summary = "Listar tipos de leche para biberón")
+    @GetMapping("/tipos-biberon")
+    public ResponseEntity<List<TipoLecheBiberon>> tiposBiberon() {
+        return ResponseEntity.ok(service.listarTiposBiberon());
+    }
+
+    @Operation(summary = "Listar tipos de alimentación sólida")
+    @GetMapping("/tipos-alimentacion-solido")
+    public ResponseEntity<List<TipoAlimentacionSolido>> tiposAlimentacionSolido() {
+        return ResponseEntity.ok(service.listarTiposAlimentacionSolido());
     }
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -13,8 +15,7 @@ import lombok.Data;
 @Schema(name = "AlimentacionRequest", description = "Datos para crear/actualizar un registro de alimentacion")
 public class AlimentacionRequest {
     @NotNull
-    @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
-    private TipoAlimentacion tipo;
+    private TipoAlimentacion tipoAlimentacion;
     private LocalDateTime fechaHora;
 
     // Lactancia
@@ -23,13 +24,14 @@ public class AlimentacionRequest {
     private TipoLactancia tipoLactancia;
 
     // Biberon
-    private String tipoLeche;
+    private TipoLecheBiberon tipoBiberon;
     private Integer cantidadMl;
     private Integer cantidadLecheFormula;
 
     // Solidos
-    private String alimento;
+    private TipoAlimentacionSolido tipoAlimentacionSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
+    private String alimentacionOtros;
     private String observaciones;
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -14,18 +16,18 @@ public class AlimentacionResponse {
     private Long id;
     private Long usuarioId;
     private Long bebeId;
-    @Schema(allowableValues = {"lactancia", "biberon", "solidos"})
-    private TipoAlimentacion tipo;
+    private TipoAlimentacion tipoAlimentacion;
     private LocalDateTime fechaHora;
     private String lado;
     private Integer duracionMin;
     private TipoLactancia tipoLactancia;
-    private String tipoLeche;
+    private TipoLecheBiberon tipoBiberon;
     private Integer cantidadMl;
     private Integer cantidadLecheFormula;
-    private String alimento;
+    private TipoAlimentacionSolido tipoAlimentacionSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
+    private String alimentacionOtros;
     private String observaciones;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
@@ -22,9 +22,9 @@ public class Alimentacion {
     @Column(name = "bebe_id", nullable = false)
     private Long bebeId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private TipoAlimentacion tipo;
+    @ManyToOne
+    @JoinColumn(name = "tipo_alimentacion_id", nullable = false)
+    private TipoAlimentacion tipoAlimentacion;
 
     @Column(name = "fecha_hora", nullable = false)
     private LocalDateTime fechaHora;
@@ -38,14 +38,19 @@ public class Alimentacion {
     private TipoLactancia tipoLactancia;
 
     // Biberon
-    private String tipoLeche;
+    @ManyToOne
+    @JoinColumn(name = "tipo_biberon_id")
+    private TipoLecheBiberon tipoBiberon;
     private Integer cantidadMl;
     private Integer cantidadLecheFormula;
 
     // Solidos
-    private String alimento;
+    @ManyToOne
+    @JoinColumn(name = "tipo_alimentacion_solido_id")
+    private TipoAlimentacionSolido tipoAlimentacionSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
+    private String alimentacionOtros;
     private String observaciones;
 
     @Column(nullable = false)

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoAlimentacionSolido.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoAlimentacionSolido.java
@@ -5,13 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Catálogo de tipos de alimentación (Lactancia, Biberón, Sólidos, ...).
+ * Catálogo para los alimentos sólidos ofrecidos al bebé.
  */
 @Data
 @NoArgsConstructor
 @Entity
-@Table(name = "tipo_alimentacion")
-public class TipoAlimentacion {
+@Table(name = "tipo_alimentacion_solidos")
+public class TipoAlimentacionSolido {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoLecheBiberon.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/TipoLecheBiberon.java
@@ -5,13 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Catálogo de tipos de alimentación (Lactancia, Biberón, Sólidos, ...).
+ * Catálogo de tipos de leche utilizados en el biberón.
  */
 @Data
 @NoArgsConstructor
 @Entity
-@Table(name = "tipo_alimentacion")
-public class TipoAlimentacion {
+@Table(name = "tipo_leche_biberon")
+public class TipoLecheBiberon {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
@@ -11,36 +11,38 @@ public class AlimentacionMapper {
         Alimentacion a = new Alimentacion();
         a.setUsuarioId(usuarioId);
         a.setBebeId(bebeId);
-        a.setTipo(req.getTipo());
+        a.setTipoAlimentacion(req.getTipoAlimentacion());
         a.setFechaHora(req.getFechaHora());
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLactancia(req.getTipoLactancia());
-        a.setTipoLeche(req.getTipoLeche());
+        a.setTipoBiberon(req.getTipoBiberon());
         a.setCantidadMl(req.getCantidadMl());
         a.setCantidadLecheFormula(req.getCantidadLecheFormula());
-        a.setAlimento(req.getAlimento());
+        a.setTipoAlimentacionSolido(req.getTipoAlimentacionSolido());
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
+        a.setAlimentacionOtros(req.getAlimentacionOtros());
         a.setObservaciones(req.getObservaciones());
         a.setEliminado(false);
         return a;
     }
 
     public static void copyToEntity(AlimentacionRequest req, Alimentacion a) {
-        a.setTipo(req.getTipo());
+        a.setTipoAlimentacion(req.getTipoAlimentacion());
         if (req.getFechaHora() != null) {
             a.setFechaHora(req.getFechaHora());
         }
         a.setLado(req.getLado());
         a.setDuracionMin(req.getDuracionMin());
         a.setTipoLactancia(req.getTipoLactancia());
-        a.setTipoLeche(req.getTipoLeche());
+        a.setTipoBiberon(req.getTipoBiberon());
         a.setCantidadMl(req.getCantidadMl());
         a.setCantidadLecheFormula(req.getCantidadLecheFormula());
-        a.setAlimento(req.getAlimento());
+        a.setTipoAlimentacionSolido(req.getTipoAlimentacionSolido());
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
+        a.setAlimentacionOtros(req.getAlimentacionOtros());
         a.setObservaciones(req.getObservaciones());
     }
 
@@ -49,17 +51,18 @@ public class AlimentacionMapper {
         r.setId(a.getId());
         r.setUsuarioId(a.getUsuarioId());
         r.setBebeId(a.getBebeId());
-        r.setTipo(a.getTipo());
+        r.setTipoAlimentacion(a.getTipoAlimentacion());
         r.setFechaHora(a.getFechaHora());
         r.setLado(a.getLado());
         r.setDuracionMin(a.getDuracionMin());
         r.setTipoLactancia(a.getTipoLactancia());
-        r.setTipoLeche(a.getTipoLeche());
+        r.setTipoBiberon(a.getTipoBiberon());
         r.setCantidadMl(a.getCantidadMl());
         r.setCantidadLecheFormula(a.getCantidadLecheFormula());
-        r.setAlimento(a.getAlimento());
+        r.setTipoAlimentacionSolido(a.getTipoAlimentacionSolido());
         r.setCantidad(a.getCantidad());
         r.setCantidadOtrosAlimentos(a.getCantidadOtrosAlimentos());
+        r.setAlimentacionOtros(a.getAlimentacionOtros());
         r.setObservaciones(a.getObservaciones());
         r.setCreatedAt(a.getCreatedAt());
         r.setUpdatedAt(a.getUpdatedAt());

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
@@ -13,5 +13,5 @@ public interface AlimentacionRepository extends JpaRepository<Alimentacion, Long
     Optional<Alimentacion> findByIdAndUsuarioIdAndBebeIdAndEliminadoFalse(Long id, Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaHoraDesc(Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, LocalDateTime desde, LocalDateTime hasta);
-    long countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipo, LocalDateTime desde, LocalDateTime hasta);
+    long countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipoAlimentacion, LocalDateTime desde, LocalDateTime hasta);
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoAlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoAlimentacionRepository.java
@@ -1,0 +1,12 @@
+package com.babytrackmaster.api_alimentacion.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+
+public interface TipoAlimentacionRepository extends JpaRepository<TipoAlimentacion, Long> {
+    Optional<TipoAlimentacion> findByNombreIgnoreCase(String nombre);
+}
+

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoAlimentacionSolidoRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoAlimentacionSolidoRepository.java
@@ -1,0 +1,9 @@
+package com.babytrackmaster.api_alimentacion.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
+
+public interface TipoAlimentacionSolidoRepository extends JpaRepository<TipoAlimentacionSolido, Long> {
+}
+

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoLecheBiberonRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/TipoLecheBiberonRepository.java
@@ -1,0 +1,9 @@
+package com.babytrackmaster.api_alimentacion.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+
+public interface TipoLecheBiberonRepository extends JpaRepository<TipoLecheBiberon, Long> {
+}
+

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
@@ -6,6 +6,9 @@ import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionResponse;
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
 
 public interface AlimentacionService {
     AlimentacionResponse crear(Long usuarioId, Long bebeId, AlimentacionRequest request);
@@ -15,4 +18,7 @@ public interface AlimentacionService {
     List<AlimentacionResponse> listar(Long usuarioId, Long bebeId);
     AlimentacionStatsResponse stats(Long usuarioId, Long bebeId);
     List<TipoLactancia> listarTiposLactancia();
+    List<TipoAlimentacion> listarTiposAlimentacion();
+    List<TipoLecheBiberon> listarTiposBiberon();
+    List<TipoAlimentacionSolido> listarTiposAlimentacionSolido();
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
@@ -16,9 +16,14 @@ import com.babytrackmaster.api_alimentacion.dto.AlimentacionStatsResponse;
 import com.babytrackmaster.api_alimentacion.entity.Alimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.entity.TipoLactancia;
+import com.babytrackmaster.api_alimentacion.entity.TipoLecheBiberon;
+import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacionSolido;
 import com.babytrackmaster.api_alimentacion.mapper.AlimentacionMapper;
 import com.babytrackmaster.api_alimentacion.repository.AlimentacionRepository;
 import com.babytrackmaster.api_alimentacion.repository.TipoLactanciaRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoAlimentacionRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoLecheBiberonRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoAlimentacionSolidoRepository;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 @Service
@@ -27,10 +32,20 @@ public class AlimentacionServiceImpl implements AlimentacionService {
 
     private final AlimentacionRepository repo;
     private final TipoLactanciaRepository tipoLactanciaRepo;
+    private final TipoAlimentacionRepository tipoAlimentacionRepo;
+    private final TipoLecheBiberonRepository tipoBiberonRepo;
+    private final TipoAlimentacionSolidoRepository tipoAlimentacionSolidoRepo;
 
-    public AlimentacionServiceImpl(AlimentacionRepository repo, TipoLactanciaRepository tipoLactanciaRepo) {
+    public AlimentacionServiceImpl(AlimentacionRepository repo,
+            TipoLactanciaRepository tipoLactanciaRepo,
+            TipoAlimentacionRepository tipoAlimentacionRepo,
+            TipoLecheBiberonRepository tipoBiberonRepo,
+            TipoAlimentacionSolidoRepository tipoAlimentacionSolidoRepo) {
         this.repo = repo;
         this.tipoLactanciaRepo = tipoLactanciaRepo;
+        this.tipoAlimentacionRepo = tipoAlimentacionRepo;
+        this.tipoBiberonRepo = tipoBiberonRepo;
+        this.tipoAlimentacionSolidoRepo = tipoAlimentacionSolidoRepo;
     }
 
     public AlimentacionResponse crear(Long usuarioId, Long bebeId, AlimentacionRequest request) {
@@ -77,6 +92,21 @@ public class AlimentacionServiceImpl implements AlimentacionService {
     }
 
     @Transactional(readOnly = true)
+    public List<TipoAlimentacion> listarTiposAlimentacion() {
+        return tipoAlimentacionRepo.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TipoLecheBiberon> listarTiposBiberon() {
+        return tipoBiberonRepo.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TipoAlimentacionSolido> listarTiposAlimentacionSolido() {
+        return tipoAlimentacionSolidoRepo.findAll();
+    }
+
+    @Transactional(readOnly = true)
     public AlimentacionStatsResponse stats(Long usuarioId, Long bebeId) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime inicioDia = now.toLocalDate().atStartOfDay();
@@ -98,19 +128,29 @@ public class AlimentacionServiceImpl implements AlimentacionService {
             weekly.set(index, weekly.get(index) + 1);
         }
 
-        long lactanciaDia = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.LACTANCIA, inicioDia, finDia);
-        long biberonDia = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.BIBERON, inicioDia, finDia);
-        long solidosDia = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.SOLIDOS, inicioDia, finDia);
+        TipoAlimentacion lactancia = tipoAlimentacionRepo.findByNombreIgnoreCase("lactancia").orElse(null);
+        TipoAlimentacion biberon = tipoAlimentacionRepo.findByNombreIgnoreCase("biberón").orElse(null);
+        TipoAlimentacion solidos = tipoAlimentacionRepo.findByNombreIgnoreCase("sólidos").orElse(null);
 
-        long lactanciaSemana = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.LACTANCIA, inicioSemana, finSemana);
-        long biberonSemana = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.BIBERON, inicioSemana, finSemana);
-        long solidosSemana = repo.countByUsuarioIdAndBebeIdAndTipoAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
-                TipoAlimentacion.SOLIDOS, inicioSemana, finSemana);
+        long lactanciaDia = lactancia == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        lactancia, inicioDia, finDia);
+        long biberonDia = biberon == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        biberon, inicioDia, finDia);
+        long solidosDia = solidos == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        solidos, inicioDia, finDia);
+
+        long lactanciaSemana = lactancia == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        lactancia, inicioSemana, finSemana);
+        long biberonSemana = biberon == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        biberon, inicioSemana, finSemana);
+        long solidosSemana = solidos == null ? 0 :
+                repo.countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId,
+                        solidos, inicioSemana, finSemana);
 
         AlimentacionStatsResponse r = new AlimentacionStatsResponse();
         r.setLactanciaDia(lactanciaDia);

--- a/api-alimentacion/src/main/resources/schema.sql
+++ b/api-alimentacion/src/main/resources/schema.sql
@@ -12,21 +12,53 @@ INSERT INTO tipo_lactancia (id, nombre) VALUES
     (6,'mixta'),
     (7,'predominante');
 
+CREATE TABLE IF NOT EXISTS tipo_alimentacion (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(50) NOT NULL UNIQUE
+);
+
+INSERT INTO tipo_alimentacion (id, nombre) VALUES
+    (1,'Lactancia'),
+    (2,'Biberón'),
+    (3,'Sólidos');
+
+CREATE TABLE IF NOT EXISTS tipo_leche_biberon (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(50) NOT NULL UNIQUE
+);
+
+INSERT INTO tipo_leche_biberon (id, nombre) VALUES
+    (1,'Materna'),
+    (2,'Fórmula'),
+    (3,'Mixta');
+
+CREATE TABLE IF NOT EXISTS tipo_alimentacion_solidos (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(50) NOT NULL UNIQUE
+);
+
+INSERT INTO tipo_alimentacion_solidos (id, nombre) VALUES
+    (1,'Frutas'),
+    (2,'Verduras'),
+    (3,'Cereales'),
+    (4,'Otros');
+
 CREATE TABLE IF NOT EXISTS alimentacion (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     usuario_id BIGINT NOT NULL,
     bebe_id BIGINT NOT NULL,
-    tipo VARCHAR(20) NOT NULL,
+    tipo_alimentacion_id BIGINT NOT NULL,
     fecha_hora TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     lado VARCHAR(10),
     duracion_min INT,
     tipo_lactancia_id BIGINT,
-    tipo_leche VARCHAR(30),
+    tipo_biberon_id BIGINT,
     cantidad_ml INT,
     cantidad_leche_formula INT,
-    alimento VARCHAR(100),
+    tipo_alimentacion_solido_id BIGINT,
     cantidad VARCHAR(50),
     cantidad_otros_alimentos INT,
+    alimentacion_otros VARCHAR(100),
     observaciones VARCHAR(255),
     eliminado BOOLEAN NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -52,16 +52,40 @@ class AlimentacionControllerTest {
     }
 
     @Test
+    void tiposAlimentacionDevuelveOk() throws Exception {
+        when(service.listarTiposAlimentacion()).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/alimentacion/tipos-alimentacion"))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    void tiposBiberonDevuelveOk() throws Exception {
+        when(service.listarTiposBiberon()).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/alimentacion/tipos-biberon"))
+               .andExpect(status().isOk());
+    }
+
+    @Test
+    void tiposAlimentacionSolidoDevuelveOk() throws Exception {
+        when(service.listarTiposAlimentacionSolido()).thenReturn(List.of());
+        mockMvc.perform(get("/api/v1/alimentacion/tipos-alimentacion-solido"))
+               .andExpect(status().isOk());
+    }
+
+    @Test
     void crearDevuelveCreated() throws Exception {
         AlimentacionRequest req = new AlimentacionRequest();
-        req.setTipo(TipoAlimentacion.BIBERON);
-        req.setFechaHora(new Date());
+        TipoAlimentacion tipo = new TipoAlimentacion();
+        tipo.setId(2L);
+        tipo.setNombre("Biberón");
+        req.setTipoAlimentacion(tipo);
+        req.setFechaHora(LocalDateTime.now());
         req.setCantidadMl(100);
         AlimentacionResponse resp = new AlimentacionResponse();
         resp.setId(1L);
         when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
 
-        String json = mapper.writeValueAsString(req).replace("BIBERON", "biberon");
+        String json = mapper.writeValueAsString(req);
 
         mockMvc.perform(post("/api/v1/alimentacion/usuario/1/bebe/2")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -72,14 +96,17 @@ class AlimentacionControllerTest {
     @Test
     void crearSinFechaHoraDevuelveCreated() throws Exception {
         AlimentacionRequest req = new AlimentacionRequest();
-        req.setTipo(TipoAlimentacion.BIBERON);
+        TipoAlimentacion tipo = new TipoAlimentacion();
+        tipo.setId(2L);
+        tipo.setNombre("Biberón");
+        req.setTipoAlimentacion(tipo);
         req.setCantidadMl(100);
         AlimentacionResponse resp = new AlimentacionResponse();
         resp.setId(1L);
-        resp.setFechaHora(new Date());
+        resp.setFechaHora(LocalDateTime.now());
         when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
 
-        String json = mapper.writeValueAsString(req).replace("BIBERON", "biberon");
+        String json = mapper.writeValueAsString(req);
 
         mockMvc.perform(post("/api/v1/alimentacion/usuario/1/bebe/2")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
@@ -6,7 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +20,9 @@ import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 import com.babytrackmaster.api_alimentacion.mapper.AlimentacionMapper;
 import com.babytrackmaster.api_alimentacion.repository.AlimentacionRepository;
 import com.babytrackmaster.api_alimentacion.repository.TipoLactanciaRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoAlimentacionRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoLecheBiberonRepository;
+import com.babytrackmaster.api_alimentacion.repository.TipoAlimentacionSolidoRepository;
 import com.babytrackmaster.api_alimentacion.service.AlimentacionService;
 
 @SpringBootTest
@@ -31,14 +34,26 @@ class AlimentacionServiceImplTest {
     @MockBean
     private TipoLactanciaRepository tipoLactanciaRepo;
 
+    @MockBean
+    private TipoAlimentacionRepository tipoAlimentacionRepo;
+
+    @MockBean
+    private TipoLecheBiberonRepository tipoLecheBiberonRepo;
+
+    @MockBean
+    private TipoAlimentacionSolidoRepository tipoAlimentacionSolidoRepo;
+
     @Autowired
     private AlimentacionService service;
 
     @Test
     void crearGuardaYDevuelve() {
         AlimentacionRequest req = new AlimentacionRequest();
-        req.setTipo(TipoAlimentacion.from("biberon"));
-        req.setFechaHora(new Date());
+        TipoAlimentacion tipo = new TipoAlimentacion();
+        tipo.setId(2L);
+        tipo.setNombre("Biberón");
+        req.setTipoAlimentacion(tipo);
+        req.setFechaHora(LocalDateTime.now());
         req.setCantidadMl(120);
 
         Alimentacion saved = AlimentacionMapper.toEntity(req, 1L, 2L);
@@ -54,7 +69,10 @@ class AlimentacionServiceImplTest {
     @Test
     void crearConFechaHoraNullAsignaFechaActual() {
         AlimentacionRequest req = new AlimentacionRequest();
-        req.setTipo(TipoAlimentacion.BIBERON);
+        TipoAlimentacion tipo = new TipoAlimentacion();
+        tipo.setId(2L);
+        tipo.setNombre("Biberón");
+        req.setTipoAlimentacion(tipo);
         req.setCantidadMl(80);
 
         Alimentacion saved = AlimentacionMapper.toEntity(req, 1L, 2L);


### PR DESCRIPTION
## Summary
- introduce catalog entities for food types, bottle milk and solid feeding
- wire Alimentacion with new relationships and expose catalog endpoints
- seed SQL schema with catalog tables and columns

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c209249f58832791598bed9207fbaa