### PR TITLE
Use API-provided duration in RecentCareCard

### DIFF
--- a/frontend-baby/src/dashboard/components/RecentCareCard.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.js
@@ -57,13 +57,16 @@ export default function RecentCareCard() {
         return item.tipoPanalNombre || '';
       case 'Sueño':
       case 'Dormir': {
+        if (item.duracion != null) {
+          return item.duracion;
+        }
         const durationMin =
-          item.duracionMin ??
-          (item.fin
-            ? dayjs.utc(item.fin)
+          item.fin
+            ? dayjs
+                .utc(item.fin)
                 .local()
                 .diff(dayjs.utc(item.inicio).local(), 'minute')
-            : 0);
+            : 0;
         const hours = Math.floor(durationMin / 60);
         const minutes = durationMin % 60;
         return `${hours}h ${minutes}m`;

--- a/frontend-baby/src/dashboard/components/RecentCareCard.test.js
+++ b/frontend-baby/src/dashboard/components/RecentCareCard.test.js
@@ -48,7 +48,36 @@ describe('RecentCareCard', () => {
     });
   });
 
-  it('calcula la duración usando inicio y fin en UTC para registros de sueño', async () => {
+  it('muestra la duración proporcionada por la API para registros de sueño', async () => {
+    const fin = new Date().toISOString();
+    const inicio = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    listarRecientes.mockResolvedValue({
+      data: [
+        {
+          id: 4,
+          tipoNombre: 'Sueño',
+          inicio,
+          fin,
+          duracion: '1h 30m',
+        },
+      ],
+    });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <RecentCareCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listarRecientes).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByText('1h 30m')).toBeInTheDocument();
+    });
+  });
+
+  it('calcula la duración usando inicio y fin en UTC cuando no se recibe duración', async () => {
     const fin = new Date().toISOString();
     const inicio = new Date(Date.now() - 90 * 60 * 1000).toISOString();
     listarRecientes.mockResolvedValue({
@@ -58,7 +87,7 @@ describe('RecentCareCard', () => {
           tipoNombre: 'Sueño',
           inicio,
           fin,
-          duracionMin: null,
+          duracion: null,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- read sleep duration directly from `duracion`
- fallback to calculate duration from `inicio`/`fin` when missing
- test RecentCareCard uses API-provided `duracion`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c30b1c66a08327a2f08c78c7881cf9