### PR TITLE
feat: track solid food quantity in feeding records

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionRequest.java
@@ -30,6 +30,7 @@ public class AlimentacionRequest {
 
     // Solidos
     private TipoAlimentacionSolido tipoAlimentacionSolido;
+    private Integer cantidadAlimentoSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
     private String alimentacionOtros;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/dto/AlimentacionResponse.java
@@ -25,6 +25,7 @@ public class AlimentacionResponse {
     private Integer cantidadMl;
     private Integer cantidadLecheFormula;
     private TipoAlimentacionSolido tipoAlimentacionSolido;
+    private Integer cantidadAlimentoSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
     private String alimentacionOtros;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/entity/Alimentacion.java
@@ -48,6 +48,7 @@ public class Alimentacion {
     @ManyToOne
     @JoinColumn(name = "tipo_alimentacion_solido_id")
     private TipoAlimentacionSolido tipoAlimentacionSolido;
+    private Integer cantidadAlimentoSolido;
     private String cantidad;
     private Integer cantidadOtrosAlimentos;
     private String alimentacionOtros;

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/mapper/AlimentacionMapper.java
@@ -20,6 +20,7 @@ public class AlimentacionMapper {
         a.setCantidadMl(req.getCantidadMl());
         a.setCantidadLecheFormula(req.getCantidadLecheFormula());
         a.setTipoAlimentacionSolido(req.getTipoAlimentacionSolido());
+        a.setCantidadAlimentoSolido(req.getCantidadAlimentoSolido());
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setAlimentacionOtros(req.getAlimentacionOtros());
@@ -40,6 +41,7 @@ public class AlimentacionMapper {
         a.setCantidadMl(req.getCantidadMl());
         a.setCantidadLecheFormula(req.getCantidadLecheFormula());
         a.setTipoAlimentacionSolido(req.getTipoAlimentacionSolido());
+        a.setCantidadAlimentoSolido(req.getCantidadAlimentoSolido());
         a.setCantidad(req.getCantidad());
         a.setCantidadOtrosAlimentos(req.getCantidadOtrosAlimentos());
         a.setAlimentacionOtros(req.getAlimentacionOtros());
@@ -60,6 +62,7 @@ public class AlimentacionMapper {
         r.setCantidadMl(a.getCantidadMl());
         r.setCantidadLecheFormula(a.getCantidadLecheFormula());
         r.setTipoAlimentacionSolido(a.getTipoAlimentacionSolido());
+        r.setCantidadAlimentoSolido(a.getCantidadAlimentoSolido());
         r.setCantidad(a.getCantidad());
         r.setCantidadOtrosAlimentos(a.getCantidadOtrosAlimentos());
         r.setAlimentacionOtros(a.getAlimentacionOtros());

--- a/api-alimentacion/src/main/resources/schema.sql
+++ b/api-alimentacion/src/main/resources/schema.sql
@@ -56,6 +56,7 @@ CREATE TABLE IF NOT EXISTS alimentacion (
     cantidad_ml INT,
     cantidad_leche_formula INT,
     tipo_alimentacion_solido_id BIGINT,
+    cantidad_alimento_solido INT,
     cantidad VARCHAR(50),
     cantidad_otros_alimentos INT,
     alimentacion_otros VARCHAR(100),

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionControllerTest.java
@@ -81,8 +81,10 @@ class AlimentacionControllerTest {
         req.setTipoAlimentacion(tipo);
         req.setFechaHora(LocalDateTime.now());
         req.setCantidadMl(100);
+        req.setCantidadAlimentoSolido(3);
         AlimentacionResponse resp = new AlimentacionResponse();
         resp.setId(1L);
+        resp.setCantidadAlimentoSolido(3);
         when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
 
         String json = mapper.writeValueAsString(req);
@@ -101,8 +103,10 @@ class AlimentacionControllerTest {
         tipo.setNombre("Biberón");
         req.setTipoAlimentacion(tipo);
         req.setCantidadMl(100);
+        req.setCantidadAlimentoSolido(3);
         AlimentacionResponse resp = new AlimentacionResponse();
         resp.setId(1L);
+        resp.setCantidadAlimentoSolido(3);
         resp.setFechaHora(LocalDateTime.now());
         when(service.crear(any(Long.class), any(Long.class), any(AlimentacionRequest.class))).thenReturn(resp);
 

--- a/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
+++ b/api-alimentacion/src/test/java/com/babytrackmaster/api_alimentacion/AlimentacionServiceImplTest.java
@@ -55,6 +55,7 @@ class AlimentacionServiceImplTest {
         req.setTipoAlimentacion(tipo);
         req.setFechaHora(LocalDateTime.now());
         req.setCantidadMl(120);
+        req.setCantidadAlimentoSolido(2);
 
         Alimentacion saved = AlimentacionMapper.toEntity(req, 1L, 2L);
         saved.setId(5L);
@@ -63,6 +64,7 @@ class AlimentacionServiceImplTest {
 
         AlimentacionResponse resp = service.crear(1L, 2L, req);
         assertEquals(5L, resp.getId());
+        assertEquals(2, resp.getCantidadAlimentoSolido());
         verify(repo).save(any(Alimentacion.class));
     }
 
@@ -82,6 +84,22 @@ class AlimentacionServiceImplTest {
 
         AlimentacionResponse resp = service.crear(1L, 2L, req);
         assertNotNull(resp.getFechaHora());
+        verify(repo).save(any(Alimentacion.class));
+    }
+    
+    @Test
+    void actualizarCantidadAlimentoSolido() {
+        AlimentacionRequest req = new AlimentacionRequest();
+        req.setCantidadAlimentoSolido(5);
+        Alimentacion existente = new Alimentacion();
+        existente.setId(7L);
+        existente.setUsuarioId(1L);
+        existente.setBebeId(2L);
+        existente.setCantidadAlimentoSolido(2);
+        when(repo.findByIdAndUsuarioIdAndBebeIdAndEliminadoFalse(7L,1L,2L)).thenReturn(java.util.Optional.of(existente));
+        when(repo.save(any(Alimentacion.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        AlimentacionResponse resp = service.actualizar(1L,2L,7L, req);
+        assertEquals(5, resp.getCantidadAlimentoSolido());
         verify(repo).save(any(Alimentacion.class));
     }
 }


### PR DESCRIPTION
## Summary
- add `cantidad_alimento_solido` column and model fields
- map new property in request/response and mapper
- test solid food quantity creation and update

## Testing
- `./mvnw -q test` *(failed: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2805021148327820ddda739b1223a