### PR TITLE
Use LONGBLOB for baby images

### DIFF
--- a/api-bebe/pom.xml
+++ b/api-bebe/pom.xml
@@ -107,6 +107,11 @@
       <artifactId>spring-security-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/api-bebe/src/main/java/com/babytrackmaster/api_bebe/entity/Bebe.java
+++ b/api-bebe/src/main/java/com/babytrackmaster/api_bebe/entity/Bebe.java
@@ -90,7 +90,7 @@ public class Bebe {
     private String observaciones;
 
     @Lob
-    @Column(name = "imagen_bebe")
+    @Column(name = "imagen_bebe", columnDefinition = "LONGBLOB")
     private byte[] imagenBebe;
 
     @Column(nullable = false)

--- a/api-bebe/src/main/resources/schema.sql
+++ b/api-bebe/src/main/resources/schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS tipo_lactancia (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS tipo_alergia (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS tipo_grupo_sanguineo (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(50) NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS bebes (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    usuario_id BIGINT NOT NULL,
+    nombre VARCHAR(100) NOT NULL,
+    fecha_nacimiento DATE NOT NULL,
+    sexo VARCHAR(10) NOT NULL,
+    peso_nacer DOUBLE,
+    talla_nacer DOUBLE,
+    semanas_gestacion INT,
+    perimetro_craneal_nacer DOUBLE,
+    peso_actual DOUBLE,
+    talla_actual DOUBLE,
+    bebe_activo BOOLEAN,
+    numero_ss VARCHAR(50),
+    tipo_lactancia_id BIGINT,
+    tipo_alergia_id BIGINT,
+    tipo_grupo_sanguineo_id BIGINT,
+    medicaciones VARCHAR(500),
+    pediatra VARCHAR(100),
+    centro_medico VARCHAR(255),
+    telefono_centro_medico VARCHAR(20),
+    observaciones VARCHAR(1000),
+    imagen_bebe LONGBLOB,
+    eliminado BOOLEAN NOT NULL,
+    creado_en TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    actualizado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+

--- a/api-bebe/src/test/java/com/babytrackmaster/api_bebe/entity/BebeImagePersistenceTest.java
+++ b/api-bebe/src/test/java/com/babytrackmaster/api_bebe/entity/BebeImagePersistenceTest.java
@@ -1,0 +1,35 @@
+package com.babytrackmaster.api_bebe.entity;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.babytrackmaster.api_bebe.repository.BebeRepository;
+
+@SpringBootTest
+class BebeImagePersistenceTest {
+
+    @Autowired
+    private BebeRepository bebeRepository;
+
+    @Test
+    void imagePersistsAndRetrievesCorrectly() {
+        Bebe bebe = new Bebe();
+        bebe.setUsuarioId(1L);
+        bebe.setNombre("Imagen");
+        bebe.setFechaNacimiento(LocalDate.of(2020, 1, 1));
+        bebe.setSexo("M");
+        byte[] imagen = new byte[]{1,2,3};
+        bebe.setImagenBebe(imagen);
+
+        Bebe saved = bebeRepository.save(bebe);
+        Bebe found = bebeRepository.findById(saved.getId()).orElseThrow();
+
+        assertArrayEquals(imagen, found.getImagenBebe());
+    }
+}
+

--- a/api-bebe/src/test/resources/application.properties
+++ b/api-bebe/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## Summary
- switch `imagen_bebe` column to `LONGBLOB`
- map `imagenBebe` field explicitly as LONGBLOB and add test to ensure image persistence
- add schema and H2 test configuration

## Testing
- `./mvnw -q -e test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2329d33f08327812ff2eaf3d419c3