### PR TITLE
fix: compute sleep duration from UTC start and end

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -57,15 +57,13 @@ export default function RecentCareCard() {
         return item.tipoPanalNombre || '';
       case 'Sueño':
       case 'Dormir': {
-        if (item.duracionMin == null && !item.fin) {
-          const totalMin = parseInt(item.duracion, 10);
-          const hours = Math.floor(totalMin / 60);
-          const minutes = totalMin % 60;
-          return `${hours}h ${minutes}m`;
-        }
         const durationMin =
           item.duracionMin ??
-          (item.fin ? dayjs(item.fin).diff(dayjs(item.inicio), 'minute') : 0);
+          (item.fin
+            ? dayjs.utc(item.fin)
+                .local()
+                .diff(dayjs.utc(item.inicio).local(), 'minute')
+            : 0);
         const hours = Math.floor(durationMin / 60);
         const minutes = durationMin % 60;
         return `${hours}h ${minutes}m`;

--- a/frontend-baby/src/dashboard/components/RecentCareCard.test.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.test.js
@@ -48,16 +48,17 @@ describe('RecentCareCard', () => {
     });
   });
 
-  it('muestra la duración introducida para registros de sueño', async () => {
+  it('calcula la duración usando inicio y fin en UTC para registros de sueño', async () => {
+    const fin = new Date().toISOString();
+    const inicio = new Date(Date.now() - 90 * 60 * 1000).toISOString();
     listarRecientes.mockResolvedValue({
       data: [
         {
           id: 2,
           tipoNombre: 'Sueño',
-          inicio: new Date().toISOString(),
-          duracion: '90',
+          inicio,
+          fin,
           duracionMin: null,
-          fin: null,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- calculate sleep durations based on UTC start and end times
- test sleep records with UTC timestamps

## Testing
- `npm test -- src/dashboard/components/RecentCareCard.test.js`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c307a10bdc832785595d46d2f1fbef