### PR TITLE
feat: make duration select scrollable

### DIFF
--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -189,6 +189,13 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
                 value={formData.duracion}
                 onChange={handleChange}
                 error={!!errors.duracion}
+                SelectProps={{
+                  MenuProps: {
+                    PaperProps: {
+                      style: { maxHeight: 200, overflowY: 'auto' },
+                    },
+                  },
+                }}
               >
                 {duracionOptions.map((option) => (
                   <MenuItem key={option} value={option}>


### PR DESCRIPTION
## Summary
- limit duration menu height and enable scrolling

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c3008c57c4832791aecf8a035ecf1f