### PR TITLE
fix: ensure solid food amount is sent correctly

### DIFF
--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -28,8 +28,16 @@ export const obtenerEstadisticas = (usuarioId, bebeId, tipoAlimentacionId) => {
 };
 
 const buildPayload = (data) => {
+  const cantidadAlimentoSolido = Number(data.cantidadAlimentoSolido);
   const payload = {
     ...data,
+    cantidadAlimentoSolido:
+      data.cantidadAlimentoSolido === undefined ||
+      data.cantidadAlimentoSolido === null ||
+      data.cantidadAlimentoSolido === '' ||
+      Number.isNaN(cantidadAlimentoSolido)
+        ? undefined
+        : cantidadAlimentoSolido,
     tipoAlimentacion: data.tipoAlimentacionId
       ? { id: data.tipoAlimentacionId }
       : undefined,

--- a/frontend-baby/src/services/alimentacionService.test.js
+++ b/frontend-baby/src/services/alimentacionService.test.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { crearRegistro } from './alimentacionService';
+import { API_ALIMENTACION_URL } from '../config';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+describe('alimentacionService', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('conserva cantidadAlimentoSolido como número en el payload', () => {
+    axios.post.mockResolvedValue({});
+    const usuarioId = 1;
+    const bebeId = 2;
+    const data = { cantidadAlimentoSolido: '5', tipoAlimentacionId: 3 };
+    const API_ALIMENTACION_ENDPOINT = `${API_ALIMENTACION_URL}/api/v1/alimentacion`;
+
+    crearRegistro(usuarioId, bebeId, data);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
+      expect.objectContaining({
+        cantidadAlimentoSolido: 5,
+        tipoAlimentacion: { id: 3 },
+      })
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- preserve `cantidadAlimentoSolido` in alimentar payload and cast to number
- add unit test for `buildPayload` handling of solid food amount

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c28289aaf88327bce8b9301aeb5751