### PR TITLE
feat: add diaper type selection

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -12,7 +12,7 @@ import FormControl from '@mui/material/FormControl';
 import FormLabel from '@mui/material/FormLabel';
 import { DateTimePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
-import { listarTipos } from '../../services/cuidadosService';
+import { listarTipos, listarTiposPanal } from '../../services/cuidadosService';
 import { saveButton, cancelButton } from '../../theme/buttonStyles';
 
 export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
@@ -23,8 +23,10 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     cantidadMl: "",
     duracion: "",
     observaciones: "",
+    tipoPanalId: "",
   });
   const [tipoOptions, setTipoOptions] = useState([]);
+  const [tipoPanalOptions, setTipoPanalOptions] = useState([]);
 
   useEffect(() => {
     if (initialData) {
@@ -34,6 +36,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         cantidadMl: initialData.cantidadMl || "",
         duracion: initialData.duracion || "",
         observaciones: initialData.observaciones || "",
+        tipoPanalId: initialData.tipoPanalId || "",
       });
     } else {
       setFormData({
@@ -42,6 +45,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         cantidadMl: "",
         duracion: "",
         observaciones: "",
+        tipoPanalId: "",
       });
     }
   }, [initialData, open]);
@@ -50,6 +54,9 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     listarTipos()
       .then((response) => setTipoOptions(response.data))
       .catch((err) => console.error("Error fetching tipos cuidado:", err));
+    listarTiposPanal()
+      .then((response) => setTipoPanalOptions(response.data))
+      .catch((err) => console.error("Error fetching tipos panal:", err));
   }, []);
 
   const handleChange = (e) => {
@@ -83,6 +90,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     (option) => Number(option.id) === Number(formData.tipoId),
   );
   const isSueno = selectedTipo?.nombre === "Sueño";
+  const isPanal = selectedTipo?.nombre === "Pañal";
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
@@ -128,7 +136,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
                 inputProps={{ min: 0 }}
               />
             </FormControl>
-          ) : (
+          ) : isPanal ? null : (
             <FormControl fullWidth sx={{ mb: 2 }}>
               <FormLabel sx={{ mb: 1 }}>Cantidad</FormLabel>
               <TextField
@@ -138,6 +146,23 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
                 onChange={handleChange}
                 inputProps={{ min: 0 }}
               />
+            </FormControl>
+          )}
+          {isPanal && (
+            <FormControl fullWidth sx={{ mb: 2 }}>
+              <FormLabel sx={{ mb: 1 }}>Tipo pañal</FormLabel>
+              <TextField
+                select
+                name="tipoPanalId"
+                value={formData.tipoPanalId}
+                onChange={handleChange}
+              >
+                {tipoPanalOptions.map((option) => (
+                  <MenuItem key={option.id} value={option.id}>
+                    {option.nombre}
+                  </MenuItem>
+                ))}
+              </TextField>
             </FormControl>
           )}
           <FormControl fullWidth sx={{ mb: 2 }}>

--- a/frontend-baby/src/dashboard/components/CuidadoForm.test.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.test.js
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CuidadoForm from './CuidadoForm';
+import { listarTipos, listarTiposPanal } from '../../services/cuidadosService';
+import { LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+
+jest.mock('../../services/cuidadosService', () => ({
+  listarTipos: jest.fn(),
+  listarTiposPanal: jest.fn(),
+}));
+
+describe('CuidadoForm', () => {
+  beforeEach(() => {
+    listarTipos.mockResolvedValue({ data: [{ id: 1, nombre: 'Pañal' }] });
+    listarTiposPanal.mockResolvedValue({
+      data: [
+        { id: 10, nombre: 'Pipi' },
+        { id: 11, nombre: 'Caca' },
+        { id: 12, nombre: 'Mixto' },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza selector de tipo de pañal y envía tipoPanalId', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <LocalizationProvider dateAdapter={AdapterDayjs}>
+        <CuidadoForm
+          open
+          onClose={() => {}}
+          onSubmit={onSubmit}
+          initialData={{ inicio: '2024-01-01T10:00' }}
+        />
+      </LocalizationProvider>
+    );
+
+    await waitFor(() => expect(listarTipos).toHaveBeenCalled());
+
+    const tipoSelect = screen.getAllByRole('combobox')[0];
+    await userEvent.click(tipoSelect);
+    await userEvent.click(screen.getByRole('option', { name: 'Pañal' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBe(2);
+    });
+    const tipoPanalSelect = screen.getAllByRole('combobox')[1];
+    await userEvent.click(tipoPanalSelect);
+    await userEvent.click(screen.getByRole('option', { name: 'Pipi' }));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Guardar' }));
+
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ tipoPanalId: 10 })
+      )
+    );
+  });
+});

