### PR TITLE
Añadir límite opcional en listados de crecimiento

### DIFF
--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/controller/CrecimientoController.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/controller/CrecimientoController.java
@@ -83,8 +83,9 @@ public class CrecimientoController {
     public ResponseEntity<List<CrecimientoResponse>> listarPorBebeYTipo(
             @PathVariable Long usuarioId,
             @PathVariable Long bebeId,
-            @PathVariable Long tipoId) {
-        return ResponseEntity.ok(service.listarPorBebeYTipo(usuarioId, bebeId, tipoId));
+            @PathVariable Long tipoId,
+            @RequestParam(value = "limit", required = false) Integer limit) {
+        return ResponseEntity.ok(service.listarPorBebeYTipo(usuarioId, bebeId, tipoId, limit));
     }
 
     @Operation(summary = "Listar registros por rango de fechas")

--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/repository/CrecimientoRepository.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/repository/CrecimientoRepository.java
@@ -14,6 +14,7 @@ public interface CrecimientoRepository extends JpaRepository<Crecimiento, Long> 
     List<Crecimiento> findByBebeIdAndUsuarioIdAndEliminadoFalseOrderByFechaDesc(Long bebeId, Long usuarioId);
     List<Crecimiento> findByBebeIdAndUsuarioIdAndEliminadoFalse(Long bebeId, Long usuarioId, Pageable pageable);
     List<Crecimiento> findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByFechaDesc(Long bebeId, Long tipoId, Long usuarioId);
+    List<Crecimiento> findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalse(Long bebeId, Long tipoId, Long usuarioId, Pageable pageable);
     List<Crecimiento> findByBebeIdAndUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(Long bebeId, Long usuarioId, Date desde, Date hasta);
     List<Crecimiento> findByBebeIdAndUsuarioIdAndTipo_IdAndEliminadoFalseAndFechaBetween(Long bebeId, Long usuarioId, Long tipoId, Date desde, Date hasta);
 }

--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/CrecimientoService.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/CrecimientoService.java
@@ -13,7 +13,7 @@ public interface CrecimientoService {
     void eliminar(Long usuarioId, Long id);
     CrecimientoResponse obtener(Long usuarioId, Long id);
     List<CrecimientoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit);
-    List<CrecimientoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId);
+    List<CrecimientoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId, Integer limit);
     List<CrecimientoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta);
     CrecimientoStatsResponse obtenerEstadisticas(Long usuarioId, Long bebeId, Long tipoId, Date desde, Date hasta);
 }

--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/iml/CrecimientoServiceImpl.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/iml/CrecimientoServiceImpl.java
@@ -82,8 +82,14 @@ public class CrecimientoServiceImpl implements CrecimientoService {
     }
 
     @Transactional(readOnly = true)
-    public List<CrecimientoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId) {
-        List<Crecimiento> list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByFechaDesc(bebeId, tipoId, usuarioId);
+    public List<CrecimientoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId, Integer limit) {
+        List<Crecimiento> list;
+        if (limit != null) {
+            list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalse(bebeId, tipoId, usuarioId,
+                    PageRequest.of(0, limit, Sort.by("fecha").descending()));
+        } else {
+            list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalseOrderByFechaDesc(bebeId, tipoId, usuarioId);
+        }
         List<CrecimientoResponse> resp = new ArrayList<>();
         for (Crecimiento c : list) {
             resp.add(CrecimientoMapper.toResponse(c));

--- a/frontend-baby/src/services/crecimientoService.js
+++ b/frontend-baby/src/services/crecimientoService.js
@@ -13,6 +13,15 @@ export const listarPorBebe = (usuarioId, bebeId, limit) => {
   );
 };
 
+export const listarPorBebeYTipo = (usuarioId, bebeId, tipoId, limit) => {
+  const params = {};
+  if (limit !== undefined) params.limit = limit;
+  return axios.get(
+    `${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/tipo/${tipoId}`,
+    { params }
+  );
+};
+
 export const crearRegistro = (usuarioId, data) => {
   return axios.post(`${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}`, data);
 };


### PR DESCRIPTION
## Summary
- Expose `?limit` on `/crecimientos/usuario/{usuarioId}/bebe/{bebeId}/tipo/{tipoId}` and propagate to service & repository
- Add `listarPorBebeYTipo` with optional limit to frontend service
- Compute weight difference in `StatsOverview` requesting two latest "Peso" records and hide diff label when absent

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8cb566483278aed1321284cd46f