### PR TITLE
feat: show daily expense totals with euro symbol

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -261,7 +261,7 @@ export default function QuickActionsCard() {
       icon: AttachMoneyIcon,
       path: '/dashboard/gastos',
       state: { openForm: true },
-      unit: '',
+      unit: '€',
       color: 'warning',
     },
   ];
@@ -287,7 +287,14 @@ export default function QuickActionsCard() {
             const Icon = action.icon;
             const info = actionsData[action.key];
             const last = info.last ? info.last.fromNow() : '-';
-            const today = `${info.today}${action.unit}`;
+            const formattedToday =
+              action.key === 'gasto'
+                ? Number(info.today)
+                    .toFixed(2)
+                    .replace(/\.00$/, '')
+                    .replace(/(\.\d)0$/, '$1')
+                : info.today;
+            const today = `${formattedToday}${action.unit}`;
 
             return (
               <Grid item xs={6} md={3} key={action.key}>

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -132,5 +132,29 @@ describe('QuickActionsCard', () => {
       expect(screen.getByText('Hoy: 3')).toBeInTheDocument();
     });
   });
+
+  it('muestra el total de gastos del día con el símbolo €', async () => {
+    const now = dayjs();
+    listarAlimentacionRecientes.mockResolvedValue({ data: [] });
+    obtenerStatsRapidas.mockResolvedValue({ data: {} });
+    listarCuidadosRecientes.mockResolvedValue({ data: [] });
+    listarGastosRecientes.mockResolvedValue([
+      { fechaHora: now.toISOString(), cantidad: 20 },
+      { fechaHora: now.toISOString(), cantidad: 20 },
+      { fechaHora: now.subtract(1, 'day').toISOString(), cantidad: 10 },
+    ]);
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 2 } }}>
+          <QuickActionsCard />
+        </BabyContext.Provider>
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Hoy: 40€')).toBeInTheDocument();
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- show euro symbol for expenses in quick actions
- format expense values and test daily total rendering

## Testing
- `cd frontend-baby && CI=true npm test -- src/dashboard/components/QuickActionsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3ee07a12883279acc388167c3f239