### PR TITLE
feat: add diaper type entity with CRUD and mapping

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/config/DataInitializer.java
@@ -10,13 +10,16 @@ import org.springframework.context.annotation.Configuration;
 import lombok.RequiredArgsConstructor;
 
 import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
 import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
 
 @Configuration
 @RequiredArgsConstructor
 public class DataInitializer {
 
     private final TipoCuidadoRepository tipoCuidadoRepository;
+    private final TipoPanalRepository tipoPanalRepository;
    
 
     @Bean
@@ -29,6 +32,13 @@ public class DataInitializer {
                     createTipoCuidado("Baño")
                 ));
             }
+            if (tipoPanalRepository.count() == 0) {
+                tipoPanalRepository.saveAll(List.of(
+                    createTipoPanal("PIPI"),
+                    createTipoPanal("CACA"),
+                    createTipoPanal("MIXTO")
+                ));
+            }
         };
     }
 
@@ -39,5 +49,14 @@ public class DataInitializer {
         tc.setCreatedAt(now);
         tc.setUpdatedAt(now);
         return tc;
+    }
+
+    private TipoPanal createTipoPanal(String nombre) {
+        TipoPanal tp = new TipoPanal();
+        Date now = new Date();
+        tp.setNombre(nombre);
+        tp.setCreatedAt(now);
+        tp.setUpdatedAt(now);
+        return tp;
     }
 }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/TipoPanalController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/TipoPanalController.java
