### PR TITLE
feat: show empty appointments message

### DIFF
--- a/frontend-baby/src/dashboard/pages/Citas.js
+++ b/frontend-baby/src/dashboard/pages/Citas.js
@@ -360,11 +360,15 @@ export default function Citas() {
         </>
       )}
 
-      {view === 'week' && citasSemana.length === 0 ? (
+      {tableData.length === 0 ? (
         <Box
           sx={{ display: 'flex', justifyContent: 'center', mt: 4, width: '100%' }}
         >
-          <Typography>No hay citas para esta semana</Typography>
+          <Typography>
+            {view === 'week'
+              ? 'No hay citas para esta semana'
+              : 'No se han registrado citas'}
+          </Typography>
         </Box>
       ) : (
         <TableContainer sx={{ mb: 4 }}>

--- a/frontend-baby/src/dashboard/pages/Citas.test.js
+++ b/frontend-baby/src/dashboard/pages/Citas.test.js
@@ -43,6 +43,26 @@ describe('Citas', () => {
     jest.clearAllMocks();
   });
 
+  it('muestra mensaje cuando no se han registrado citas', async () => {
+    listar.mockResolvedValue({ data: [] });
+    listarTipos.mockResolvedValue({ data: [] });
+    listarEstados.mockResolvedValue({ data: [] });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 1 } }}>
+          <Citas />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listar).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText('No se han registrado citas')
+    ).toBeInTheDocument();
+  });
+
   it('muestra mensaje cuando no hay citas en la semana', async () => {
     listar.mockResolvedValue({ data: [] });
     listarTipos.mockResolvedValue({ data: [] });


### PR DESCRIPTION
## Summary
- Display specific message when there are no appointments and switch between week and general views
- Render appointments table only when there is data
- Add tests for empty appointments in default view

## Testing
- `cd frontend-baby && CI=true npm test -- src/dashboard/pages/Citas.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4021c09cc832780a4bb7b3a69a5a4