--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -49,7 +49,7 @@ export default function RecentCareCard() {
         return quantity ? `${quantity}ml` : '';
       }
       case 'Pañal':
-        return 'Limpio';
+        return item.tipoPanalNombre || '';
       case 'Sueño':
       case 'Dormir': {
         const durationMin =

--- a/frontend-baby/src/dashboard/components/RecentCareCard.test.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.test.js
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import RecentCareCard from './RecentCareCard';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+import { listarRecientes } from '../../services/cuidadosService';
+
+jest.mock('../../services/cuidadosService', () => ({
+  listarRecientes: jest.fn(),
+}));
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}));
+
+describe('RecentCareCard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('muestra tipoPanalNombre para cuidados de pañal', async () => {
+    listarRecientes.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          tipoNombre: 'Pañal',
+          inicio: '2024-01-01T10:00',
+          tipoPanalNombre: 'Pipi',
+        },
+      ],
+    });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <RecentCareCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listarRecientes).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByText('Pipi')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -61,6 +61,7 @@ export default function Cuidados() {
   );
 
   const isSueno = tipos[tab]?.nombre === "Sueño";
+  const isPanal = tipos[tab]?.nombre === "Pañal";
 
   useEffect(() => {
     const stats = Array(7).fill(0);
@@ -162,7 +163,7 @@ export default function Cuidados() {
     const headers = [
       "Hora",
       "Tipo",
-      isSueno ? "Duración" : "Cantidad",
+      isSueno ? "Duración" : isPanal ? "Tipo pañal" : "Cantidad",
       "Nota",
     ];
     const rows = filteredCuidados.map((cuidado) => [
@@ -170,6 +171,8 @@ export default function Cuidados() {
       cuidado.tipoNombre,
       cuidado.tipoNombre === "Sueño"
         ? cuidado.duracion ?? "-"
+        : cuidado.tipoNombre === "Pañal"
+        ? cuidado.tipoPanalNombre ?? "-"
         : cuidado.cantidadMl ?? "-",
       cuidado.observaciones ?? "",
     ]);
@@ -192,7 +195,7 @@ export default function Cuidados() {
     const tableColumn = [
       "Hora",
       "Tipo",
-      isSueno ? "Duración" : "Cantidad",
+      isSueno ? "Duración" : isPanal ? "Tipo pañal" : "Cantidad",
       "Nota",
     ];
     const tableRows = filteredCuidados.map((cuidado) => [
@@ -200,6 +203,8 @@ export default function Cuidados() {
       cuidado.tipoNombre,
       cuidado.tipoNombre === "Sueño"
         ? cuidado.duracion ?? "-"
+        : cuidado.tipoNombre === "Pañal"
+        ? cuidado.tipoPanalNombre ?? "-"
         : cuidado.cantidadMl ?? "-",
       cuidado.observaciones ?? "",
     ]);
@@ -244,7 +249,9 @@ export default function Cuidados() {
             <TableRow>
               <TableCell>Hora</TableCell>
               <TableCell>Tipo</TableCell>
-              <TableCell>{isSueno ? "Duración" : "Cantidad"}</TableCell>
+              <TableCell>
+                {isSueno ? "Duración" : isPanal ? "Tipo pañal" : "Cantidad"}
+              </TableCell>
               <TableCell>Nota</TableCell>
               <TableCell align="center">Acciones</TableCell>
             </TableRow>
@@ -261,6 +268,8 @@ export default function Cuidados() {
                   <TableCell sx={{ fontWeight: 600 }}>
                     {cuidado.tipoNombre === "Sueño"
                       ? cuidado.duracion ?? "-"
+                      : cuidado.tipoNombre === "Pañal"
+                      ? cuidado.tipoPanalNombre ?? "-"
                       : cuidado.cantidadMl ?? "-"}
                   </TableCell>
                   <TableCell>{cuidado.observaciones}</TableCell>

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -3,6 +3,7 @@ import { API_CUIDADOS_URL } from '../config';
 
 const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
 const API_TIPOS_CUIDADO_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/tipos-cuidado`;
+const API_TIPOS_PANAL_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/tipos-panal`;
 
 export const listarPorBebe = (usuarioId, bebeId, page, size) => {
   const params = {};
@@ -29,13 +30,15 @@ export const obtenerStatsRapidas = (usuarioId, bebeId) =>
   );
 
 export const crearCuidado = (usuarioId, data) => {
-  return axios.post(`${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}`, data);
+  const payload = { ...data, tipoPanalId: data.tipoPanalId };
+  return axios.post(`${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}`, payload);
 };
 
 export const actualizarCuidado = (usuarioId, id, data) => {
+  const payload = { ...data, tipoPanalId: data.tipoPanalId };
   return axios.put(
     `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/${id}`,
-    data
+    payload
   );
 };
 
@@ -45,5 +48,9 @@ export const eliminarCuidado = (usuarioId, id) => {
 
 export const listarTipos = () => {
   return axios.get(`${API_TIPOS_CUIDADO_ENDPOINT}`);
+};
+
+export const listarTiposPanal = () => {
+  return axios.get(`${API_TIPOS_PANAL_ENDPOINT}`);
 };
 

--- a/frontend-baby/src/services/cuidadosService.test.js
+++ b/frontend-baby/src/services/cuidadosService.test.js
@@ -1,11 +1,18 @@
 import axios from 'axios';
-import { obtenerStatsRapidas } from './cuidadosService';
+import {
+  obtenerStatsRapidas,
+  crearCuidado,
+  actualizarCuidado,
+  listarTiposPanal,
+} from './cuidadosService';
 import { API_CUIDADOS_URL } from '../config';
 
 jest.mock('axios', () => ({
   __esModule: true,
   default: {
     get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
   },
 }));
 
@@ -24,6 +31,44 @@ describe('cuidadosService', () => {
 
     expect(axios.get).toHaveBeenCalledWith(
       `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+    );
+  });
+
+  it('listarTiposPanal realiza la llamada HTTP correcta', () => {
+    axios.get.mockResolvedValue({});
+    const API_TIPOS_PANAL_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/tipos-panal`;
+
+    listarTiposPanal();
+
+    expect(axios.get).toHaveBeenCalledWith(API_TIPOS_PANAL_ENDPOINT);
+  });
+
+  it('crearCuidado envía tipoPanalId cuando está presente', () => {
+    axios.post.mockResolvedValue({});
+    const usuarioId = 1;
+    const data = { bebeId: 2, tipoPanalId: 3 };
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    crearCuidado(usuarioId, data);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}`,
+      expect.objectContaining({ tipoPanalId: 3 })
+    );
+  });
+
+  it('actualizarCuidado envía tipoPanalId cuando está presente', () => {
+    axios.put.mockResolvedValue({});
+    const usuarioId = 1;
+    const id = 5;
+    const data = { bebeId: 2, tipoPanalId: 4 };
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    actualizarCuidado(usuarioId, id, data);
+
+    expect(axios.put).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/${id}`,
+      expect.objectContaining({ tipoPanalId: 4 })
     );
   });
 });


### PR DESCRIPTION
## Summary
- add API endpoint and helper to list diaper types and send `tipoPanalId`
- extend care form with diaper type selector and propagate field through care views
- show diaper type in care listings and recent card

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c2a5baa0c0832782aaed27c0aa75a1