@@ -1,0 +1,71 @@
+package com.babytrackmaster.api_cuidados.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.babytrackmaster.api_cuidados.dto.TipoPanalRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoPanalResponse;
+import com.babytrackmaster.api_cuidados.service.TipoPanalService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/tipos-panal")
+@Tag(name = "Tipos de pañal", description = "Gestión de tipos de pañal")
+public class TipoPanalController {
+
+    private final TipoPanalService service;
+
+    public TipoPanalController(TipoPanalService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Crear un tipo de pañal")
+    @PostMapping
+    public ResponseEntity<TipoPanalResponse> crear(
+            @Valid @RequestBody TipoPanalRequest req) {
+        return new ResponseEntity<TipoPanalResponse>(service.crear(req), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "Actualizar un tipo de pañal")
+    @PutMapping("/{id}")
+    public ResponseEntity<TipoPanalResponse> actualizar(
+            @Parameter(description = "ID del tipo de pañal", example = "1") @PathVariable Long id,
+            @Valid @RequestBody TipoPanalRequest req) {
+        return ResponseEntity.ok(service.actualizar(id, req));
+    }
+
+    @Operation(summary = "Eliminar un tipo de pañal")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(
+            @Parameter(description = "ID del tipo de pañal", example = "1") @PathVariable Long id) {
+        service.eliminar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "Obtener un tipo de pañal")
+    @GetMapping("/{id}")
+    public ResponseEntity<TipoPanalResponse> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(service.obtener(id));
+    }
+
+    @Operation(summary = "Listar tipos de pañal")
+    @GetMapping
+    public ResponseEntity<List<TipoPanalResponse>> listar() {
+        return ResponseEntity.ok(service.listar());
+    }
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
@@ -18,7 +18,8 @@ public class CuidadoRequest {
     private Date fin;
     private String duracion;
     private Integer cantidadMl;
-    private String tipoPanal;
+    @Schema(example = "1", description = "ID del tipo de pañal")
+    private Long tipoPanalId;
     private String medicamento;
     private String dosis;
     private String observaciones;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
@@ -21,7 +21,8 @@ public class CuidadoResponse {
     private String duracion;
     @Schema(example = "120")
     private Integer cantidadMl;
-    private String tipoPanal;
+    private Long tipoPanalId;
+    private String tipoPanalNombre;
     private String medicamento;
     private String dosis;
     private String observaciones;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoPanalRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoPanalRequest.java
@@ -1,0 +1,16 @@
+package com.babytrackmaster.api_cuidados.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Schema(name = "TipoPanalRequest", description = "Datos para crear/actualizar un tipo de pañal")
+public class TipoPanalRequest {
+    @NotBlank
+    @Size(min = 1, max = 60)
+    @Schema(example = "PIPI", description = "Nombre del tipo de pañal")
+    private String nombre;
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoPanalResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/TipoPanalResponse.java
@@ -1,0 +1,20 @@
+package com.babytrackmaster.api_cuidados.dto;
+
+import java.util.Date;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(name = "TipoPanalResponse", description = "Representación de un tipo de pañal")
+public class TipoPanalResponse {
+    @Schema(example = "1")
+    private Long id;
+
+    @Schema(example = "PIPI")
+    private String nombre;
+
+    private Date createdAt;
+    private Date updatedAt;
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
@@ -39,8 +39,9 @@ public class Cuidado {
     @Column(name="cantidad_ml")
     private Integer cantidadMl;
 
-    @Column(name="tipo_panal", length=20)
-    private String tipoPanal; // PIPI/CACA/MIXTO
+    @ManyToOne
+    @JoinColumn(name = "tipo_panal")
+    private TipoPanal tipoPanal;
 
     @Column(length=120)
     private String medicamento;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/TipoPanal.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/TipoPanal.java
@@ -1,0 +1,30 @@
+package com.babytrackmaster.api_cuidados.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@NoArgsConstructor
+@Entity
+@Table(name = "tipo_panal")
+public class TipoPanal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 60)
+    private String nombre;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created_at", nullable = false)
+    private Date createdAt;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "updated_at", nullable = false)
+    private Date updatedAt;
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -6,22 +6,30 @@ import com.babytrackmaster.api_cuidados.dto.CuidadoRequest;
 import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
 import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
 
 public class CuidadoMapper {
 
-    public static Cuidado toEntity(CuidadoRequest req, Long usuarioId, TipoCuidadoRepository tipoRepo) {
+    public static Cuidado toEntity(CuidadoRequest req, Long usuarioId, TipoCuidadoRepository tipoRepo, TipoPanalRepository tipoPanalRepo) {
         Cuidado c = new Cuidado();
         c.setBebeId(req.getBebeId());
         c.setUsuarioId(usuarioId);
         TipoCuidado tipo = tipoRepo.findById(req.getTipoId())
                 .orElseThrow(() -> new IllegalArgumentException("Tipo de cuidado no encontrado: " + req.getTipoId()));
         c.setTipo(tipo);
+        if (req.getTipoPanalId() != null) {
+            TipoPanal tp = tipoPanalRepo.findById(req.getTipoPanalId())
+                    .orElseThrow(() -> new IllegalArgumentException("Tipo de pañal no encontrado: " + req.getTipoPanalId()));
+            c.setTipoPanal(tp);
+        } else {
+            c.setTipoPanal(null);
+        }
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
         c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
-        c.setTipoPanal(req.getTipoPanal());
         c.setMedicamento(req.getMedicamento());
         c.setDosis(req.getDosis());
         c.setObservaciones(req.getObservaciones());
@@ -32,17 +40,23 @@ public class CuidadoMapper {
         return c;
     }
 
-    public static void copyToEntity(CuidadoRequest req, Cuidado c, Long usuarioId, TipoCuidadoRepository tipoRepo) {
+    public static void copyToEntity(CuidadoRequest req, Cuidado c, Long usuarioId, TipoCuidadoRepository tipoRepo, TipoPanalRepository tipoPanalRepo) {
         c.setBebeId(req.getBebeId());
         c.setUsuarioId(usuarioId);
         TipoCuidado tipo = tipoRepo.findById(req.getTipoId())
                 .orElseThrow(() -> new IllegalArgumentException("Tipo de cuidado no encontrado: " + req.getTipoId()));
         c.setTipo(tipo);
+        if (req.getTipoPanalId() != null) {
+            TipoPanal tp = tipoPanalRepo.findById(req.getTipoPanalId())
+                    .orElseThrow(() -> new IllegalArgumentException("Tipo de pañal no encontrado: " + req.getTipoPanalId()));
+            c.setTipoPanal(tp);
+        } else {
+            c.setTipoPanal(null);
+        }
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
         c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
-        c.setTipoPanal(req.getTipoPanal());
         c.setMedicamento(req.getMedicamento());
         c.setDosis(req.getDosis());
         c.setObservaciones(req.getObservaciones());
@@ -62,7 +76,10 @@ public class CuidadoMapper {
         r.setFin(c.getFin());
         r.setDuracion(c.getDuracion());
         r.setCantidadMl(c.getCantidadMl());
-        r.setTipoPanal(c.getTipoPanal());
+        if (c.getTipoPanal() != null) {
+            r.setTipoPanalId(c.getTipoPanal().getId());
+            r.setTipoPanalNombre(c.getTipoPanal().getNombre());
+        }
         r.setMedicamento(c.getMedicamento());
         r.setDosis(c.getDosis());
         r.setObservaciones(c.getObservaciones());

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/TipoPanalMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/TipoPanalMapper.java
@@ -1,0 +1,34 @@
+package com.babytrackmaster.api_cuidados.mapper;
+
+import java.util.Date;
+
+import com.babytrackmaster.api_cuidados.dto.TipoPanalRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoPanalResponse;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
+
+public class TipoPanalMapper {
+
+    public static TipoPanal toEntity(TipoPanalRequest req) {
+        TipoPanal t = new TipoPanal();
+        t.setNombre(req.getNombre());
+        Date now = new Date();
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return t;
+    }
+
+    public static void copyToEntity(TipoPanalRequest req, TipoPanal t) {
+        t.setNombre(req.getNombre());
+        t.setUpdatedAt(new Date());
+    }
+
+    public static TipoPanalResponse toResponse(TipoPanal t) {
+        TipoPanalResponse r = new TipoPanalResponse();
+        r.setId(t.getId());
+        r.setNombre(t.getNombre());
+        r.setCreatedAt(t.getCreatedAt());
+        r.setUpdatedAt(t.getUpdatedAt());
+        return r;
+    }
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/TipoPanalRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/TipoPanalRepository.java
@@ -1,0 +1,8 @@
+package com.babytrackmaster.api_cuidados.repository;
+
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipoPanalRepository extends JpaRepository<TipoPanal, Long> {
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/TipoPanalService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/TipoPanalService.java
@@ -1,0 +1,15 @@
+package com.babytrackmaster.api_cuidados.service;
+
+import java.util.List;
+
+import com.babytrackmaster.api_cuidados.dto.TipoPanalRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoPanalResponse;
+
+public interface TipoPanalService {
+    TipoPanalResponse crear(TipoPanalRequest request);
+    TipoPanalResponse actualizar(Long id, TipoPanalRequest request);
+    void eliminar(Long id);
+    TipoPanalResponse obtener(Long id);
+    List<TipoPanalResponse> listar();
+}
+

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -16,6 +16,7 @@ import com.babytrackmaster.api_cuidados.entity.Cuidado;
 import com.babytrackmaster.api_cuidados.mapper.CuidadoMapper;
 import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
 import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
 import com.babytrackmaster.api_cuidados.service.CuidadoService;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -26,14 +27,16 @@ public class CuidadoServiceImpl implements CuidadoService {
 
     private final CuidadoRepository repo;
     private final TipoCuidadoRepository tipoRepo;
+    private final TipoPanalRepository tipoPanalRepo;
 
-    public CuidadoServiceImpl(CuidadoRepository repo, TipoCuidadoRepository tipoRepo) {
+    public CuidadoServiceImpl(CuidadoRepository repo, TipoCuidadoRepository tipoRepo, TipoPanalRepository tipoPanalRepo) {
         this.repo = repo;
         this.tipoRepo = tipoRepo;
+        this.tipoPanalRepo = tipoPanalRepo;
     }
 
     public CuidadoResponse crear(Long usuarioId, CuidadoRequest request) {
-        Cuidado c = CuidadoMapper.toEntity(request, usuarioId, tipoRepo);
+        Cuidado c = CuidadoMapper.toEntity(request, usuarioId, tipoRepo, tipoPanalRepo);
         c = repo.save(c);
         return CuidadoMapper.toResponse(c);
     }
@@ -43,7 +46,7 @@ public class CuidadoServiceImpl implements CuidadoService {
         if (c == null) {
             throw new IllegalArgumentException("Cuidado no encontrado: " + id);
         }
-        CuidadoMapper.copyToEntity(request, c, usuarioId, tipoRepo);
+        CuidadoMapper.copyToEntity(request, c, usuarioId, tipoRepo, tipoPanalRepo);
         c = repo.save(c);
         return CuidadoMapper.toResponse(c);
     }

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/TipoPanalServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/TipoPanalServiceImpl.java
@@ -1,0 +1,70 @@
+package com.babytrackmaster.api_cuidados.service.iml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.babytrackmaster.api_cuidados.dto.TipoPanalRequest;
+import com.babytrackmaster.api_cuidados.dto.TipoPanalResponse;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
+import com.babytrackmaster.api_cuidados.mapper.TipoPanalMapper;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
+import com.babytrackmaster.api_cuidados.service.TipoPanalService;
+
+@Service
+@Transactional
+public class TipoPanalServiceImpl implements TipoPanalService {
+
+    private final TipoPanalRepository repo;
+
+    public TipoPanalServiceImpl(TipoPanalRepository repo) {
+        this.repo = repo;
+    }
+
+    public TipoPanalResponse crear(TipoPanalRequest request) {
+        TipoPanal t = TipoPanalMapper.toEntity(request);
+        t = repo.save(t);
+        return TipoPanalMapper.toResponse(t);
+    }
+
+    public TipoPanalResponse actualizar(Long id, TipoPanalRequest request) {
+        TipoPanal t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de pañal no encontrado: " + id);
+        }
+        TipoPanalMapper.copyToEntity(request, t);
+        t = repo.save(t);
+        return TipoPanalMapper.toResponse(t);
+    }
+
+    public void eliminar(Long id) {
+        TipoPanal t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de pañal no encontrado: " + id);
+        }
+        repo.delete(t);
+    }
+
+    @Transactional(readOnly = true)
+    public TipoPanalResponse obtener(Long id) {
+        TipoPanal t = repo.findById(id).orElse(null);
+        if (t == null) {
+            throw new IllegalArgumentException("Tipo de pañal no encontrado: " + id);
+        }
+        return TipoPanalMapper.toResponse(t);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TipoPanalResponse> listar() {
+        List<TipoPanal> list = repo.findAll(Sort.by("nombre"));
+        List<TipoPanalResponse> resp = new ArrayList<TipoPanalResponse>();
+        for (int i = 0; i < list.size(); i++) {
+            resp.add(TipoPanalMapper.toResponse(list.get(i)));
+        }
+        return resp;
+    }
+}
+

--- a/api-cuidados/src/main/resources/schema.sql
+++ b/api-cuidados/src/main/resources/schema.sql
@@ -13,9 +13,27 @@ INSERT INTO tipo_cuidado (nombre, created_at, updated_at) VALUES
 ('MEDICACION', NOW(), NOW()),
 ('PASEO', NOW(), NOW());
 
+CREATE TABLE IF NOT EXISTS tipo_panal (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    nombre VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO tipo_panal (nombre, created_at, updated_at) VALUES
+('PIPI', NOW(), NOW()),
+('CACA', NOW(), NOW()),
+('MIXTO', NOW(), NOW());
+
 ALTER TABLE cuidados
     ADD COLUMN duracion VARCHAR(50);
 
 ALTER TABLE cuidados
     ADD CONSTRAINT fk_cuidados_tipo FOREIGN KEY (tipo) REFERENCES tipo_cuidado(id);
+
+ALTER TABLE cuidados
+    ADD COLUMN tipo_panal BIGINT;
+
+ALTER TABLE cuidados
+    ADD CONSTRAINT fk_cuidados_tipo_panal FOREIGN KEY (tipo_panal) REFERENCES tipo_panal(id);
 

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
@@ -19,8 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
 import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
 import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
@@ -32,6 +34,8 @@ class CuidadoControllerTest {
     @Autowired
     private TipoCuidadoRepository tipoRepo;
     @Autowired
+    private TipoPanalRepository tipoPanalRepo;
+    @Autowired
     private CuidadoRepository cuidadoRepo;
 
     private Date baseDate;
@@ -40,18 +44,20 @@ class CuidadoControllerTest {
     void setUp() {
         cuidadoRepo.deleteAll();
         tipoRepo.deleteAll();
+        tipoPanalRepo.deleteAll();
         baseDate = date(2024,3,10,0,0);
 
         TipoCuidado sueno = saveTipo("Sue\u00f1o");
         TipoCuidado panal = saveTipo("Pa\u00f1al");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
+        TipoPanal pipi = saveTipoPanal("PIPI");
 
-        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,2,0));
-        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,11,30));
-        createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
-        createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
-        createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
-        createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
+        createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,2,0));
+        createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,11,30));
+        createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5));
+        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5));
+        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        createCuidado(bano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
     @Test
@@ -73,11 +79,21 @@ class CuidadoControllerTest {
         return tipoRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
+    private TipoPanal saveTipoPanal(String nombre) {
+        TipoPanal t = new TipoPanal();
+        Date now = new Date();
+        t.setNombre(nombre);
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return tipoPanalRepo.save(t);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
         c.setTipo(tipo);
+        c.setTipoPanal(tipoPanal);
         c.setInicio(inicio);
         c.setFin(fin);
         Date now = new Date();

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -15,8 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.babytrackmaster.api_cuidados.dto.QuickStatsResponse;
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
+import com.babytrackmaster.api_cuidados.entity.TipoPanal;
 import com.babytrackmaster.api_cuidados.repository.CuidadoRepository;
 import com.babytrackmaster.api_cuidados.repository.TipoCuidadoRepository;
+import com.babytrackmaster.api_cuidados.repository.TipoPanalRepository;
 import com.babytrackmaster.api_cuidados.service.CuidadoService;
 
 @SpringBootTest
@@ -28,6 +30,8 @@ class CuidadoServiceImplTest {
     @Autowired
     private TipoCuidadoRepository tipoRepo;
     @Autowired
+    private TipoPanalRepository tipoPanalRepo;
+    @Autowired
     private CuidadoRepository cuidadoRepo;
 
     private Date baseDate;
@@ -36,19 +40,21 @@ class CuidadoServiceImplTest {
     void setUp() {
         cuidadoRepo.deleteAll();
         tipoRepo.deleteAll();
+        tipoPanalRepo.deleteAll();
         baseDate = date(2024,3,10,0,0);
 
         TipoCuidado sueno = saveTipo("Sue\u00f1o");
         TipoCuidado panal = saveTipo("Pa\u00f1al");
         TipoCuidado bano = saveTipo("Ba\u00f1o");
+        TipoPanal pipi = saveTipoPanal("PIPI");
 
-        createCuidado(sueno, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
-        createCuidado(sueno, date(2024,3,10,10,0), date(2024,3,10,10,30), "90");
-        createCuidado(sueno, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
-        createCuidado(panal, date(2024,3,10,3,0), date(2024,3,10,3,5));
-        createCuidado(panal, date(2024,3,10,7,0), date(2024,3,10,7,5));
-        createCuidado(panal, date(2024,3,10,13,0), date(2024,3,10,13,7));
-        createCuidado(bano, date(2024,3,10,18,0), date(2024,3,10,18,20));
+        createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
+        createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,10,30), "90");
+        createCuidado(sueno, null, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
+        createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5));
+        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5));
+        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        createCuidado(bano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
     @Test
@@ -68,11 +74,21 @@ class CuidadoServiceImplTest {
         return tipoRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin, String duracion) {
+    private TipoPanal saveTipoPanal(String nombre) {
+        TipoPanal t = new TipoPanal();
+        Date now = new Date();
+        t.setNombre(nombre);
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return tipoPanalRepo.save(t);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
         c.setTipo(tipo);
+        c.setTipoPanal(tipoPanal);
         c.setInicio(inicio);
         c.setFin(fin);
         c.setDuracion(duracion);
@@ -82,8 +98,8 @@ class CuidadoServiceImplTest {
         return cuidadoRepo.save(c);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, Date inicio, Date fin) {
-        return createCuidado(tipo, inicio, fin, null);
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin) {
+        return createCuidado(tipo, tipoPanal, inicio, fin, null);
     }
 
     private Date date(int year,int month,int day,int hour,int minute) {


### PR DESCRIPTION
## Summary
- add `tipo_panal` table and seed data; link `cuidados.tipo_panal` to it
- model diaper type with entity, DTOs, mapper, repository, service and controller
- map `TipoPanal` in `Cuidado` including new request/response fields

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a44ba76c832797e67ee37fcd532a