### PR TITLE
Mostrar duración textual en cuidados de sueño

### DIFF
--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -52,12 +52,6 @@ export default function Cuidados() {
   const normalize = (str) =>
     str?.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 
-  const formatDurationMinutes = (minutes) => {
-    if (isNaN(minutes)) return "-";
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return `${hours}h ${mins}m`;
-  };
 
   const filteredCuidados = useMemo(
     () =>
@@ -188,7 +182,7 @@ export default function Cuidados() {
         cuidado.tipoNombre,
       ];
       if (cuidado.tipoNombre === "Sueño") {
-        row.push(formatDurationMinutes(Number(cuidado.duracion)));
+        row.push(cuidado.duracion);
       } else if (cuidado.tipoNombre === "Pañal") {
         row.push(cuidado.tipoPanalNombre ?? "-");
         row.push(cuidado.cantidadPanal ?? "-");
@@ -226,7 +220,7 @@ export default function Cuidados() {
         cuidado.tipoNombre,
       ];
       if (cuidado.tipoNombre === "Sueño") {
-        row.push(formatDurationMinutes(Number(cuidado.duracion)));
+        row.push(cuidado.duracion);
       } else if (cuidado.tipoNombre === "Pañal") {
         row.push(cuidado.tipoPanalNombre ?? "-");
         row.push(cuidado.cantidadPanal ?? "-");
@@ -310,7 +304,7 @@ export default function Cuidados() {
                   ) : (
                     <TableCell sx={{ fontWeight: 600 }}>
                       {cuidado.tipoNombre === "Sueño"
-                        ? formatDurationMinutes(Number(cuidado.duracion))
+                        ? cuidado.duracion
                         : cuidado.cantidadMl ?? "-"}
                     </TableCell>
                   )}


### PR DESCRIPTION
## Summary
- Muestra `cuidado.duracion` directamente para registros de sueño
- Ajusta exportaciones CSV y PDF para usar la duración textual

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2f317db5c8327a5ae69671c2a447c