### PR TITLE
feat: compare sleep duration

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickStatsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.js
@@ -7,39 +7,67 @@ import { PieChart } from '@mui/x-charts/PieChart';
 import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
+import { parseDurationToHours } from '../../utils/duration';
 
 export default function QuickStatsCard() {
   const { user } = useContext(AuthContext);
   const { activeBaby } = useContext(BabyContext);
   const [stats, setStats] = useState({
-    horasSueno: 0,
+    horasSueno: { today: 0, diff: 0 },
     panales: 0,
     banos: 0,
   });
 
   useEffect(() => {
     if (user?.id && activeBaby?.id) {
-      obtenerStatsRapidas(user.id, activeBaby.id)
-        .then(({ data }) => setStats(data))
+      const yesterdayMillis = Date.now() - 24 * 60 * 60 * 1000;
+      Promise.all([
+        obtenerStatsRapidas(user.id, activeBaby.id),
+        obtenerStatsRapidas(user.id, activeBaby.id, yesterdayMillis),
+      ])
+        .then(([hoy, ayer]) => {
+          const hoyData = hoy.data || {};
+          const ayerData = ayer.data || {};
+          const todaySleep = parseDurationToHours(hoyData.horasSueno);
+          const yesterdaySleep = parseDurationToHours(ayerData.horasSueno);
+          setStats({
+            horasSueno: {
+              today: todaySleep,
+              diff: todaySleep - yesterdaySleep,
+            },
+            panales: hoyData.panales || 0,
+            banos: hoyData.banos || 0,
+          });
+        })
         .catch(() =>
-          setStats({ horasSueno: 0, panales: 0, banos: 0 })
+          setStats({ horasSueno: { today: 0, diff: 0 }, panales: 0, banos: 0 })
         );
     }
   }, [user, activeBaby]);
 
+  const formatHours = (h) => (h % 1 === 0 ? h : h.toFixed(1));
+
   const statsArray = [
-    { label: 'Horas de sueño', value: `${stats.horasSueno}h` },
+    {
+      label: 'Horas de sueño',
+      value: `${formatHours(stats.horasSueno.today)}h`,
+      diff: stats.horasSueno.diff,
+    },
     { label: 'Pañales', value: `${stats.panales}` },
     { label: 'Baños', value: `${stats.banos}` },
   ];
 
   const chartData = [
-    { id: 0, value: stats.horasSueno, label: 'Horas de sueño' },
+    { id: 0, value: stats.horasSueno.today, label: 'Horas de sueño' },
     { id: 1, value: stats.panales, label: 'Pañales' },
     { id: 2, value: stats.banos, label: 'Baños' },
   ];
 
-  const hasStats = Object.values(stats).some((value) => value > 0);
+  const hasStats = [
+    stats.horasSueno.today,
+    stats.panales,
+    stats.banos,
+  ].some((value) => value > 0);
 
   return (
     <Card variant="outlined" sx={{ height: '100%' }}>
@@ -56,6 +84,15 @@ export default function QuickStatsCard() {
                   <Typography variant="h5" component="p">
                     {stat.value}
                   </Typography>
+                  {stat.diff !== undefined && (
+                    <Typography variant="caption" color="text.secondary">
+                      {stat.diff > 0
+                        ? `${formatHours(stat.diff)} más que ayer`
+                        : stat.diff < 0
+                        ? `${formatHours(Math.abs(stat.diff))} menos que ayer`
+                        : 'Igual que ayer'}
+                    </Typography>
+                  )}
                   <Typography variant="caption" color="text.secondary">
                     {stat.label}
                   </Typography>

--- a/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickStatsCard.test.js
@@ -26,9 +26,13 @@ describe('QuickStatsCard', () => {
   });
 
   it('muestra estadísticas obtenidas del servicio', async () => {
-    obtenerStatsRapidas.mockResolvedValue({
-      data: { horasSueno: 8, panales: 5, banos: 1 },
-    });
+    obtenerStatsRapidas
+      .mockResolvedValueOnce({
+        data: { horasSueno: '8h', panales: 5, banos: 1 },
+      })
+      .mockResolvedValueOnce({
+        data: { horasSueno: '7h', panales: 4, banos: 1 },
+      });
 
     render(
       <AuthContext.Provider value={{ user: { id: 1 } }}>
@@ -38,18 +42,25 @@ describe('QuickStatsCard', () => {
       </AuthContext.Provider>
     );
 
-    expect(obtenerStatsRapidas).toHaveBeenCalledWith(1, 2);
+    expect(obtenerStatsRapidas).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(obtenerStatsRapidas).toHaveBeenNthCalledWith(
+      2,
+      1,
+      2,
+      expect.any(Number)
+    );
 
     await waitFor(() => {
       expect(screen.getByText('8h')).toBeInTheDocument();
+      expect(screen.getByText('1 más que ayer')).toBeInTheDocument();
       expect(screen.getByText('5')).toBeInTheDocument();
-      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getAllByText('1').length).toBeGreaterThan(0);
     });
   });
 
   it('muestra mensaje cuando el servicio devuelve valores por defecto', async () => {
     obtenerStatsRapidas.mockResolvedValue({
-      data: { horasSueno: 0, panales: 0, banos: 0 },
+      data: { horasSueno: '0h', panales: 0, banos: 0 },
     });
 
     render(
@@ -60,7 +71,13 @@ describe('QuickStatsCard', () => {
       </AuthContext.Provider>
     );
 
-    expect(obtenerStatsRapidas).toHaveBeenCalledWith(1, 2);
+    expect(obtenerStatsRapidas).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(obtenerStatsRapidas).toHaveBeenNthCalledWith(
+      2,
+      1,
+      2,
+      expect.any(Number)
+    );
 
     await waitFor(() => {
       expect(

--- a/frontend-baby/src/utils/duration.js
+++ b/frontend-baby/src/utils/duration.js
@@ -1,0 +1,13 @@
+export const parseDurationToHours = (str) => {
+  if (str == null) return 0;
+  if (typeof str === 'number') return str;
+  const match = String(str)
+    .trim()
+    .match(/^(?:\s*(\d+)h)?\s*(?:([0-9]+)m)?$/i);
+  if (!match) return 0;
+  const hours = parseInt(match[1] || '0', 10);
+  const minutes = parseInt(match[2] || '0', 10);
+  return hours + minutes / 60;
+};
+
+export default parseDurationToHours;


### PR DESCRIPTION
## Summary
- parse sleep duration strings like `7h30m` to decimal hours
- compare today's and yesterday's sleep in stats overview
- include sleep comparison in quick stats card with tests

## Testing
- `cd frontend-baby && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c2f513c4708327bd3a0327605320e6