### PR TITLE
Fix diaper stats aggregation for quick stats

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/dto/QuickStatsResponse.java
@@ -8,7 +8,7 @@ import lombok.Data;
 public class QuickStatsResponse {
     @Schema(example = "8.0", description = "Horas totales de sueño")
     private double horasSueno;
-    @Schema(example = "5", description = "Cantidad de pañales")
+    @Schema(example = "5", description = "Cantidad total de pañales del día")
     private int panales;
     @Schema(example = "1", description = "Cantidad de baños")
     private int banos;

--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -157,7 +157,11 @@ public class CuidadoServiceImpl implements CuidadoService {
         }
 
         int numBanosTotal = numBanos.size();
-        int numPanalesTotal = numPanales.size();
+        int numPanalesTotal = 0;
+        for (Cuidado c : numPanales) {
+            Integer cant = c.getCantidadPanal();
+            numPanalesTotal += (cant != null) ? cant : 1;
+        }
 
         QuickStatsResponse resp = new QuickStatsResponse();
         resp.setHorasSueno(horasSueno);

--- a/frontend-baby/src/services/cuidadosService.js
+++ b/frontend-baby/src/services/cuidadosService.js
@@ -24,12 +24,12 @@ export const listarRecientes = (usuarioId, bebeId, limit = 5) => {
   );
 };
 
-export const obtenerStatsRapidas = (usuarioId, bebeId, fechaMillis) => {
-  const params = {};
-  if (fechaMillis !== undefined) params.fechaMillis = fechaMillis;
+export const obtenerStatsRapidas = (usuarioId, bebeId, fecha) => {
   return axios.get(
     `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
-    { params }
+    {
+      params: { fecha },
+    }
   );
 };
 

--- a/frontend-baby/src/services/cuidadosService.test.js
+++ b/frontend-baby/src/services/cuidadosService.test.js
@@ -31,22 +31,22 @@ describe('cuidadosService', () => {
 
     expect(axios.get).toHaveBeenCalledWith(
       `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
-      { params: {} }
+      { params: { fecha: undefined } }
     );
   });
 
-  it('obtenerStatsRapidas incluye fechaMillis cuando se proporciona', () => {
+  it('obtenerStatsRapidas incluye fecha cuando se proporciona', () => {
     axios.get.mockResolvedValue({});
     const usuarioId = 1;
     const bebeId = 2;
-    const fechaMillis = 123;
+    const fecha = 123;
     const API_CUIDADOS_ENDPOINT = `${API_CUIDADOS_URL}/api/v1/cuidados`;
 
-    obtenerStatsRapidas(usuarioId, bebeId, fechaMillis);
+    obtenerStatsRapidas(usuarioId, bebeId, fecha);
 
     expect(axios.get).toHaveBeenCalledWith(
       `${API_CUIDADOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/stats`,
-      { params: { fechaMillis } }
+      { params: { fecha } }
     );
   });
 


### PR DESCRIPTION
## Summary
- sum diaper quantities instead of counting records
- update API docs for diaper totals and send optional date param
- rename quick stats service param to `fecha` and adjust tests

## Testing
- `CI=true npm test src/services/cuidadosService.test.js`
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e765fddc83278c6b9d9538f4804b