### PR TITLE
Show user-entered sleep duration in RecentCareCard

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -52,6 +52,12 @@ export default function RecentCareCard() {
         return item.tipoPanalNombre || '';
       case 'Sueño':
       case 'Dormir': {
+        if (item.duracionMin == null && !item.fin) {
+          const totalMin = parseInt(item.duracion, 10);
+          const hours = Math.floor(totalMin / 60);
+          const minutes = totalMin % 60;
+          return `${hours}h ${minutes}m`;
+        }
         const durationMin =
           item.duracionMin ??
           (item.fin ? dayjs(item.fin).diff(dayjs(item.inicio), 'minute') : 0);

--- a/frontend-baby/src/dashboard/components/RecentCareCard.test.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.test.js
@@ -46,4 +46,32 @@ describe('RecentCareCard', () => {
       expect(screen.getByText('Pipi')).toBeInTheDocument();
     });
   });
+
+  it('muestra la duración introducida para registros de sueño', async () => {
+    listarRecientes.mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          tipoNombre: 'Sueño',
+          inicio: '2024-01-01T10:00',
+          duracion: '90',
+          duracionMin: null,
+          fin: null,
+        },
+      ],
+    });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <RecentCareCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listarRecientes).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByText('1h 30m')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- interpret `item.duracion` when no end or precomputed duration exists to show sleep length
- add unit test for displaying recorded sleep duration

## Testing
- `CI=true npm test -- RecentCareCard.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2b41026048327a51f602e789e8579