### PR TITLE
feat(api-alimentacion): add recent feed listing endpoint

### DIFF
--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/controller/AlimentacionController.java
@@ -85,6 +85,15 @@ public class AlimentacionController {
         return ResponseEntity.ok(service.listar(usuarioId, bebeId));
     }
 
+    @Operation(summary = "Listar registros recientes de alimentación")
+    @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/recientes")
+    public ResponseEntity<List<AlimentacionResponse>> listarRecientes(
+            @PathVariable Long usuarioId,
+            @PathVariable Long bebeId,
+            @RequestParam(value = "limit", required = false) Integer limit) {
+        return ResponseEntity.ok(service.listarRecientes(usuarioId, bebeId, limit));
+    }
+
     @Operation(summary = "Obtener último biberón")
     @GetMapping("/usuario/{usuarioId}/bebe/{bebeId}/ultimo-biberon")
     public ResponseEntity<Map<String, Object>> obtenerUltimoBiberon(

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/repository/AlimentacionRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.babytrackmaster.api_alimentacion.entity.Alimentacion;
@@ -12,6 +13,7 @@ import com.babytrackmaster.api_alimentacion.entity.TipoAlimentacion;
 public interface AlimentacionRepository extends JpaRepository<Alimentacion, Long> {
     Optional<Alimentacion> findByIdAndUsuarioIdAndBebeIdAndEliminadoFalse(Long id, Long usuarioId, Long bebeId);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaHoraDesc(Long usuarioId, Long bebeId);
+    List<Alimentacion> findByUsuarioIdAndBebeIdAndEliminadoFalse(Long usuarioId, Long bebeId, Pageable pageable);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, LocalDateTime desde, LocalDateTime hasta);
     List<Alimentacion> findByUsuarioIdAndBebeIdAndTipoAlimentacionIdAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, Long tipoAlimentacionId, LocalDateTime desde, LocalDateTime hasta);
     long countByUsuarioIdAndBebeIdAndTipoAlimentacionAndFechaHoraBetweenAndEliminadoFalse(Long usuarioId, Long bebeId, TipoAlimentacion tipoAlimentacion, LocalDateTime desde, LocalDateTime hasta);

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/AlimentacionService.java
@@ -16,6 +16,7 @@ public interface AlimentacionService {
     void eliminar(Long usuarioId, Long bebeId, Long id);
     AlimentacionResponse obtener(Long usuarioId, Long bebeId, Long id);
     List<AlimentacionResponse> listar(Long usuarioId, Long bebeId);
+    List<AlimentacionResponse> listarRecientes(Long usuarioId, Long bebeId, Integer limit);
     AlimentacionResponse obtenerUltimoBiberon(Long usuarioId, Long bebeId);
     AlimentacionStatsResponse stats(Long usuarioId, Long bebeId, Long tipoAlimentacionId);
     List<TipoLactancia> listarTiposLactancia();

--- a/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
+++ b/api-alimentacion/src/main/java/com/babytrackmaster/api_alimentacion/service/impl/AlimentacionServiceImpl.java
@@ -7,6 +7,8 @@ import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -79,6 +81,18 @@ public class AlimentacionServiceImpl implements AlimentacionService {
     @Transactional(readOnly = true)
     public List<AlimentacionResponse> listar(Long usuarioId, Long bebeId) {
         List<Alimentacion> list = repo.findByUsuarioIdAndBebeIdAndEliminadoFalseOrderByFechaHoraDesc(usuarioId, bebeId);
+        List<AlimentacionResponse> resp = new ArrayList<>();
+        for (Alimentacion a : list) {
+            resp.add(AlimentacionMapper.toResponse(a));
+        }
+        return resp;
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlimentacionResponse> listarRecientes(Long usuarioId, Long bebeId, Integer limit) {
+        int lim = (limit != null) ? limit : 5;
+        List<Alimentacion> list = repo.findByUsuarioIdAndBebeIdAndEliminadoFalse(usuarioId, bebeId,
+                PageRequest.of(0, lim, Sort.by("fechaHora").descending()));
         List<AlimentacionResponse> resp = new ArrayList<>();
         for (Alimentacion a : list) {
             resp.add(AlimentacionMapper.toResponse(a));


### PR DESCRIPTION
## Summary
- add repository method to fetch limited recent Alimentacion records
- expose listarRecientes service method and REST endpoint with optional limit

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.babytrackmaster:api-alimentacion ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c31a657ae48327a6c375f23d734792