### PR TITLE
feat: prevent future feeding times

### DIFF
--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -163,6 +163,8 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
   const validate = () => {
     const newErrors = {};
     if (!formData.inicio) newErrors.inicio = 'Requerido';
+    else if (formData.inicio.isAfter(dayjs()))
+      newErrors.inicio = 'No puede ser futura';
     if (!formData.tipoAlimentacionId)
       newErrors.tipoAlimentacionId = 'Requerido';
     if (selectedTipo === 'lactancia') {
@@ -275,7 +277,14 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
             <DateTimePicker
               value={formData.inicio}
               onChange={handleInicioChange}
-              slotProps={{ textField: { fullWidth: true, error: !!errors.inicio, helperText: errors.inicio } }}
+              maxDateTime={dayjs()}
+              slotProps={{
+                textField: {
+                  fullWidth: true,
+                  error: !!errors.inicio,
+                  helperText: errors.inicio,
+                },
+              }}
             />
           </FormControl>
           {selectedTipo === 'lactancia' && (


### PR DESCRIPTION
## Summary
- restrict feeding time to current or past moments
- validate that feeding start time is not in the future

## Testing
- `cd frontend-baby && CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2ca19a6348327a374f21b8c8f1679