### PR TITLE
feat: count daily baths

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -23,7 +23,6 @@ import {
 } from '../../services/cuidadosService';
 import { listarRecientes as listarAlimentacionRecientes } from '../../services/alimentacionService';
 import { listarRecientes as listarGastosRecientes } from '../../services/gastosService';
-import { parseDurationToHours } from '../../utils/duration';
 
 const initialActionsData = {
   pecho: { last: null, today: 0 },
@@ -66,8 +65,7 @@ export default function QuickActionsCard() {
                         dayjs(item.inicio).isSame(now, 'day'),
                     )
                     .reduce(
-                      (sum, item) =>
-                        sum + parseDurationToHours(item.duracion),
+                      (sum, item) => sum + Number(item.cantidadMl || 0),
                       0,
                     )
                 : 0;
@@ -245,7 +243,7 @@ export default function QuickActionsCard() {
       icon: BathtubIcon,
       path: '/dashboard/cuidados',
       state: { tipo: 'Baño', disableTipo: true },
-      unit: 'h',
+      unit: '',
       color: 'info',
     },
     {

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -93,7 +93,7 @@ describe('QuickActionsCard', () => {
     });
   });
 
-  it('suma correctamente las horas de baño del día de hoy', async () => {
+  it('suma correctamente los baños del día de hoy', async () => {
     const now = dayjs();
     listarAlimentacionRecientes.mockResolvedValue({ data: [] });
     obtenerStatsRapidas.mockResolvedValue({ data: {} });
@@ -104,17 +104,17 @@ describe('QuickActionsCard', () => {
           {
             tipoNombre: 'Baño',
             inicio: now.toISOString(),
-            duracion: '30m',
+            cantidadMl: 1,
           },
           {
             tipoNombre: 'Baño',
             inicio: now.toISOString(),
-            duracion: '3h00m',
+            cantidadMl: 2,
           },
           {
             tipoNombre: 'Baño',
             inicio: now.subtract(1, 'day').toISOString(),
-            duracion: '15m',
+            cantidadMl: 5,
           },
         ],
       });
@@ -125,11 +125,11 @@ describe('QuickActionsCard', () => {
         <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
           <QuickActionsCard />
         </BabyContext.Provider>
-      </AuthContext.Provider>
+      </AuthContext.Provider>,
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Hoy: 3.5h')).toBeInTheDocument();
+      expect(screen.getByText('Hoy: 3')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- count today's baths using stored quantity instead of duration
- show bath count without unit in quick actions
- adjust tests for bath count logic

## Testing
- `npm test -- src/dashboard/components/QuickActionsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3eba7aa64832796da7c9b8b810405