### PR TITLE
Allow decimal newborn weight input

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -216,7 +216,7 @@ export default function AnadirBebe() {
                     label="Peso al nacer (kg)"
                     name="pesoNacer"
                     type="number"
-                    inputProps={{ min: 0 }}
+                    inputProps={{ min: 0, step: 0.01 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.pesoNacer}


### PR DESCRIPTION
## Summary
- allow decimal input for newborn weight in Add Baby form

## Testing
- `cd frontend-baby && CI=true npm test -- --watch=false`
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
const dom = new JSDOM(`<!DOCTYPE html><input type="number" min="0" step="0.01">`);
const input = dom.window.document.querySelector('input');
input.value = '2.77';
console.log('valid', input.validity.valid);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c3be4239d48327b3137adf8d65fc4f