### PR TITLE
feat: add recent care endpoint and client filtering

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/controller/CuidadoController.java
@@ -93,6 +93,15 @@ public class CuidadoController {
                 return ResponseEntity.ok(service.listarPorBebe(usuarioId, bebeId, limit));
         }
 
+        @Operation(summary = "Listar cuidados recientes")
+        @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/recientes")
+        public ResponseEntity<List<CuidadoResponse>> listarRecientes(
+                        @PathVariable Long usuarioId,
+                        @PathVariable Long bebeId,
+                        @RequestParam(value = "limit", defaultValue = "5") Integer limit) {
+                return ResponseEntity.ok(service.listarRecientes(usuarioId, bebeId, null, limit));
+        }
+
 	@Operation(summary = "Listar cuidados por bebé y tipo")
         @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/tipo/{tipoId}")
         public ResponseEntity<List<CuidadoResponse>> listarPorBebeYTipo(

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/repository/CuidadoRepository.java
@@ -13,6 +13,7 @@ public interface CuidadoRepository extends JpaRepository<Cuidado, Long> {
     Optional<Cuidado> findByIdAndUsuarioIdAndEliminadoFalse(Long id, Long usuarioId);
     List<Cuidado> findByBebeIdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long usuarioId);
     List<Cuidado> findByBebeIdAndUsuarioIdAndEliminadoFalse(Long bebeId, Long usuarioId, Pageable pageable);
+    List<Cuidado> findByBebeIdAndUsuarioIdAndInicioAfterAndEliminadoFalse(Long bebeId, Long usuarioId, Date since, Pageable pageable);
     List<Cuidado> findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long tipoId, Long usuarioId);
     List<Cuidado> findByBebeIdAndUsuarioIdAndInicioBetweenAndEliminadoFalseOrderByInicioDesc(Long bebeId, Long usuarioId, Date desde, Date hasta);
     List<Cuidado> findByBebeIdAndUsuarioIdAndTipo_NombreAndEliminadoFalseAndInicioBetween(Long bebeId, Long usuarioId, String tipoNombre, Date desde, Date hasta);

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/CuidadoService.java
@@ -13,6 +13,7 @@ public interface CuidadoService {
     void eliminar(Long usuarioId, Long id);
     CuidadoResponse obtener(Long usuarioId, Long id);
     List<CuidadoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit);
+    List<CuidadoResponse> listarRecientes(Long usuarioId, Long bebeId, Date since, Integer limit);
     List<CuidadoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId);
     List<CuidadoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta);
     QuickStatsResponse obtenerEstadisticasRapidas(Long usuarioId, Long bebeId, Date fecha);

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -87,6 +87,19 @@ public class CuidadoServiceImpl implements CuidadoService {
     }
 
     @Transactional(readOnly = true)
+    public List<CuidadoResponse> listarRecientes(Long usuarioId, Long bebeId, Date since, Integer limit) {
+        Date from = (since != null) ? since
+                : new Date(System.currentTimeMillis() - 120L * 60 * 60 * 1000);
+        List<Cuidado> list = repo.findByBebeIdAndUsuarioIdAndInicioAfterAndEliminadoFalse(bebeId, usuarioId, from,
+                PageRequest.of(0, limit, Sort.by("inicio").descending()));
+        List<CuidadoResponse> resp = new ArrayList<>();
+        for (Cuidado c : list) {
+            resp.add(CuidadoMapper.toResponse(c));
+        }
+        return resp;
+    }
+
+    @Transactional(readOnly = true)
     public List<CuidadoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId) {
         List<Cuidado> list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByInicioDesc(bebeId, tipoId, usuarioId);
         List<CuidadoResponse> resp = new ArrayList<CuidadoResponse>();

--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -76,7 +76,13 @@ export default function RecentCareCard() {
   useEffect(() => {
     if (bebeId && usuarioId) {
       listarRecientes(usuarioId, bebeId, 3)
-        .then((response) => setRecentCare(response.data))
+        .then((response) => {
+          const cutoff = dayjs().subtract(120, 'hour');
+          const filtered = response.data.filter((cuidado) =>
+            dayjs(cuidado.inicio).isAfter(cutoff)
+          );
+          setRecentCare(filtered);
+        })
         .catch((error) => console.error('Error fetching recent care:', error));
     }
   }, [bebeId, usuarioId]);

--- a/frontend-baby/src/dashboard/components/RecentCareCard.test.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.test.js
@@ -27,7 +27,7 @@ describe('RecentCareCard', () => {
         {
           id: 1,
           tipoNombre: 'Pañal',
-          inicio: '2024-01-01T10:00',
+          inicio: new Date().toISOString(),
           tipoPanalNombre: 'Pipi',
         },
       ],
@@ -53,7 +53,7 @@ describe('RecentCareCard', () => {
         {
           id: 2,
           tipoNombre: 'Sueño',
-          inicio: '2024-01-01T10:00',
+          inicio: new Date().toISOString(),
           duracion: '90',
           duracionMin: null,
           fin: null,

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -17,7 +17,7 @@ export const listarPorBebe = (usuarioId, bebeId, page, size) => {
 
 export const listarRecientes = (usuarioId, bebeId, limit = 5) => {
   return axios.get(
-    `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
+    `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/recientes`,
     {
       params: { limit },
     }


### PR DESCRIPTION
## Summary
- expose `/recientes` endpoint to fetch limited recent care records with 120h window
- adjust frontend service and component to call new endpoint and filter out old records
- add tests and dynamic data to RecentCareCard

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.babytrackmaster:api-cuidados)*
- `npm test --prefix frontend-baby -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2c6d419bc832799df929f1f820478