### PR TITLE
Prevent future dates in growth form

### DIFF
--- a/frontend-baby/src/dashboard/components/CrecimientoForm.js
+++ b/frontend-baby/src/dashboard/components/CrecimientoForm.js
@@ -74,6 +74,10 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
 
   const handleSubmit = () => {
     if (!formData.fecha) return;
+    if (formData.fecha.isAfter(dayjs(), 'day')) {
+      alert('La fecha no puede ser posterior a hoy.');
+      return;
+    }
     const payload = {
       ...formData,
       fecha: formData.fecha ? formData.fecha.format('YYYY-MM-DD') : '',
@@ -94,6 +98,7 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
             <DatePicker
               value={formData.fecha}
               onChange={handleFechaChange}
+              disableFuture
               slotProps={{ textField: { fullWidth: true, required: true } }}
             />
           </FormControl>


### PR DESCRIPTION
## Summary
- disallow selecting future dates in growth records
- guard submission if date is after today

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c2cac471dc83279e47fdb40bd536a6