### PR TITLE
feat: sum lactation minutes and show units

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -78,9 +78,12 @@ export default function QuickActionsCard() {
               ? getDate(biberonItems[0])
               : null;
 
-            const todayPecho = pechoItems.filter((item) =>
-              getDate(item).isSame(now, 'day'),
-            ).length;
+            const todayPecho = pechoItems
+              .filter((item) => getDate(item).isSame(now, 'day'))
+              .reduce(
+                (sum, item) => sum + Number(item.duracionMin || 0),
+                0,
+              );
             const todayBiberon = biberonItems.filter((item) =>
               getDate(item).isSame(now, 'day'),
             ).length;
@@ -170,7 +173,7 @@ export default function QuickActionsCard() {
         disableTipo: true,
         disableTipoLactancia: true,
       },
-      unit: '',
+      unit: 'min',
       color: 'primary',
     },
     {


### PR DESCRIPTION
## Summary
- accumulate lactation durations instead of counting sessions
- show lactation totals with `min` unit

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c31d90a7608327832057ae99c80ba8