### PR TITLE
Sumar mililitros en acciones rápidas de biberón

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -84,9 +84,13 @@ export default function QuickActionsCard() {
                 (sum, item) => sum + Number(item.duracionMin || 0),
                 0,
               );
-            const todayBiberon = biberonItems.filter((item) =>
-              getDate(item).isSame(now, 'day'),
-            ).length;
+            const todayBiberon = biberonItems.reduce(
+              (sum, item) =>
+                getDate(item).isSame(now, 'day')
+                  ? sum + Number(item.cantidadMl || 0)
+                  : sum,
+              0,
+            );
 
             setActionsData((prev) => ({
               ...prev,
@@ -182,7 +186,7 @@ export default function QuickActionsCard() {
       icon: LocalDrinkIcon,
       path: '/dashboard/alimentacion',
       state: { tipo: 'biberon', disableTipo: true },
-      unit: '',
+      unit: 'ml',
       color: 'primary',
     },
     {

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import QuickActionsCard from './QuickActionsCard';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+import { listarRecientes as listarAlimentacionRecientes } from '../../services/alimentacionService';
+import { listarRecientes as listarCuidadosRecientes, obtenerStatsRapidas } from '../../services/cuidadosService';
+import { listarRecientes as listarGastosRecientes } from '../../services/gastosService';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock(
+  'react-router-dom',
+  () => ({
+    __esModule: true,
+    useNavigate: () => jest.fn(),
+  }),
+  { virtual: true }
+);
+
+jest.mock('../../services/alimentacionService', () => ({
+  listarRecientes: jest.fn(),
+}));
+
+jest.mock('../../services/cuidadosService', () => ({
+  listarRecientes: jest.fn(),
+  obtenerStatsRapidas: jest.fn(),
+}));
+
+jest.mock('../../services/gastosService', () => ({
+  listarRecientes: jest.fn(),
+}));
+
+dayjs.extend(relativeTime);
+
+if (typeof global.structuredClone !== 'function') {
+  global.structuredClone = (val) => JSON.parse(JSON.stringify(val));
+}
+
+describe('QuickActionsCard', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('muestra total de mililitros de biberón consumidos hoy', async () => {
+    const now = dayjs();
+    listarAlimentacionRecientes.mockResolvedValue({
+      data: [
+        {
+          fechaHora: now.toISOString(),
+          tipoAlimentacion: { nombre: 'Biberón' },
+          cantidadMl: 100,
+        },
+        {
+          fechaHora: now.toISOString(),
+          tipoAlimentacion: { nombre: 'Biberón' },
+          cantidadMl: 50,
+        },
+        {
+          fechaHora: now.subtract(1, 'day').toISOString(),
+          tipoAlimentacion: { nombre: 'Biberón' },
+          cantidadMl: 200,
+        },
+      ],
+    });
+    obtenerStatsRapidas.mockResolvedValue({ data: {} });
+    listarCuidadosRecientes.mockResolvedValue({ data: [] });
+    listarGastosRecientes.mockResolvedValue({ data: [] });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <QuickActionsCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(listarAlimentacionRecientes).toHaveBeenCalledWith(1, 2, 20);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Hoy: 150ml')).toBeInTheDocument();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Sumar mililitros de biberón del día en QuickActionsCard
- Mostrar unidad "ml" para acción de biberón
- Añadir prueba que verifica el cálculo de mililitros del biberón

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c32155f8788327b094352b62c7d3eb