### PR TITLE
refactor: unify care listings

### DIFF
--- a/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
+++ b/frontend-baby/src/dashboard/components/QuickActionsCard.test.js
@@ -97,27 +97,25 @@ describe('QuickActionsCard', () => {
     const now = dayjs();
     listarAlimentacionRecientes.mockResolvedValue({ data: [] });
     obtenerStatsRapidas.mockResolvedValue({ data: {} });
-    listarCuidadosRecientes
-      .mockResolvedValueOnce({ data: [] })
-      .mockResolvedValueOnce({
-        data: [
-          {
-            tipoNombre: 'Baño',
-            inicio: now.toISOString(),
-            cantidadMl: 1,
-          },
-          {
-            tipoNombre: 'Baño',
-            inicio: now.toISOString(),
-            cantidadMl: 2,
-          },
-          {
-            tipoNombre: 'Baño',
-            inicio: now.subtract(1, 'day').toISOString(),
-            cantidadMl: 5,
-          },
-        ],
-      });
+    listarCuidadosRecientes.mockResolvedValue({
+      data: [
+        {
+          tipoNombre: 'Baño',
+          inicio: now.toISOString(),
+          cantidadMl: 1,
+        },
+        {
+          tipoNombre: 'Baño',
+          inicio: now.toISOString(),
+          cantidadMl: 2,
+        },
+        {
+          tipoNombre: 'Baño',
+          inicio: now.subtract(1, 'day').toISOString(),
+          cantidadMl: 5,
+        },
+      ],
+    });
     listarGastosRecientes.mockResolvedValue([]);
 
     render(


### PR DESCRIPTION
## Summary
- remove duplicate calls to recent care service and reuse data for daily totals and last timestamps
- adjust unit test for new single call behavior

## Testing
- `cd frontend-baby && npm test -- QuickActionsCard.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3f7cdaec88327b2269738de2de94d