### PR TITLE
Sum bath quantities in quick stats

### DIFF
--- a/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
+++ b/api-cuidados/src/main/java/com/babytrackmaster/api_cuidados/service/iml/CuidadoServiceImpl.java
@@ -146,7 +146,11 @@ public class CuidadoServiceImpl implements CuidadoService {
             horasSueno += parseDurationToHours(c.getDuracion(), c.getInicio(), c.getFin());
         }
 
-        int numBanosTotal = numBanos.size();
+        int numBanosTotal = 0;
+        for (Cuidado c : numBanos) {
+            Integer cant = c.getCantidadMl();
+            numBanosTotal += (cant != null) ? cant : 1;
+        }
         int numPanalesTotal = 0;
         for (Cuidado c : numPanales) {
             Integer cant = c.getCantidadPanal();

--- a/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
+++ b/api-cuidados/src/test/java/com/babytrackmaster/api_cuidados/CuidadoServiceImplTest.java
@@ -38,6 +38,7 @@ class CuidadoServiceImplTest {
     private Date baseDate;
     private Cuidado panalGuardado;
     private TipoCuidado tipoSueno;
+    private TipoCuidado tipoBano;
 
     @BeforeEach
     void setUp() {
@@ -48,7 +49,7 @@ class CuidadoServiceImplTest {
 
         tipoSueno = saveTipo("Sue\u00f1o");
         TipoCuidado panal = saveTipo("Pa\u00f1al");
-        TipoCuidado bano = saveTipo("Ba\u00f1o");
+        tipoBano = saveTipo("Ba\u00f1o");
         TipoPanal pipi = saveTipoPanal("PIPI");
 
         createCuidado(tipoSueno, null, date(2024,3,10,0,0), date(2024,3,10,4,0), "120");
@@ -57,7 +58,7 @@ class CuidadoServiceImplTest {
         panalGuardado = createCuidado(panal, pipi, date(2024,3,10,3,0), date(2024,3,10,3,5), null, 2);
         createCuidado(panal, pipi, date(2024,3,10,7,0), date(2024,3,10,7,5), null, 1);
         createCuidado(panal, pipi, date(2024,3,10,13,0), date(2024,3,10,13,7), null, 1);
-        createCuidado(bano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
+        createCuidado(tipoBano, null, date(2024,3,10,18,0), date(2024,3,10,18,20));
     }
 
     @Test
@@ -79,6 +80,18 @@ class CuidadoServiceImplTest {
     void obtenerDevuelveCantidadPanal() {
         CuidadoResponse resp = service.obtener(1L, panalGuardado.getId());
         assertEquals(2, resp.getCantidadPanal());
+    }
+
+    @Test
+    void quickStatsSumaCantidadMlDeBanos() {
+        Cuidado b1 = createCuidado(tipoBano, null, date(2024,3,10,19,0), date(2024,3,10,19,10));
+        b1.setCantidadMl(2);
+        cuidadoRepo.save(b1);
+        Cuidado b2 = createCuidado(tipoBano, null, date(2024,3,10,20,0), date(2024,3,10,20,15));
+        b2.setCantidadMl(3);
+        cuidadoRepo.save(b2);
+        QuickStatsResponse resp = service.obtenerEstadisticasRapidas(1L,1L, baseDate);
+        assertEquals(6, resp.getBanos());
     }
 
     private TipoCuidado saveTipo(String nombre) {


### PR DESCRIPTION
## Summary
- Accumulate "Baño" records by their `cantidadMl` (defaulting to 1) when building quick stats
- Test that quick stats returns summed bath totals across multiple records

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3d7ad8a448327b7b539471fdff8fc