### PR TITLE
feat(frontend): dynamic growth labels

### DIFF
--- a/frontend-baby/src/dashboard/pages/Crecimiento.js
+++ b/frontend-baby/src/dashboard/pages/Crecimiento.js
@@ -34,6 +34,34 @@ import { BabyContext } from "../../context/BabyContext";
 import { AuthContext } from "../../context/AuthContext";
 import { addButton } from "../../theme/buttonStyles";
 
+function getLabelsByTipo(tipo) {
+  switch (tipo?.nombre) {
+    case "Peso":
+      return {
+        valorHeader: "Peso (kg)",
+        chartTitle: "Evolución del peso",
+        seriesLabel: "Peso",
+      };
+    case "Talla":
+      return {
+        valorHeader: "Medida (cm)",
+        chartTitle: "Evolución de la talla",
+        seriesLabel: "Talla",
+      };
+    case "Perímetro cefálico":
+      return {
+        valorHeader: "Medida (cm)",
+        chartTitle: "Evolución del perímetro cefálico",
+        seriesLabel: "Perímetro cefálico",
+      };
+    default:
+      return {
+        valorHeader: "Valor",
+        chartTitle: "Evolución",
+      };
+  }
+}
+
 export default function Crecimiento() {
   const [tab, setTab] = useState(0);
   const [registros, setRegistros] = useState([]);
@@ -48,6 +76,8 @@ export default function Crecimiento() {
   const usuarioId = user?.id;
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
+
+  const labels = useMemo(() => getLabelsByTipo(tipos[tab]), [tipos, tab]);
 
   const filteredRegistros = useMemo(() => {
     let data =
@@ -190,8 +220,8 @@ export default function Crecimiento() {
             <TableRow>
               <TableCell>Fecha</TableCell>
               <TableCell>Tipo</TableCell>
-              <TableCell>Valor</TableCell>
-              <TableCell>Nota</TableCell>
+              <TableCell>{labels.valorHeader}</TableCell>
+              <TableCell>Observaciones</TableCell>
               <TableCell align="center">Acciones</TableCell>
             </TableRow>
           </TableHead>
@@ -243,7 +273,7 @@ export default function Crecimiento() {
       <Card variant="outlined">
         <CardContent>
           <Typography variant="h6" gutterBottom>
-            Evolución
+            {labels.chartTitle}
           </Typography>
           <LineChart
             height={300}
@@ -254,7 +284,10 @@ export default function Crecimiento() {
               },
             ]}
             series={[
-              { data: chartData.map((d) => d.y), label: "Valor" },
+              {
+                data: chartData.map((d) => d.y),
+                label: labels.seriesLabel || "Valor",
+              },
               ...(chartData.some((d) => d.p !== undefined)
                 ? [{ data: chartData.map((d) => d.p), label: "Percentil OMS" }]
                 : []),

--- a/frontend-baby/src/dashboard/pages/Crecimiento.test.js
+++ b/frontend-baby/src/dashboard/pages/Crecimiento.test.js
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import Crecimiento from './Crecimiento';
+import { AuthContext } from '../../context/AuthContext';
+import { BabyContext } from '../../context/BabyContext';
+import { listarPorBebe, listarTipos } from '../../services/crecimientoService';
+
+jest.mock('../../services/crecimientoService', () => ({
+  listarPorBebe: jest.fn(),
+  listarTipos: jest.fn(),
+  crearRegistro: jest.fn(),
+  actualizarRegistro: jest.fn(),
+  eliminarRegistro: jest.fn(),
+}));
+
+jest.mock('../components/CrecimientoForm', () => () => null);
+
+jest.mock('@mui/x-charts/LineChart', () => ({
+  LineChart: ({ series }) => (
+    <div data-testid="chart">
+      {series.map((s, i) => (
+        <div key={i}>{s.label}</div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+describe('Crecimiento', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('muestra etiquetas correctas por pestaña', async () => {
+    listarTipos.mockResolvedValue({
+      data: [
+        { id: 1, nombre: 'Peso' },
+        { id: 2, nombre: 'Talla' },
+        { id: 3, nombre: 'Perímetro cefálico' },
+      ],
+    });
+    listarPorBebe.mockResolvedValue({ data: [] });
+
+    render(
+      <AuthContext.Provider value={{ user: { id: 1 } }}>
+        <BabyContext.Provider value={{ activeBaby: { id: 1 } }}>
+          <Crecimiento />
+        </BabyContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    await waitFor(() => expect(listarTipos).toHaveBeenCalled());
+
+    expect(await screen.findByText('Peso (kg)')).toBeInTheDocument();
+    expect(await screen.findByText('Evolución del peso')).toBeInTheDocument();
+    expect(
+      within(await screen.findByTestId('chart')).getByText('Peso')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Talla' }));
+
+    expect(await screen.findByText('Medida (cm)')).toBeInTheDocument();
+    expect(await screen.findByText('Evolución de la talla')).toBeInTheDocument();
+    expect(
+      within(await screen.findByTestId('chart')).getByText('Talla')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Perímetro cefálico' }));
+
+    expect(
+      await screen.findByText('Evolución del perímetro cefálico')
+    ).toBeInTheDocument();
+    expect(
+      within(await screen.findByTestId('chart')).getByText('Perímetro cefálico')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add getLabelsByTipo helper to map growth type to table and chart labels
- show correct labels per tab in Crecimiento page
- cover dynamic labels with React Testing Library tests

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68c4c09451e08327b723db4ff8230398