### PR TITLE
feat: filter weekly feeding stats by type

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.babytrackmaster.api_alimentacion.dto.AlimentacionRequest;
@@ -87,8 +88,9 @@ public class AlimentacionController {
     @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/stats")
     public ResponseEntity<AlimentacionStatsResponse> stats(
             @PathVariable Long usuarioId,
-            @PathVariable Long bebeId) {
-        return ResponseEntity.ok(service.stats(usuarioId, bebeId));
+            @PathVariable Long bebeId,
+            @RequestParam(required = false) Long tipoAlimentacionId) {
+        return ResponseEntity.ok(service.stats(usuarioId, bebeId, tipoAlimentacionId));
     }
 
     @Operation(summary = "Listar tipos de lactancia")

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
@@ -13,5 +13,6 @@ public interface AlimentacionRepository extends JpaRepository<Alimentacion, Long
     Optional<Alimentacion> findByIdAndUsuarioIdAndBebeIdAndEliminadoFalse(Long id, Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaHoraDesc(Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, LocalDateTime desde, LocalDateTime hasta);
+    List<Alimentacion> findByUsuarioIdAndBebeIdAndTipoAlimentacionIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, Long tipoAlimentacionId, LocalDateTime desde, LocalDateTime hasta);
     long countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipoAlimentacion, LocalDateTime desde, LocalDateTime hasta);
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
@@ -16,7 +16,7 @@ public interface AlimentacionService {
     void eliminar(Long usuarioId, Long bebeId, Long id);
     AlimentacionResponse obtener(Long usuarioId, Long bebeId, Long id);
     List<AlimentacionResponse> listar(Long usuarioId, Long bebeId);
-    AlimentacionStatsResponse stats(Long usuarioId, Long bebeId);
+    AlimentacionStatsResponse stats(Long usuarioId, Long bebeId, Long tipoAlimentacionId);
     List<TipoLactancia> listarTiposLactancia();
     List<TipoAlimentacion> listarTiposAlimentacion();
     List<TipoLecheBiberon> listarTiposBiberon();

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
@@ -107,7 +107,7 @@ public class AlimentacionServiceImpl implements AlimentacionService {
     }
 
     @Transactional(readOnly = true)
-    public AlimentacionStatsResponse stats(Long usuarioId, Long bebeId) {
+    public AlimentacionStatsResponse stats(Long usuarioId, Long bebeId, Long tipoAlimentacionId) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime inicioDia = now.toLocalDate().atStartOfDay();
         LocalDateTime finDia = inicioDia.plusDays(1);
@@ -116,8 +116,9 @@ public class AlimentacionServiceImpl implements AlimentacionService {
         LocalDateTime inicioSemana = now.toLocalDate().with(TemporalAdjusters.previousOrSame(firstDow)).atStartOfDay();
         LocalDateTime finSemana = inicioSemana.plusWeeks(1);
 
-        List<Alimentacion> registrosSemana = repo
-                .findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId, inicioSemana, finSemana);
+        List<Alimentacion> registrosSemana = tipoAlimentacionId == null
+                ? repo.findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId, inicioSemana, finSemana)
+                : repo.findByUsuarioIdAndBebeIdAndTipoAlimentacionIdAndFechaHoraBetweenAndEliminadoFalse(usuarioId, bebeId, tipoAlimentacionId, inicioSemana, finSemana);
         List<Long> weekly = new ArrayList<>(7);
         for (int i = 0; i < 7; i++) {
             weekly.add(0L);

--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -97,6 +97,7 @@ export default function Alimentacion() {
   const handleTabChange = (event, newValue) => {
     setTab(newValue);
     setPage(0);
+    fetchEstadisticas(newValue);
   };
 
   const fetchRegistros = () => {
@@ -106,9 +107,9 @@ export default function Alimentacion() {
       .catch((err) => console.error('Error fetching alimentacion:', err));
   };
 
-  const fetchEstadisticas = () => {
+  const fetchEstadisticas = (tipoId) => {
     if (!bebeId || !usuarioId) return;
-    obtenerEstadisticas(usuarioId, bebeId)
+    obtenerEstadisticas(usuarioId, bebeId, tipoId)
       .then((res) => {
         const weekly = res.data?.weekly ?? [];
         setWeeklyStats(Array.from({ length: 7 }, (_, i) => weekly[i] ?? 0));
@@ -119,15 +120,17 @@ export default function Alimentacion() {
   useEffect(() => {
     if (bebeId) {
       fetchRegistros();
-      fetchEstadisticas();
+      if (tab) fetchEstadisticas(tab);
     }
-  }, [bebeId]);
+  }, [bebeId, tab]);
 
   useEffect(() => {
     listarTiposAlimentacion()
       .then((res) => {
         setTiposAlimentacion(res.data);
-        setTab(res.data[0]?.id ?? null);
+        const firstId = res.data[0]?.id ?? null;
+        setTab(firstId);
+        if (firstId) fetchEstadisticas(firstId);
       })
       .catch((err) =>
         console.error('Error fetching tipos alimentacion:', err)
@@ -193,7 +196,7 @@ export default function Alimentacion() {
       eliminarRegistro(usuarioId, bebeId, id)
         .then(() => {
           fetchRegistros();
-          fetchEstadisticas();
+          fetchEstadisticas(tab);
         })
         .catch((err) => console.error('Error deleting registro:', err));
     }
@@ -210,7 +213,7 @@ export default function Alimentacion() {
         setOpenForm(false);
         setSelected(null);
         fetchRegistros();
-        fetchEstadisticas();
+        fetchEstadisticas(tab);
       })
       .catch((err) => console.error('Error saving registro:', err));
   };

--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -18,9 +18,12 @@ export const listarRecientes = (usuarioId, bebeId, limit) => {
   );
 };
 
-export const obtenerEstadisticas = (usuarioId, bebeId) => {
+export const obtenerEstadisticas = (usuarioId, bebeId, tipoAlimentacionId) => {
+  const params = {};
+  if (tipoAlimentacionId !== undefined) params.tipoAlimentacionId = tipoAlimentacionId;
   return axios.get(
-    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
+    { params }
   );
 };
 


### PR DESCRIPTION
## Summary
- allow optional `tipoAlimentacionId` in feeding stats endpoint
- support type filtering in weekly stats calculation
- send type filter from frontend and refresh charts when switching tabs

## Testing
- `mvn -q -f api-alimentacion/pom.xml test` *(fails: Non-resolvable parent POM)*
- `CI=true npm test --prefix frontend-baby`

------
https://chatgpt.com/codex/tasks/task_e_68c216609eb08327956e4025ae3292cc