### PR TITLE
feat: expose last bottle endpoint for stats

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
@@ -1,6 +1,7 @@
 package com.babytrackmaster.api_alimentacion.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -82,6 +83,18 @@ public class AlimentacionController {
             @PathVariable Long usuarioId,
             @PathVariable Long bebeId) {
         return ResponseEntity.ok(service.listar(usuarioId, bebeId));
+    }
+
+    @Operation(summary = "Obtener último biberón")
+    @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/ultimo-biberon")
+    public ResponseEntity<Map<String, Object>> obtenerUltimoBiberon(
+            @PathVariable Long usuarioId,
+            @PathVariable Long bebeId) {
+        AlimentacionResponse resp = service.obtenerUltimoBiberon(usuarioId, bebeId);
+        if (resp == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(Map.of("fechaHora", resp.getFechaHora()));
     }
 
     @Operation(summary = "Obtener estadísticas de alimentación")

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
@@ -15,4 +15,5 @@ public interface AlimentacionRepository extends JpaRepository<Alimentacion, Long
     List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, LocalDateTime desde, LocalDateTime hasta);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndTipoAlimentacionIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, Long tipoAlimentacionId, LocalDateTime desde, LocalDateTime hasta);
     long countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipoAlimentacion, LocalDateTime desde, LocalDateTime hasta);
