### PR TITLE
docs: describe cantidad_alimento_solido parameter

### DIFF
--- a/api-alimentacion/README.md
+++ b/api-alimentacion/README.md
@@ -3,6 +3,25 @@ Microservicio para el **registro de alimentación**: lactancia, biberón y alime
 ## Descripción
 Permite CRUD de registros de alimentación para cada bebé y usuario, así como estadísticas básicas.
 
+## Campos principales
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `cantidad_alimento_solido` | INT | Cantidad en gramos del alimento sólido ingerido por el bebé. |
+
+## Ejemplo de uso: registro de sólidos
+
+```bash
+curl -X POST "http://localhost:8091/api/v1/alimentacion/usuario/{usuarioId}/bebe/{bebeId}" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "tipoAlimentacion": { "id": 3 },
+        "tipoAlimentacionSolido": { "id": 1 },
+        "cantidadAlimentoSolido": 80,
+        "observaciones": "Puré de verduras"
+      }'
+```
+
 ## Tecnologías usadas
 - Java 17
 - Spring Boot 3.x (Spring Web)

--- a/documentacion/README.md
+++ b/documentacion/README.md
@@ -13,3 +13,9 @@ Carpeta para la **documentación funcional y técnica** del proyecto.
 ## Tecnologías y formatos
 - Markdown (`.md`), PDF, DOCX
 - Herramientas: Draw.io / Excalidraw / Figma (wireframes), PlantUML (diagramas), Swagger/OpenAPI (APIs)
+
+## Campos de alimentación
+
+| Campo                     | Tipo | Descripción                                                                 |
+|---------------------------|------|-----------------------------------------------------------------------------|
+| `cantidad_alimento_solido` | INT  | Cantidad en gramos del alimento sólido ingerido por el bebé en cada registro. |


### PR DESCRIPTION
## Summary
- document tabla de alimentación con el nuevo campo `cantidad_alimento_solido`
- ejemplo de API actualizado para incluir `cantidadAlimentoSolido`

## Testing
- `./mvnw -q test` *(api-alimentacion)* (failed: Non-resolvable parent POM, Network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_68c283f513f48327a318c0dce3ba7ecf