### PR TITLE
Actualizar duracion de cuidado a entero

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoRequest.java
@@ -16,7 +16,7 @@ public class CuidadoRequest {
     @NotNull private Date inicio;
 
     private Date fin;
-    private String duracion;
+    private Integer duracion;
     private Integer cantidadMl;
     @Schema(example = "1", description = "ID del tipo de pañal")
     private Long tipoPanalId;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/CuidadoResponse.java
@@ -18,7 +18,7 @@ public class CuidadoResponse {
     private String tipoNombre;
     private Date inicio;
     private Date fin;
-    private String duracion;
+    private Integer duracion;
     @Schema(example = "120")
     private Integer cantidadMl;
     private Long tipoPanalId;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/entity/Cuidado.java
@@ -33,8 +33,8 @@ public class Cuidado {
     @Temporal(TemporalType.TIMESTAMP)
     private Date fin;
 
-    @Column(name="duracion", length=50)
-    private String duracion;
+    @Column(name="duracion")
+    private Integer duracion;
 
     @Column(name="cantidad_ml")
     private Integer cantidadMl;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/mapper/CuidadoMapper.java
@@ -28,7 +28,7 @@ public class CuidadoMapper {
         }
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
-        c.setDuracion(req.getDuracion());
+        c.setDuracion(req.getDuracion()); // duración en minutos
         c.setCantidadMl(req.getCantidadMl());
         c.setCantidadPanal(req.getCantidadPanal());
         c.setMedicamento(req.getMedicamento());
@@ -56,7 +56,7 @@ public class CuidadoMapper {
         }
         c.setInicio(req.getInicio());
         c.setFin(req.getFin());
-        c.setDuracion(req.getDuracion());
+        c.setDuracion(req.getDuracion()); // duración en minutos
         c.setCantidadMl(req.getCantidadMl());
         c.setCantidadPanal(req.getCantidadPanal());
         c.setMedicamento(req.getMedicamento());

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -129,14 +129,7 @@ public class CuidadoServiceImpl implements CuidadoService {
         double horasSueno = 0d;
         for (Cuidado c : suenos) {
             if (c.getDuracion() != null) {
-                try {
-                    horasSueno += Double.parseDouble(c.getDuracion()) / 60d;
-                } catch (NumberFormatException e) {
-                    if (c.getInicio() != null && c.getFin() != null) {
-                        long diff = c.getFin().getTime() - c.getInicio().getTime();
-                        horasSueno += diff / (1000d * 60d * 60d);
-                    }
-                }
+                horasSueno += c.getDuracion() / 60d;
             } else if (c.getInicio() != null && c.getFin() != null) {
                 long diff = c.getFin().getTime() - c.getInicio().getTime();
                 horasSueno += diff / (1000d * 60d * 60d);

--- a/api-cuidados/src/main/resources/schema.sql
+++ b/api-cuidados/src/main/resources/schema.sql
@@ -26,7 +26,7 @@ INSERT INTO tipo_panal (nombre, created_at, updated_at) VALUES
 ('MIXTO', NOW(), NOW());
 
 ALTER TABLE cuidados
-    ADD COLUMN duracion VARCHAR(50);
+    ADD COLUMN duracion INT;
 
 ALTER TABLE cuidados
     ADD CONSTRAINT fk_cuidados_tipo FOREIGN KEY (tipo) REFERENCES tipo_cuidado(id);

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -50,8 +50,8 @@ class CuidadoServiceImplTest {
         TipoCuidado bano = saveTipo("Ba\u00f1o");
         TipoPanal pipi = saveTipoPanal("PIPI");
 
-        createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
-        createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,10,30), "90");
+        createCuidado(sueno, null, date(2024,3,10,0,0), date(2024,3,10,4,0), 120);
+        createCuidado(sueno, null, date(2024,3,10,10,0), date(2024,3,10,10,30), 90);
         createCuidado(sueno, null, date(2024,3,10,16,0), date(2024,3,10,18,0), null);
         panalGuardado = createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5), null, 2);
         createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5), null, 1);
@@ -91,7 +91,7 @@ class CuidadoServiceImplTest {
         return tipoPanalRepo.save(t);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion, Integer cantidadPanal) {
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, Integer duracion, Integer cantidadPanal) {
         Cuidado c = new Cuidado();
         c.setBebeId(1L);
         c.setUsuarioId(1L);
@@ -107,7 +107,7 @@ class CuidadoServiceImplTest {
         return cuidadoRepo.save(c);
     }
 
-    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, String duracion) {
+    private Cuidado createCuidado(TipoCuidado tipo, TipoPanal tipoPanal, Date inicio, Date fin, Integer duracion) {
         return createCuidado(tipo, tipoPanal, inicio, fin, duracion, null);
     }
 


### PR DESCRIPTION
## Summary
- Cambiar el campo `duracion` de String a Integer en entidad, DTOs y esquema
- Ajustar el servicio y mapper para trabajar con enteros
- Actualizar pruebas acorde al nuevo tipo de dato

## Testing
- `./mvnw test` *(falla: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b62f8a908327802e3182b2c376ed