### PR TITLE
Add diaper quantity field across front-end and API

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
@@ -20,6 +20,8 @@ public class CuidadoRequest {
     private Integer cantidadMl;
     @Schema(example = "1", description = "ID del tipo de pañal")
     private Long tipoPanalId;
+    @Schema(example = "2", description = "Cantidad de pañales")
+    private Integer cantidadPanal;
     private String medicamento;
     private String dosis;
     private String observaciones;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
@@ -23,6 +23,8 @@ public class CuidadoResponse {
     private Integer cantidadMl;
     private Long tipoPanalId;
     private String tipoPanalNombre;
+    @Schema(example = "2")
+    private Integer cantidadPanal;
     private String medicamento;
     private String dosis;
     private String observaciones;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
@@ -43,6 +43,9 @@ public class Cuidado {
     @JoinColumn(name = "tipo_panal")
     private TipoPanal tipoPanal;
 
+    @Column(name = "cantidad_panal")
+    private Integer cantidadPanal;
+
     @Column(length=120)
     private String medicamento;
 

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -30,6 +30,7 @@ public class CuidadoMapper {
         c.setFin(req.getFin());
         c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
+        c.setCantidadPanal(req.getCantidadPanal());
         c.setMedicamento(req.getMedicamento());
         c.setDosis(req.getDosis());
         c.setObservaciones(req.getObservaciones());
@@ -57,6 +58,7 @@ public class CuidadoMapper {
         c.setFin(req.getFin());
         c.setDuracion(req.getDuracion());
         c.setCantidadMl(req.getCantidadMl());
+        c.setCantidadPanal(req.getCantidadPanal());
         c.setMedicamento(req.getMedicamento());
         c.setDosis(req.getDosis());
         c.setObservaciones(req.getObservaciones());
@@ -76,6 +78,7 @@ public class CuidadoMapper {
         r.setFin(c.getFin());
         r.setDuracion(c.getDuracion());
         r.setCantidadMl(c.getCantidadMl());
+        r.setCantidadPanal(c.getCantidadPanal());
         if (c.getTipoPanal() != null) {
             r.setTipoPanalId(c.getTipoPanal().getId());
             r.setTipoPanalNombre(c.getTipoPanal().getNombre());

--- a/api-cuidados/src/main/resources/schema.sql
+++ b/api-cuidados/src/main/resources/schema.sql
@@ -37,3 +37,6 @@ ALTER TABLE cuidados
 ALTER TABLE cuidados
     ADD CONSTRAINT fk_cuidados_tipo_panal FOREIGN KEY (tipo_panal) REFERENCES tipo_panal(id);
 
+ALTER TABLE cuidados
+    ADD COLUMN cantidad_panal INT;
+

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoControllerTest.java
@@ -39,6 +39,7 @@ class CuidadoControllerTest {
     private CuidadoRepository cuidadoRepo;
 
     private Date baseDate;
+    private Cuidado panalGuardado;
 
     @BeforeEach
     void setUp() {
@@ -54,9 +55,9 @@ class CuidadoControllerTest {
 
         createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,2,0));
         createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,11,30));
-        createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5));
-        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5));
-        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        panalGuardado = createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5), 2);
+        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5), 1);
+        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7), 1);
         createCuidado(bano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
@@ -68,6 +69,13 @@ class CuidadoControllerTest {
             .andExpect(jsonPath("$.horasSueno", closeTo(3.5, 0.01)))
             .andExpect(jsonPath("$.panales").value(3))
             .andExpect(jsonPath("$.banos").value(1));
+    }
+
+    @Test
+    void obtenerIncluyeCantidadPanal() throws Exception {
+        mockMvc.perform(get("/api/v1/cuidados/usuario/1/" + panalGuardado.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.cantidadPanal").value(2));
     }
 
     private TipoCuidado saveTipo(String nombre) {
@@ -88,18 +96,23 @@ class CuidadoControllerTest {
         return tipoPanalRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin) {
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, Integer cantidadPanal) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
         c.setTipo(tipo);
         c.setTipoPanal(tipoPanal);
+        c.setCantidadPanal(cantidadPanal);
         c.setInicio(inicio);
         c.setFin(fin);
         Date now = new Date();
         c.setCreatedAt(now);
         c.setUpdatedAt(now);
         return cuidadoRepo.save(c);
+    }
+
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin) {
+        return createCuidado(tipo, tipoPanal, inicio, fin, null);
     }
 
     private Date date(int year,int month,int day,int hour,int minute) {

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.babytrackmaster.api_cuidados.dto.QuickStatsResponse;
+import com.babytrackmaster.api_cuidados.dto.CuidadoResponse;
 import com.babytrackmaster.api_cuidados.entity.Cuidado;
 import com.babytrackmaster.api_cuidados.entity.TipoCuidado;
 import com.babytrackmaster.api_cuidados.entity.TipoPanal;
@@ -35,6 +36,7 @@ class CuidadoServiceImplTest {
     private CuidadoRepository cuidadoRepo;
 
     private Date baseDate;
+    private Cuidado panalGuardado;
 
     @BeforeEach
     void setUp() {
@@ -51,9 +53,9 @@ class CuidadoServiceImplTest {
         createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
         createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,10,30), "90");
         createCuidado(sueno, null, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
-        createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5));
-        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5));
-        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7));
+        panalGuardado = createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5), null, 2);
+        createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5), null, 1);
+        createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7), null, 1);
         createCuidado(bano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
@@ -63,6 +65,12 @@ class CuidadoServiceImplTest {
         assertEquals(5.5, resp.getHorasSueno(), 0.001);
         assertEquals(3, resp.getPanales());
         assertEquals(1, resp.getBanos());
+    }
+
+    @Test
+    void obtenerDevuelveCantidadPanal() {
+        CuidadoResponse resp = service.obtener(1L, panalGuardado.getId());
+        assertEquals(2, resp.getCantidadPanal());
     }
 
     private TipoCuidado saveTipo(String nombre) {
@@ -83,7 +91,7 @@ class CuidadoServiceImplTest {
         return tipoPanalRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion) {
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion, Integer cantidadPanal) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
@@ -92,14 +100,19 @@ class CuidadoServiceImplTest {
         c.setInicio(inicio);
         c.setFin(fin);
         c.setDuracion(duracion);
+        c.setCantidadPanal(cantidadPanal);
         Date now = new Date();
         c.setCreatedAt(now);
         c.setUpdatedAt(now);
         return cuidadoRepo.save(c);
     }
 
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion) {
+        return createCuidado(tipo, tipoPanal, inicio, fin, duracion, null);
+    }
+
     private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin) {
-        return createCuidado(tipo, tipoPanal, inicio, fin, null);
+        return createCuidado(tipo, tipoPanal, inicio, fin, null, null);
     }
 
     private Date date(int year,int month,int day,int hour,int minute) {

--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -24,6 +24,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     duracion: "",
     observaciones: "",
     tipoPanalId: "",
+    cantidadPanal: "",
   });
   const [tipoOptions, setTipoOptions] = useState([]);
   const [tipoPanalOptions, setTipoPanalOptions] = useState([]);
