### PR TITLE
Actualizar textos de formularios y eliminar unidad en crecimiento

### DIFF
--- a/frontend-baby/src/dashboard/components/AlimentacionForm.js
+++ b/frontend-baby/src/dashboard/components/AlimentacionForm.js
@@ -250,7 +250,9 @@ export default function AlimentacionForm({ open, onClose, onSubmit, initialData 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>
-        {initialData && initialData.id ? 'Editar registro' : 'Añadir registro'}
+        {initialData && initialData.id
+          ? 'Editar registro'
+          : 'Registrar alimentación'}
       </DialogTitle>
       <DialogContent>
         <Stack sx={{ mt: 1 }}>

--- a/frontend-baby/src/dashboard/components/CitaForm.js
+++ b/frontend-baby/src/dashboard/components/CitaForm.js
@@ -130,7 +130,9 @@ export default function CitaForm({ open, onClose, onSubmit, initialData }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-        <DialogTitle>{initialData && initialData.id ? 'Editar cita' : 'Añadir cita'}</DialogTitle>
+        <DialogTitle>
+          {initialData && initialData.id ? 'Editar cita' : 'Registrar cita'}
+        </DialogTitle>
         <DialogContent>
           <Stack sx={{ mt: 1 }}>
             <FormControl fullWidth sx={{ mb: 2 }}>

--- a/frontend-baby/src/dashboard/components/CrecimientoForm.js
+++ b/frontend-baby/src/dashboard/components/CrecimientoForm.js
@@ -19,7 +19,6 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
     fecha: null,
     tipoId: '',
     valor: '',
-    unidad: '',
     observaciones: '',
   });
   const [tipoOptions, setTipoOptions] = useState([]);
@@ -30,7 +29,6 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
         fecha: initialData.fecha ? dayjs(initialData.fecha) : null,
         tipoId: initialData.tipoId || '',
         valor: initialData.valor || '',
-        unidad: initialData.unidad || '',
         observaciones: initialData.observaciones || '',
       });
     } else {
@@ -38,7 +36,6 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
         fecha: null,
         tipoId: '',
         valor: '',
-        unidad: '',
         observaciones: '',
       });
     }
@@ -50,21 +47,11 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
       .catch((err) => console.error('Error fetching tipos crecimiento:', err));
   }, []);
 
-  const getUnidad = (tipoId) => {
-    const tipo = tipoOptions.find((t) => t.id == tipoId);
-    if (!tipo) return '';
-    const nombre = tipo.nombre.toLowerCase();
-    if (nombre.includes('peso')) return 'kg';
-    if (nombre.includes('talla') || nombre.includes('perímetro') || nombre.includes('perimetro')) return 'cm';
-    return '';
-  };
-
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
       [name]: value,
-      ...(name === 'tipoId' ? { unidad: getUnidad(value) } : {}),
     }));
   };
 
@@ -89,7 +76,9 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle>
-        {initialData && initialData.id ? 'Editar registro' : 'Añadir registro'}
+        {initialData && initialData.id
+          ? 'Editar registro'
+          : 'Registrar crecimiento'}
       </DialogTitle>
       <DialogContent>
         <Stack sx={{ mt: 1 }}>
@@ -127,16 +116,7 @@ export default function CrecimientoForm({ open, onClose, onSubmit, initialData }
               inputProps={{ min: 0, step: 'any' }}
             />
           </FormControl>
-          {formData.unidad && (
-            <FormControl fullWidth sx={{ mb: 2 }}>
-              <FormLabel sx={{ mb: 1 }}>Unidad</FormLabel>
-              <TextField
-                name="unidad"
-                value={formData.unidad}
-                onChange={handleChange}
-              />
-            </FormControl>
-          )}
+          {/* Unidad field removed as it's determined automatically */}
           <FormControl fullWidth sx={{ mb: 2 }}>
             <FormLabel sx={{ mb: 1 }}>Observaciones</FormLabel>
             <TextField

--- a/frontend-baby/src/dashboard/components/CuidadoForm.js
+++ b/frontend-baby/src/dashboard/components/CuidadoForm.js
@@ -144,7 +144,7 @@ export default function CuidadoForm({ open, onClose, onSubmit, initialData }) {
       <DialogTitle>
         {initialData && initialData.id
           ? "Editar cuidado"
-          : "Añadir nuevo cuidado"}
+          : "Registrar cuidado"}
       </DialogTitle>
       <DialogContent>
         <Stack sx={{ mt: 1 }}>

--- a/frontend-baby/src/dashboard/components/GastoForm.js
+++ b/frontend-baby/src/dashboard/components/GastoForm.js
@@ -133,7 +133,9 @@ export default function GastoForm({ open, onClose, onSubmit, initialData }) {
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-        <DialogTitle>{initialData && initialData.id ? 'Editar gasto' : 'Añadir nuevo gasto'}</DialogTitle>
+        <DialogTitle>
+          {initialData && initialData.id ? 'Editar gasto' : 'Registrar gasto'}
+        </DialogTitle>
         <DialogContent>
           <Stack sx={{ mt: 1 }}>
             <FormControl fullWidth sx={{ mb: 2 }}>


### PR DESCRIPTION
## Resumen
- Ajustar títulos de diálogos para registros de alimentación, crecimiento, cuidado, gasto y cita
- Eliminar el campo "Unidad" en el formulario de crecimiento y actualizar lógica asociada

## Testing
- `npm test -- --watchAll=false` *(falla: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d0c2fb6c8327a2ae503b5d4e0147