### PR TITLE
feat: add endpoint for last growth measurements

### DIFF
--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/controller/CrecimientoController.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/controller/CrecimientoController.java
@@ -88,6 +88,16 @@ public class CrecimientoController {
         return ResponseEntity.ok(service.listarPorBebeYTipo(usuarioId, bebeId, tipoId, limit));
     }
 
+    @Operation(summary = "Listar las últimas mediciones por tipo")
+    @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/tipo/{tipoId}/ultimos")
+    public ResponseEntity<List<CrecimientoResponse>> listarUltimosPorTipo(
+            @PathVariable Long usuarioId,
+            @PathVariable Long bebeId,
+            @PathVariable Long tipoId,
+            @RequestParam("limit") Integer limit) {
+        return ResponseEntity.ok(service.listarUltimosPorTipo(usuarioId, bebeId, tipoId, limit));
+    }
+
     @Operation(summary = "Listar registros por rango de fechas")
     @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/rango")
     public ResponseEntity<List<CrecimientoResponse>> listarPorRango(

--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/CrecimientoService.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/CrecimientoService.java
@@ -14,6 +14,7 @@ public interface CrecimientoService {
     CrecimientoResponse obtener(Long usuarioId, Long id);
     List<CrecimientoResponse> listarPorBebe(Long usuarioId, Long bebeId, Integer limit);
     List<CrecimientoResponse> listarPorBebeYTipo(Long usuarioId, Long bebeId, Long tipoId, Integer limit);
+    List<CrecimientoResponse> listarUltimosPorTipo(Long usuarioId, Long bebeId, Long tipoId, Integer limit);
     List<CrecimientoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta);
     CrecimientoStatsResponse obtenerEstadisticas(Long usuarioId, Long bebeId, Long tipoId, Date desde, Date hasta);
 }

--- a/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/iml/CrecimientoServiceImpl.java
+++ b/api-crecimiento/src/main/java/com/babytrackmaster/api_crecimiento/service/iml/CrecimientoServiceImpl.java
@@ -98,6 +98,17 @@ public class CrecimientoServiceImpl implements CrecimientoService {
     }
 
     @Transactional(readOnly = true)
+    public List<CrecimientoResponse> listarUltimosPorTipo(Long usuarioId, Long bebeId, Long tipoId, Integer limit) {
+        List<Crecimiento> list = repo.findByBebeIdAndTipo_IdAndUsuarioIdAndEliminadoFalse(bebeId, tipoId, usuarioId,
+                PageRequest.of(0, limit, Sort.by("fecha").descending()));
+        List<CrecimientoResponse> resp = new ArrayList<>();
+        for (Crecimiento c : list) {
+            resp.add(CrecimientoMapper.toResponse(c));
+        }
+        return resp;
+    }
+
+    @Transactional(readOnly = true)
     public List<CrecimientoResponse> listarPorRango(Long usuarioId, Long bebeId, Date desde, Date hasta) {
         List<Crecimiento> list = repo.findByBebeIdAndUsuarioIdAndFechaBetweenAndEliminadoFalseOrderByFechaDesc(bebeId, usuarioId, desde, hasta);
         List<CrecimientoResponse> resp = new ArrayList<>();

--- a/frontend-baby/src/dashboard/components/StatsOverview.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.js
@@ -15,7 +15,7 @@ import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
 import { listarRecientes as listarAlimentacionRecientes } from '../../services/alimentacionService';
 import {
-  listarPorBebeYTipo,
+  listarUltimosPorTipo,
   listarTipos,
 } from '../../services/crecimientoService';
 
@@ -79,7 +79,7 @@ export default function StatsOverview() {
             t.nombre?.toLowerCase().includes('peso')
           );
           if (peso) {
-            listarPorBebeYTipo(user.id, activeBaby.id, peso.id, 2)
+            listarUltimosPorTipo(user.id, activeBaby.id, peso.id, 2)
               .then(({ data: registros }) => {
                 if (Array.isArray(registros) && registros.length > 0) {
                   const valorActual = registros[0].valor;

--- a/frontend-baby/src/services/crecimientoService.js
+++ b/frontend-baby/src/services/crecimientoService.js
@@ -22,6 +22,13 @@ export const listarPorBebeYTipo = (usuarioId, bebeId, tipoId, limit) => {
   );
 };
 
+export const listarUltimosPorTipo = (usuarioId, bebeId, tipoId, limit) => {
+  return axios.get(
+    `${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/tipo/${tipoId}/ultimos`,
+    { params: { limit } }
+  );
+};
+
 export const crearRegistro = (usuarioId, data) => {
   return axios.post(`${API_CRECIMIENTOS_ENDPOINT}/usuario/${usuarioId}`, data);
 };


### PR DESCRIPTION
## Summary
- add last measurements endpoint in crecimiento controller
- expose service method to fetch latest growth entries
- use new endpoint in frontend stats overview

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2da5c50688327b1fd0a0f77fa233b