### PR TITLE
Restrict newborn date selection to past days

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -170,6 +170,8 @@ export default function AnadirBebe() {
                     label="Fecha de nacimiento"
                     value={formData.fechaNacimiento}
                     onChange={handleDateChange}
+                    disableFuture
+                    maxDate={dayjs().subtract(1, 'day')}
                     disabled={loading}
                     slotProps={{
                       textField: {

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -206,6 +206,8 @@ export default function EditarBebe() {
                     label="Fecha de nacimiento"
                     value={formData.fechaNacimiento}
                     onChange={handleDateChange}
+                    disableFuture
+                    maxDate={dayjs().subtract(1, 'day')}
                     disabled={loading}
                     slotProps={{
                       textField: {


### PR DESCRIPTION
## Summary
- prevent selecting current or future birth dates on add/edit baby forms by limiting DatePicker

## Testing
- `npm run lint` *(fails: Missing script "lint")*
- `npx eslint .`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2d3a7ce0883279b97a3df0116ce62