### PR TITLE
Use gasto fecha field in QuickActionsCard

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.js
@@ -176,7 +176,7 @@ export default function QuickActionsCard() {
         .then((gastos) => {
           if (Array.isArray(gastos) && gastos.length > 0) {
             const now = dayjs();
-            const getDate = (item) => dayjs(item.fechaHora);
+            const getDate = (item) => dayjs(item.fecha);
             const last = getDate(gastos[0]);
             const todayTotal = gastos.reduce((sum, item) => {
               const date = getDate(item);

--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -139,9 +139,9 @@ describe('QuickActionsCard', () => {
     obtenerStatsRapidas.mockResolvedValue({ data: {} });
     listarCuidadosRecientes.mockResolvedValue({ data: [] });
     listarGastosRecientes.mockResolvedValue([
-      { fechaHora: now.toISOString(), cantidad: 20 },
-      { fechaHora: now.toISOString(), cantidad: 20 },
-      { fechaHora: now.subtract(1, 'day').toISOString(), cantidad: 10 },
+      { fecha: now.toISOString(), cantidad: 20 },
+      { fecha: now.toISOString(), cantidad: 20 },
+      { fecha: now.subtract(1, 'day').toISOString(), cantidad: 10 },
     ]);
 
     render(
@@ -154,6 +154,11 @@ describe('QuickActionsCard', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Hoy: 40€')).toBeInTheDocument();
+    });
+
+    const lastText = `Última vez: ${dayjs(now.toISOString()).fromNow()}`;
+    await waitFor(() => {
+      expect(screen.getByText(lastText)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Use `fecha` instead of `fechaHora` for gasto dates in QuickActionsCard and related calculations
- Update tests to mock gasto `fecha` and verify last-time display

## Testing
- `CI=true npm test -- src/dashboard/components/QuickActionsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3f710fe5c8327bc2d764346fa777c