@@ -37,6 +38,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         duracion: initialData.duracion || "",
         observaciones: initialData.observaciones || "",
         tipoPanalId: initialData.tipoPanalId || "",
+        cantidadPanal: initialData.cantidadPanal || "",
       });
     } else {
       setFormData({
@@ -46,6 +48,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
         duracion: "",
         observaciones: "",
         tipoPanalId: "",
+        cantidadPanal: "",
       });
     }
   }, [initialData, open]);
@@ -62,7 +65,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
   const handleChange = (e) => {
     const { name, value } = e.target;
     const sanitizedValue =
-      ["cantidadMl", "duracion"].includes(name)
+      ["cantidadMl", "duracion", "cantidadPanal"].includes(name)
         ? String(Math.max(0, Number(value)))
         : value;
     setFormData((prev) => ({
@@ -79,6 +82,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
     if (!formData.inicio) return;
     const payload = {
       ...formData,
+      cantidadPanal: formData.cantidadPanal,
       inicio: formData.inicio
         ? formData.inicio.format("YYYY-MM-DDTHH:mm")
         : "",
@@ -149,21 +153,33 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
             </FormControl>
           )}
           {isPanal && (
-            <FormControl fullWidth sx={{ mb: 2 }}>
-              <FormLabel sx={{ mb: 1 }}>Tipo pañal</FormLabel>
-              <TextField
-                select
-                name="tipoPanalId"
-                value={formData.tipoPanalId}
-                onChange={handleChange}
-              >
-                {tipoPanalOptions.map((option) => (
-                  <MenuItem key={option.id} value={option.id}>
-                    {option.nombre}
-                  </MenuItem>
-                ))}
-              </TextField>
-            </FormControl>
+            <>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Tipo pañal</FormLabel>
+                <TextField
+                  select
+                  name="tipoPanalId"
+                  value={formData.tipoPanalId}
+                  onChange={handleChange}
+                >
+                  {tipoPanalOptions.map((option) => (
+                    <MenuItem key={option.id} value={option.id}>
+                      {option.nombre}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </FormControl>
+              <FormControl fullWidth sx={{ mb: 2 }}>
+                <FormLabel sx={{ mb: 1 }}>Cantidad pañal</FormLabel>
+                <TextField
+                  type="number"
+                  name="cantidadPanal"
+                  value={formData.cantidadPanal}
+                  onChange={handleChange}
+                  inputProps={{ min: 0 }}
+                />
+              </FormControl>
+            </>
           )}
           <FormControl fullWidth sx={{ mb: 2 }}>
             <FormLabel sx={{ mb: 1 }}>Observaciones</FormLabel>

--- a/frontend-baby/src/dashboard/components/CuidadoForm.test.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.test.js
@@ -26,7 +26,7 @@ describe('CuidadoForm', () => {
     jest.clearAllMocks();
   });
 
-  it('renderiza selector de tipo de pañal y envía tipoPanalId', async () => {
+  it('renderiza selector de tipo de pañal y envía tipoPanalId y cantidadPanal', async () => {
     const onSubmit = jest.fn();
     render(
       <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -52,11 +52,15 @@ describe('CuidadoForm', () => {
     await userEvent.click(tipoPanalSelect);
     await userEvent.click(screen.getByRole('option', { name: 'Pipi' }));
 
+    const spinbuttons = screen.getAllByRole('spinbutton');
+    const cantidadInput = spinbuttons[spinbuttons.length - 1];
+    await userEvent.type(cantidadInput, '2');
+
     await userEvent.click(screen.getByRole('button', { name: 'Guardar' }));
 
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({ tipoPanalId: 10 })
+        expect.objectContaining({ tipoPanalId: 10, cantidadPanal: '2' })
       )
     );
   });

--- a/frontend-baby/src/services/cuidadosService.test.js
+++ b/frontend-baby/src/services/cuidadosService.test.js
@@ -71,4 +71,33 @@ describe('cuidadosService', () => {
       expect.objectContaining({ tipoPanalId: 4 })
     );
   });
+
+  it('crearCuidado transmite cantidadPanal sin alterarlo', () => {
+    axios.post.mockResolvedValue({});
+    const usuarioId = 1;
+    const data = { bebeId: 2, cantidadPanal: 5 };
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    crearCuidado(usuarioId, data);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}`,
+      expect.objectContaining({ cantidadPanal: 5 })
+    );
+  });
+
+  it('actualizarCuidado transmite cantidadPanal sin alterarlo', () => {
+    axios.put.mockResolvedValue({});
+    const usuarioId = 1;
+    const id = 5;
+    const data = { bebeId: 2, cantidadPanal: 7 };
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    actualizarCuidado(usuarioId, id, data);
+
+    expect(axios.put).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/${id}`,
+      expect.objectContaining({ cantidadPanal: 7 })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- track diaper quantity in CuidadoForm and service tests
- persist new `cantidadPanal` field in API entity, DTOs, mapper and schema
- test controller and service to ensure diaper quantity is saved and returned

## Testing
- `npm test -- --watchAll=false`
- `mvn -q test` *(fails: Non-resolvable parent POM: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a92a6f488327936fcf93273c5e70