### PR TITLE
feat: refresh status summary periodically

### DIFF
--- a/frontend-baby/src/dashboard/components/StatusSummaryCard.js
+++ b/frontend-baby/src/dashboard/components/StatusSummaryCard.js
@@ -29,7 +29,9 @@ export default function StatusSummaryCard() {
   });
 
   useEffect(() => {
-    if (user?.id && activeBaby?.id) {
+    let intervalId;
+
+    const fetchEvents = () => {
       Promise.all([
         listarCuidadosRecientes(user.id, activeBaby.id, 20),
         listarAlimentacionRecientes(user.id, activeBaby.id, 20),
@@ -48,7 +50,18 @@ export default function StatusSummaryCard() {
         .catch(() =>
           setEvents({ feeding: null, diaper: null, sleep: null, bath: null })
         );
+    };
+
+    if (user?.id && activeBaby?.id) {
+      fetchEvents();
+      intervalId = setInterval(fetchEvents, 15000);
     }
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
   }, [user, activeBaby]);
 
   const formatTime = (event) =>


### PR DESCRIPTION
## Summary
- refresh StatusSummaryCard every 15s by polling recent care and feeding
- clear polling interval on unmount

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c3f5f15c5883279df361a2d8a64e09