### PR TITLE
Ajusta servicio de gastos con paginación

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -169,12 +169,12 @@ export default function QuickActionsCard() {
         });
 
       listarGastosRecientes(usuarioId, bebeId, 20)
-        .then(({ data }) => {
-          if (Array.isArray(data) && data.length > 0) {
+        .then((gastos) => {
+          if (Array.isArray(gastos) && gastos.length > 0) {
             const now = dayjs();
             const getDate = (item) => dayjs(item.fechaHora);
-            const last = getDate(data[0]);
-            const todayTotal = data.reduce((sum, item) => {
+            const last = getDate(gastos[0]);
+            const todayTotal = gastos.reduce((sum, item) => {
               const date = getDate(item);
               return date.isSame(now, 'day')
                 ? sum + Number(item.cantidad || 0)

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -74,7 +74,7 @@ describe('QuickActionsCard', () => {
     });
     obtenerStatsRapidas.mockResolvedValue({ data: {} });
     listarCuidadosRecientes.mockResolvedValue({ data: [] });
-    listarGastosRecientes.mockResolvedValue({ data: [] });
+    listarGastosRecientes.mockResolvedValue([]);
 
     render(
       <AuthContext.Provider value={{ user: { id: 1 } }}>
@@ -118,7 +118,7 @@ describe('QuickActionsCard', () => {
           },
         ],
       });
-    listarGastosRecientes.mockResolvedValue({ data: [] });
+    listarGastosRecientes.mockResolvedValue([]);
 
     render(
       <AuthContext.Provider value={{ user: { id: 1 } }}>

--- a/frontend-baby/src/services/gastosService.js
+++ b/frontend-baby/src/services/gastosService.js
@@ -14,12 +14,13 @@ export const listarPorBebe = (usuarioId, bebeId, page = 0, size = 10) => {
 };
 
 export const listarRecientes = (usuarioId, bebeId, limit = 5) => {
-  return axios.get(
-    `${API_GASTOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
-    {
-      params: { limit },
-    }
-  );
+  return axios
+    .get(`${API_GASTOS_ENDPOINT}/usuario/${usuarioId}/bebe/${bebeId}`,
+      {
+        params: { page: 0, size: limit },
+      },
+    )
+    .then((response) => response.data.content);
 };
 
 export const crearGasto = (usuarioId, data) => {


### PR DESCRIPTION
## Summary
- Usa `page` y `size` en lugar de `limit` al listar gastos recientes y retorna `response.data.content`
- Actualiza `QuickActionsCard` para procesar el arreglo de gastos recientes
- Ajusta prueba de `QuickActionsCard` para el nuevo comportamiento del servicio de gastos

## Testing
- `CI=true npm test -- --runTestsByPath src/dashboard/components/QuickActionsCard.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c3ecb88e188327a2f724de94f00026