### PR TITLE
Ajustar datos de sólidos en reportes de alimentación

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -243,9 +243,9 @@ export default function Alimentacion() {
   };
 
   const getNombreSolido = (registro) =>
-    registro.tipoAlimentacionSolido?.nombre === 'Otros'
-      ? registro.alimentacionOtros
-      : registro.tipoAlimentacionSolido?.nombre;
+    registro.alimentacionOtros ||
+    registro.tipoAlimentacionSolido?.nombre ||
+    '';
 
   const handleExportCsv = () => {
     const current = selectedSlug;
@@ -273,7 +273,7 @@ export default function Alimentacion() {
           r.observaciones || '',
         ];
       }
-      return [...base, alimento, r.cantidadMl, r.observaciones || ''];
+      return [...base, alimento, r.cantidad, r.observaciones || ''];
     });
     const csvContent = [headers, ...rows].map((e) => e.join(',')).join('\n');
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
@@ -312,7 +312,7 @@ export default function Alimentacion() {
           r.observaciones || '',
         ];
       }
-      return [...base, alimento, r.cantidadMl, r.observaciones || ''];
+      return [...base, alimento, r.cantidad, r.observaciones || ''];
     });
     const doc = new jsPDF();
     autoTable(doc, {
@@ -395,7 +395,7 @@ export default function Alimentacion() {
                     {selectedSlug === 'solidos' && (
                       <>
                         <TableCell>{alimento}</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>{r.cantidadMl}</TableCell>
+                        <TableCell sx={{ fontWeight: 600 }}>{r.cantidad}</TableCell>
                         <TableCell>{r.observaciones}</TableCell>
                       </>
                     )}


### PR DESCRIPTION
## Summary
- Corrige nombre de sólido priorizando `alimentacionOtros`
- Exporta CSV/PDF con `r.cantidad` para registros sólidos
- Muestra nombre y gramos en la tabla de sólidos

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2280737cc8327b6b936ea68bbf4d2