### PR TITLE
feat: show message when weekly appointments missing

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -360,84 +360,92 @@ export default function Citas() {
         </>
       )}
 
-      <TableContainer sx={{ mb: 4 }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Fecha</TableCell>
-              <TableCell>Hora</TableCell>
-              <TableCell>Motivo</TableCell>
-              <TableCell>Tipo</TableCell>
-              <TableCell>Estado</TableCell>
-              {view !== 'week' && <TableCell>Centro médico</TableCell>}
-              <TableCell align="center">Acciones</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {tableData
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((cita) => (
-                <TableRow key={cita.id}>
-                  <TableCell>
-                    {dayjs(cita.fecha).format('DD/MM/YYYY')}
-                  </TableCell>
-                  <TableCell>
-                    {dayjs(`${cita.fecha}T${cita.hora}`).format('HH:mm')}
-                  </TableCell>
-                  <TableCell>{cita.motivo}</TableCell>
-                  <TableCell>
-                    {cita.tipoNombre ||
-                      tipos.find((t) => Number(t.id) === Number(cita.tipoId))?.nombre}
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={cita.estadoNombre}
-                      color={getEstadoColor(cita.estadoNombre)}
-                      size="small"
-                    />
-                  </TableCell>
-                  {view !== 'week' && (
-                    <TableCell>{cita.centroMedico || '-'}</TableCell>
-                  )}
-                  <TableCell align="center">
-                    <IconButton
-                      size="small"
-                      aria-label="reminder"
-                      onClick={() => handleRecordatorio(cita.id)}
-                      sx={{ color: '#6c757d' }}
-                    >
-                      <NotificationsActiveIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      aria-label="edit"
-                      onClick={() => handleEdit(cita)}
-                      sx={{ color: '#0d6efd' }}
-                    >
-                      <EditIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      aria-label="estado"
-                      onClick={(e) => handleOpenEstadoMenu(e, cita.id)}
-                      sx={{ color: '#6c757d' }}
-                    >
-                      <MoreVertIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
-                </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-        <TablePagination
-          component="div"
-          count={tableData.length}
-          page={page}
-          onPageChange={handleChangePage}
-          rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      </TableContainer>
+      {view === 'week' && citasSemana.length === 0 ? (
+        <Box
+          sx={{ display: 'flex', justifyContent: 'center', mt: 4, width: '100%' }}
+        >
+          <Typography>No hay citas para esta semana</Typography>
+        </Box>
+      ) : (
+        <TableContainer sx={{ mb: 4 }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Fecha</TableCell>
+                <TableCell>Hora</TableCell>
+                <TableCell>Motivo</TableCell>
+                <TableCell>Tipo</TableCell>
+                <TableCell>Estado</TableCell>
+                {view !== 'week' && <TableCell>Centro médico</TableCell>}
+                <TableCell align="center">Acciones</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {tableData
+                .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                .map((cita) => (
+                  <TableRow key={cita.id}>
+                    <TableCell>
+                      {dayjs(cita.fecha).format('DD/MM/YYYY')}
+                    </TableCell>
+                    <TableCell>
+                      {dayjs(`${cita.fecha}T${cita.hora}`).format('HH:mm')}
+                    </TableCell>
+                    <TableCell>{cita.motivo}</TableCell>
+                    <TableCell>
+                      {cita.tipoNombre ||
+                        tipos.find((t) => Number(t.id) === Number(cita.tipoId))?.nombre}
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={cita.estadoNombre}
+                        color={getEstadoColor(cita.estadoNombre)}
+                        size="small"
+                      />
+                    </TableCell>
+                    {view !== 'week' && (
+                      <TableCell>{cita.centroMedico || '-'}</TableCell>
+                    )}
+                    <TableCell align="center">
+                      <IconButton
+                        size="small"
+                        aria-label="reminder"
+                        onClick={() => handleRecordatorio(cita.id)}
+                        sx={{ color: '#6c757d' }}
+                      >
+                        <NotificationsActiveIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        aria-label="edit"
+                        onClick={() => handleEdit(cita)}
+                        sx={{ color: '#0d6efd' }}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        size="small"
+                        aria-label="estado"
+                        onClick={(e) => handleOpenEstadoMenu(e, cita.id)}
+                        sx={{ color: '#6c757d' }}
+                      >
+                        <MoreVertIcon fontSize="small" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+            </TableBody>
+          </Table>
+          <TablePagination
+            component="div"
+            count={tableData.length}
+            page={page}
+            onPageChange={handleChangePage}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+        </TableContainer>
+      )}
       <Menu
         anchorEl={menuAnchor}
         open={Boolean(menuAnchor)}

--- a/frontend-baby/src/dashboard/pages/Citas.test.js
+++ b/frontend-baby/src/dashboard/pages/Citas.test.js
@@ -1,0 +1,67 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import Citas from './Citas';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+jest.mock('../../services/citasService', () => ({
+  listar: jest.fn(),
+  crearCita: jest.fn(),
+  actualizarCita: jest.fn(),
+  confirmarCita: jest.fn(),
+  cancelarCita: jest.fn(),
+  completarCita: jest.fn(),
+  marcarNoAsistida: jest.fn(),
+  listarTipos: jest.fn(),
+  listarEstados: jest.fn(),
+  enviarRecordatorio: jest.fn(),
+}));
+
+const {
+  listar,
+  listarTipos,
+  listarEstados,
+} = require('../../services/citasService');
+
+jest.mock('../components/CitaForm', () => () => null);
+
+jest.mock('@mui/x-date-pickers', () => ({
+  DateCalendar: () => null,
+  PickersDay: () => null,
+}));
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe('Citas', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('muestra mensaje cuando no hay citas en la semana', async () => {
+    listar.mockResolvedValue({ data: [] });
+    listarTipos.mockResolvedValue({ data: [] });
+    listarEstados.mockResolvedValue({ data: [] });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 1 } }}>
+          <Citas />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listar).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: /semana/i }));
+
+    expect(
+      await screen.findByText('No hay citas para esta semana')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- show a helpful message when the weekly view has no appointments
- add tests for weekly no-appointments message

## Testing
- `cd frontend-baby && npm test src/dashboard/pages/Citas.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c3fff6a1b083278146eb1a0090e584