+    Optional<Alimentacion> findFirstByUsuarioIdAndBebeIdAndTipoAlimentacionNombreIgnoreCaseAndEliminadoFalseOrderByFechaHoraDesc(Long usuarioId, Long bebeId, String nombre);
 }

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
@@ -16,6 +16,7 @@ public interface AlimentacionService {
     void eliminar(Long usuarioId, Long bebeId, Long id);
     AlimentacionResponse obtener(Long usuarioId, Long bebeId, Long id);
     List<AlimentacionResponse> listar(Long usuarioId, Long bebeId);
+    AlimentacionResponse obtenerUltimoBiberon(Long usuarioId, Long bebeId);
     AlimentacionStatsResponse stats(Long usuarioId, Long bebeId, Long tipoAlimentacionId);
     List<TipoLactancia> listarTiposLactancia();
     List<TipoAlimentacion> listarTiposAlimentacion();

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
@@ -87,6 +87,15 @@ public class AlimentacionServiceImpl implements AlimentacionService {
     }
 
     @Transactional(readOnly = true)
+    public AlimentacionResponse obtenerUltimoBiberon(Long usuarioId, Long bebeId) {
+        return repo
+                .findFirstByUsuarioIdAndBebeIdAndTipoAlimentacionNombreIgnoreCaseAndEliminadoFalseOrderByFechaHoraDesc(
+                        usuarioId, bebeId, "biberón")
+                .map(AlimentacionMapper::toResponse)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
     public List<TipoLactancia> listarTiposLactancia() {
         return tipoLactanciaRepo.findAll();
     }

--- a/frontend-baby/src/dashboard/components/StatsOverview.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.js
@@ -13,7 +13,7 @@ import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
-import { listarRecientes } from '../../services/alimentacionService';
+import { obtenerUltimoBiberon } from '../../services/alimentacionService';
 import {
   listarUltimosPorTipo,
   listarTipos,
@@ -31,7 +31,7 @@ export default function StatsOverview() {
   const { activeBaby } = useContext(BabyContext);
 
   const [stats, setStats] = useState({
-    lastBottle: 'Hace 2h',
+    lastBottle: 'Sin datos',
     sleep: { hours: 0, diff: 0 },
     diapers: { count: 0, diff: 0 },
     weight: { value: '0 kg', diff: undefined, diffValue: 0 },
@@ -67,26 +67,20 @@ export default function StatsOverview() {
           /* ignore errors */
         });
 
-      listarRecientes(user.id, activeBaby.id, 1)
+      obtenerUltimoBiberon(user.id, activeBaby.id)
         .then(({ data }) => {
-          if (Array.isArray(data) && data.length > 0) {
-            const last = data[0];
-            const date =
-              last.fecha || last.date || last.fechaHora || last.createdAt;
-            if (date) {
-              setStats((prev) => ({
-                ...prev,
-                lastBottle: formatTimeAgo(date),
-              }));
-            } else {
-              setStats((prev) => ({ ...prev, lastBottle: 'Sin datos' }));
-            }
+          const date = data?.fechaHora || data;
+          if (date) {
+            setStats((prev) => ({
+              ...prev,
+              lastBottle: formatTimeAgo(date),
+            }));
           } else {
             setStats((prev) => ({ ...prev, lastBottle: 'Sin datos' }));
           }
         })
         .catch(() => {
-          /* ignore errors */
+          setStats((prev) => ({ ...prev, lastBottle: 'Sin datos' }));
         });
 
       listarTipos()

--- a/frontend-baby/src/dashboard/components/StatsOverview.test.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.test.js
@@ -3,7 +3,7 @@ import StatsOverview from './StatsOverview';
 import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
-import { listarRecientes } from '../../services/alimentacionService';
+import { obtenerUltimoBiberon } from '../../services/alimentacionService';
 import { listarTipos } from '../../services/crecimientoService';
 
 jest.mock('../../services/cuidadosService', () => ({
@@ -11,7 +11,7 @@ jest.mock('../../services/cuidadosService', () => ({
 }));
 
 jest.mock('../../services/alimentacionService', () => ({
-  listarRecientes: jest.fn(),
+  obtenerUltimoBiberon: jest.fn(),
 }));
 
 jest.mock('../../services/crecimientoService', () => ({
@@ -50,11 +50,13 @@ describe('StatsOverview', () => {
     const lastDate = new Date(
       now.getTime() - (2 * 60 + 15) * 60 * 1000
     ).toISOString();
-    listarRecientes.mockResolvedValue({ data: [{ fecha: lastDate }] });
+    obtenerUltimoBiberon.mockResolvedValue({
+      data: { fechaHora: lastDate },
+    });
 
     renderComponent();
 
-    await waitFor(() => expect(listarRecientes).toHaveBeenCalled());
+    await waitFor(() => expect(obtenerUltimoBiberon).toHaveBeenCalled());
     await waitFor(() => {
       expect(screen.getByText('Hace 2h 15m')).toBeInTheDocument();
     });
@@ -64,11 +66,11 @@ describe('StatsOverview', () => {
     jest.useFakeTimers().setSystemTime(new Date('2024-01-01T12:00:00Z'));
     obtenerStatsRapidas.mockResolvedValue({ data: {} });
     listarTipos.mockResolvedValue({ data: [] });
-    listarRecientes.mockResolvedValue({ data: [] });
+    obtenerUltimoBiberon.mockResolvedValue({ data: {} });
 
     renderComponent();
 
-    await waitFor(() => expect(listarRecientes).toHaveBeenCalled());
+    await waitFor(() => expect(obtenerUltimoBiberon).toHaveBeenCalled());
     await waitFor(() => {
       expect(screen.getByText('Sin datos')).toBeInTheDocument();
     });

--- a/frontend-baby/src/services/alimentacionService.js
+++ b/frontend-baby/src/services/alimentacionService.js
@@ -18,6 +18,11 @@ export const listarRecientes = (usuarioId, bebeId, limit) => {
   );
 };
 
+export const obtenerUltimoBiberon = (usuarioId, bebeId) =>
+  axios.get(
+    `${API_ALIMENTACION_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}/ultimo-biberon`
+  );
+
 export const obtenerEstadisticas = (usuarioId, bebeId, tipoAlimentacionId) => {
   const params = {};
   if (tipoAlimentacionId !== undefined) params.tipoAlimentacionId = tipoAlimentacionId;


### PR DESCRIPTION
## Summary
- add repository method and service logic to fetch the latest bottle feeding
- expose `/ultimo-biberon` endpoint returning the last feeding time
- show last bottle time in dashboard via new frontend service and tests

## Testing
- `cd api-alimentacion && ./mvnw -q test` *(fails: Non-resolvable parent POM)*
- `cd frontend-baby && npm test -- src/dashboard/components/StatsOverview.test.js src/services/alimentacionService.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3133dd6fc832793a9c47f20d59e7c