### PR TITLE
fix: prevent future dates in GastoForm

### DIFF
--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -87,6 +87,13 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
       }));
       return;
     }
+    if (formData.fecha.isAfter(dayjs(), 'day')) {
+      setErrors((prev) => ({
+        ...prev,
+        fecha: "La fecha no puede ser futura",
+      }));
+      return;
+    }
     const data = {
       ...formData,
       fecha: formData.fecha ? formData.fecha.format("YYYY-MM-DD") : "",
@@ -104,7 +111,15 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
               <DatePicker
                 value={formData.fecha}
                 onChange={handleDateChange}
-                slotProps={{ textField: { fullWidth: true, required: true, error: Boolean(errors.fecha), helperText: errors.fecha } }}
+                disableFuture
+                slotProps={{
+                  textField: {
+                    fullWidth: true,
+                    required: true,
+                    error: Boolean(errors.fecha),
+                    helperText: errors.fecha,
+                  },
+                }}
               />
             </FormControl>
             <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- disallow selecting future dates in `GastoForm` DatePicker
- validate that submitted expense dates are not in the future

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2cb352cb883278ead186846e00b34