### PR TITLE
feat: allow decimal newborn weight

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -252,7 +252,7 @@ export default function EditarBebe() {
                     label="Peso al nacer (kg)"
                     name="pesoNacer"
                     type="number"
-                    inputProps={{ min: 0 }}
+                    inputProps={{ min: 0, step: 0.01 }}
                     InputLabelProps={{ shrink: true }}
                     fullWidth
                     value={formData.pesoNacer}


### PR DESCRIPTION
## Summary
- allow entering newborn weight with decimals in EditarBebe by setting step 0.01

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c3be4a123c832794cc4fdd6d06a107