### PR TITLE
feat: show diaper diff vs yesterday

### DIFF
--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -24,10 +24,14 @@ export const listarRecientes = (usuarioId, bebeId, limit = 5) => {
   );
 };
 
-export const obtenerStatsRapidas = (usuarioId, bebeId) =>
-  axios.get(
-    `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+export const obtenerStatsRapidas = (usuarioId, bebeId, fechaMillis) => {
+  const params = {};
+  if (fechaMillis !== undefined) params.fechaMillis = fechaMillis;
+  return axios.get(
+    `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
+    { params }
   );
+};
 
 export const crearCuidado = (usuarioId, data) => {
   const payload = { ...data, tipoPanalId: data.tipoPanalId };

--- a/frontend-baby/src/services/cuidadosService.test.js
+++ b/frontend-baby/src/services/cuidadosService.test.js
@@ -21,7 +21,7 @@ describe('cuidadosService', () => {
     jest.clearAllMocks();
   });
 
-  it('obtenerStatsRapidas realiza la llamada HTTP correcta', () => {
+  it('obtenerStatsRapidas realiza la llamada HTTP correcta sin fecha', () => {
     axios.get.mockResolvedValue({});
     const usuarioId = 1;
     const bebeId = 2;
@@ -30,7 +30,23 @@ describe('cuidadosService', () => {
     obtenerStatsRapidas(usuarioId, bebeId);
 
     expect(axios.get).toHaveBeenCalledWith(
-      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
+      { params: {} }
+    );
+  });
+
+  it('obtenerStatsRapidas incluye fechaMillis cuando se proporciona', () => {
+    axios.get.mockResolvedValue({});
+    const usuarioId = 1;
+    const bebeId = 2;
+    const fechaMillis = 123;
+    const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
+
+    obtenerStatsRapidas(usuarioId, bebeId, fechaMillis);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
+      { params: { fechaMillis } }
     );
   });
 


### PR DESCRIPTION
## Summary
- allow optional `fechaMillis` in diaper stats service
- compare today's vs yesterday's diaper count and show diff message
- cover service stats with tests

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c2e07a3a988327becc74f4e269db3f