### PR TITLE
Hide charts and tables when empty

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -357,140 +357,148 @@ export default function Alimentacion() {
         ))}
       </Tabs>
 
-      <TableContainer sx={{ mb: 4 }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              {headersMap[selectedSlug]?.map((h) => (
-                <TableCell key={h}>{h}</TableCell>
-              ))}
-              <TableCell align="center">Acciones</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filtered
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((r) => {
-                const alimento = getNombreSolido(r);
-                return (
-                  <TableRow key={r.id}>
-                    <TableCell>
-                      {dayjs(r.fechaHora).format('DD/MM/YYYY HH:mm')}
-                    </TableCell>
-                    {selectedSlug === 'lactancia' && (
-                      <>
-                        <TableCell>{r.tipoLactancia?.nombre}</TableCell>
-                        <TableCell>{r.lado}</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>
-                          {r.duracionMin}
+      {filtered.length > 0 ? (
+        <>
+          <TableContainer sx={{ mb: 4 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  {headersMap[selectedSlug]?.map((h) => (
+                    <TableCell key={h}>{h}</TableCell>
+                  ))}
+                  <TableCell align="center">Acciones</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {filtered
+                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                  .map((r) => {
+                    const alimento = getNombreSolido(r);
+                    return (
+                      <TableRow key={r.id}>
+                        <TableCell>
+                          {dayjs(r.fechaHora).format('DD/MM/YYYY HH:mm')}
                         </TableCell>
-                        <TableCell>{alimento}</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>
-                          {r.cantidadAlimentoSolido}
+                        {selectedSlug === 'lactancia' && (
+                          <>
+                            <TableCell>{r.tipoLactancia?.nombre}</TableCell>
+                            <TableCell>{r.lado}</TableCell>
+                            <TableCell sx={{ fontWeight: 600 }}>
+                              {r.duracionMin}
+                            </TableCell>
+                            <TableCell>{alimento}</TableCell>
+                            <TableCell sx={{ fontWeight: 600 }}>
+                              {r.cantidadAlimentoSolido}
+                            </TableCell>
+                            <TableCell sx={{ fontWeight: 600 }}>
+                              {r.cantidadLecheFormula}
+                            </TableCell>
+                            <TableCell>{r.observaciones}</TableCell>
+                          </>
+                        )}
+                        {selectedSlug === 'biberon' && (
+                          <>
+                            <TableCell>{r.tipoBiberon?.nombre}</TableCell>
+                            <TableCell sx={{ fontWeight: 600 }}>{r.cantidadMl}</TableCell>
+                            <TableCell>{r.observaciones}</TableCell>
+                          </>
+                        )}
+                        {selectedSlug === 'solidos' && (
+                          <>
+                            <TableCell>{alimento}</TableCell>
+                            <TableCell sx={{ fontWeight: 600 }}>{r.cantidad}</TableCell>
+                            <TableCell>{r.observaciones}</TableCell>
+                          </>
+                        )}
+                        <TableCell align="center">
+                          <IconButton
+                            size="small"
+                            aria-label="edit"
+                            onClick={() => handleEdit(r)}
+                            sx={{ color: '#0d6efd' }}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                          <IconButton
+                            size="small"
+                            aria-label="delete"
+                            onClick={() => handleDelete(r.id)}
+                            sx={{ color: '#dc3545' }}
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
                         </TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>
-                          {r.cantidadLecheFormula}
-                        </TableCell>
-                        <TableCell>{r.observaciones}</TableCell>
-                      </>
-                    )}
-                    {selectedSlug === 'biberon' && (
-                      <>
-                        <TableCell>{r.tipoBiberon?.nombre}</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>{r.cantidadMl}</TableCell>
-                        <TableCell>{r.observaciones}</TableCell>
-                      </>
-                    )}
-                    {selectedSlug === 'solidos' && (
-                      <>
-                        <TableCell>{alimento}</TableCell>
-                        <TableCell sx={{ fontWeight: 600 }}>{r.cantidad}</TableCell>
-                        <TableCell>{r.observaciones}</TableCell>
-                      </>
-                    )}
-                    <TableCell align="center">
-                      <IconButton
-                        size="small"
-                        aria-label="edit"
-                        onClick={() => handleEdit(r)}
-                        sx={{ color: '#0d6efd' }}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                      <IconButton
-                        size="small"
-                        aria-label="delete"
-                        onClick={() => handleDelete(r.id)}
-                        sx={{ color: '#dc3545' }}
-                      >
-                        <DeleteIcon fontSize="small" />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-          </TableBody>
-        </Table>
-        <TablePagination
-          component="div"
-          count={filtered.length}
-          page={page}
-          onPageChange={handleChangePage}
-          rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      </TableContainer>
+                      </TableRow>
+                    );
+                  })}
+              </TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={filtered.length}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </TableContainer>
 
-      {filtered.length > 0 && (
-        <Box sx={{ mb: 4, display: 'flex', gap: 2 }}>
-          <Button variant="outlined" onClick={handleExportPdf}>
-            Exportar PDF
-          </Button>
-          <Button variant="outlined" onClick={handleExportCsv}>
-            Exportar CSV
-          </Button>
-        </Box>
+          <Box sx={{ mb: 4, display: 'flex', gap: 2 }}>
+            <Button variant="outlined" onClick={handleExportPdf}>
+              Exportar PDF
+            </Button>
+            <Button variant="outlined" onClick={handleExportCsv}>
+              Exportar CSV
+            </Button>
+          </Box>
+
+          <Stack spacing={2}>
+            <Card variant="outlined">
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Totales por día de la semana
+                </Typography>
+                <BarChart
+                  height={250}
+                  xAxis={[{
+                    scaleType: 'band',
+                    data: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
+                  }]}
+                  series={[{ data: weeklyStats, color: chartColor }]}
+                  margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+                  grid={{ horizontal: true }}
+                  borderRadius={8}
+                />
+              </CardContent>
+            </Card>
+            <Card variant="outlined">
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  Comparativa lactancia vs biberón
+                </Typography>
+                <BarChart
+                  height={250}
+                  xAxis={[{ scaleType: 'band', data: ['Lactancia', 'Biberón'] }]}
+                  series={[
+                    { data: [lactanciaCount, 0], color: theme.palette.chart.babyBlue },
+                    { data: [0, biberonCount], color: theme.palette.chart.babyPink },
+                  ]}
+                  margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+                  grid={{ horizontal: true }}
+                  colors={Object.values(theme.palette.chart)}
+                  borderRadius={8}
+                />
+              </CardContent>
+            </Card>
+          </Stack>
+        </>
+      ) : (
+        selectedTipo && (
+          <Typography>
+            Aún no se han insertado datos de {selectedTipo.nombre.toLowerCase()}
+          </Typography>
+        )
       )}
-
-      <Stack spacing={2}>
-        <Card variant="outlined">
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              Totales por día de la semana
-            </Typography>
-            <BarChart
-              height={250}
-              xAxis={[{
-                scaleType: 'band',
-                data: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
-              }]}
-              series={[{ data: weeklyStats, color: chartColor }]}
-              margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
-              grid={{ horizontal: true }}
-              borderRadius={8}
-            />
-          </CardContent>
-        </Card>
-        <Card variant="outlined">
-          <CardContent>
-            <Typography variant="h6" gutterBottom>
-              Comparativa lactancia vs biberón
-            </Typography>
-            <BarChart
-              height={250}
-              xAxis={[{ scaleType: 'band', data: ['Lactancia', 'Biberón'] }]}
-              series={[
-                { data: [lactanciaCount, 0], color: theme.palette.chart.babyBlue },
-                { data: [0, biberonCount], color: theme.palette.chart.babyPink },
-              ]}
-              margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
-              grid={{ horizontal: true }}
-              colors={Object.values(theme.palette.chart)}
-              borderRadius={8}
-            />
-          </CardContent>
-        </Card>
-      </Stack>
 
       <AlimentacionForm
         open={openForm}

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -264,114 +264,121 @@ export default function Cuidados() {
           <Tab key={t.id} label={t.nombre} />
         ))}
       </Tabs>
-
-      <TableContainer sx={{ mb: 4 }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Hora</TableCell>
-              <TableCell>Tipo</TableCell>
-              {isPanal ? (
-                <>
-                  <TableCell>Tipo pañal</TableCell>
-                  <TableCell>Cantidad</TableCell>
-                </>
-              ) : (
-                <TableCell>{isSueno ? "Duración" : "Cantidad"}</TableCell>
-              )}
-              <TableCell>Nota</TableCell>
-              <TableCell align="center">Acciones</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredCuidados
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((cuidado) => (
-                <TableRow key={cuidado.id}>
-                  <TableCell>
-                    {dayjs(cuidado.inicio).format("DD/MM/YYYY HH:mm")}
-                  </TableCell>
-                  <TableCell>{cuidado.tipoNombre}</TableCell>
-                  {cuidado.tipoNombre === "Pañal" ? (
+      {filteredCuidados.length > 0 ? (
+        <>
+          <TableContainer sx={{ mb: 4 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Hora</TableCell>
+                  <TableCell>Tipo</TableCell>
+                  {isPanal ? (
                     <>
-                      <TableCell sx={{ fontWeight: 600 }}>
-                        {cuidado.tipoPanalNombre ?? "-"}
-                      </TableCell>
-                      <TableCell sx={{ fontWeight: 600 }}>
-                        {cuidado.cantidadPanal ?? "-"}
-                      </TableCell>
+                      <TableCell>Tipo pañal</TableCell>
+                      <TableCell>Cantidad</TableCell>
                     </>
                   ) : (
-                    <TableCell sx={{ fontWeight: 600 }}>
-                      {cuidado.tipoNombre === "Sueño"
-                        ? cuidado.duracion
-                        : cuidado.cantidadMl ?? "-"}
-                    </TableCell>
+                    <TableCell>{isSueno ? "Duración" : "Cantidad"}</TableCell>
                   )}
-                  <TableCell>{cuidado.observaciones}</TableCell>
-                  <TableCell align="center">
-                    <IconButton
-                      size="small"
-                      aria-label="edit"
-                      onClick={() => handleEdit(cuidado)}
-                      sx={{ color: '#0d6efd' }}
-                    >
-                      <EditIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      aria-label="delete"
-                      onClick={() => handleDelete(cuidado.id)}
-                      sx={{ color: '#dc3545' }}
-                    >
-                      <DeleteIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
+                  <TableCell>Nota</TableCell>
+                  <TableCell align="center">Acciones</TableCell>
                 </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-        <TablePagination
-          component="div"
-          count={filteredCuidados.length}
-          page={page}
-          onPageChange={handleChangePage}
-          rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      </TableContainer>
+              </TableHead>
+              <TableBody>
+                {filteredCuidados
+                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                  .map((cuidado) => (
+                    <TableRow key={cuidado.id}>
+                      <TableCell>
+                        {dayjs(cuidado.inicio).format("DD/MM/YYYY HH:mm")}
+                      </TableCell>
+                      <TableCell>{cuidado.tipoNombre}</TableCell>
+                      {cuidado.tipoNombre === "Pañal" ? (
+                        <>
+                          <TableCell sx={{ fontWeight: 600 }}>
+                            {cuidado.tipoPanalNombre ?? "-"}
+                          </TableCell>
+                          <TableCell sx={{ fontWeight: 600 }}>
+                            {cuidado.cantidadPanal ?? "-"}
+                          </TableCell>
+                        </>
+                      ) : (
+                        <TableCell sx={{ fontWeight: 600 }}>
+                          {cuidado.tipoNombre === "Sueño"
+                            ? cuidado.duracion
+                            : cuidado.cantidadMl ?? "-"}
+                        </TableCell>
+                      )}
+                      <TableCell>{cuidado.observaciones}</TableCell>
+                      <TableCell align="center">
+                        <IconButton
+                          size="small"
+                          aria-label="edit"
+                          onClick={() => handleEdit(cuidado)}
+                          sx={{ color: '#0d6efd' }}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label="delete"
+                          onClick={() => handleDelete(cuidado.id)}
+                          sx={{ color: '#dc3545' }}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={filteredCuidados.length}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </TableContainer>
 
-      {filteredCuidados.length > 0 && (
-        <Box sx={{ mb: 4, display: "flex", gap: 2 }}>
-          <Button variant="outlined" onClick={handleExportPdf}>
-            Exportar PDF
-          </Button>
-          <Button variant="outlined" onClick={handleExportCsv}>
-            Exportar CSV
-          </Button>
-        </Box>
-      )}
+          <Box sx={{ mb: 4, display: "flex", gap: 2 }}>
+            <Button variant="outlined" onClick={handleExportPdf}>
+              Exportar PDF
+            </Button>
+            <Button variant="outlined" onClick={handleExportCsv}>
+              Exportar CSV
+            </Button>
+          </Box>
 
-      <Card variant="outlined">
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Estadísticas de cuidados
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Estadísticas de cuidados
+              </Typography>
+              <BarChart
+                height={250}
+                xAxis={[
+                  {
+                    scaleType: "band",
+                    data: ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"],
+                  },
+                ]}
+                series={[{ data: weeklyStats, color: chartColor }]}
+                margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+                grid={{ horizontal: true }}
+                borderRadius={8}
+              />
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+        tipos[tab] && (
+          <Typography>
+            Aún no se han insertado datos de {tipos[tab].nombre.toLowerCase()}
           </Typography>
-          <BarChart
-            height={250}
-            xAxis={[
-              {
-                scaleType: "band",
-                data: ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"],
-              },
-            ]}
-            series={[{ data: weeklyStats, color: chartColor }]}
-            margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
-            grid={{ horizontal: true }}
-            borderRadius={8}
-          />
-        </CardContent>
-      </Card>
+        )
+      )}
       <CuidadoForm
         open={openForm}
         onClose={() => setOpenForm(false)}

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -276,99 +276,105 @@ export default function Gastos() {
         Total del mes: {totalMes.toFixed(2)} €
       </Typography>
 
-      <TableContainer sx={{ mb: 4 }}>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Fecha</TableCell>
-              <TableCell>Categoría</TableCell>
-              <TableCell>Precio €</TableCell>
-              <TableCell>Descripción</TableCell>
-              <TableCell align="center">Acciones</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {filteredGastos
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map((gasto) => (
-                <TableRow key={gasto.id}>
-                  <TableCell>
-                    {dayjs(gasto.fecha).format("DD/MM/YYYY")}
-                  </TableCell>
-                  <TableCell>
-                    {gasto.categoriaNombre ||
-                      categorias.find(
-                        (c) => Number(c.id) === Number(gasto.categoriaId),
-                      )?.nombre}
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 600 }}>
-                    {Number(gasto.cantidad).toFixed(2)}
-                  </TableCell>
-                  <TableCell>{gasto.descripcion}</TableCell>
-                  
-                  <TableCell align="center">
-                    <IconButton
-                      size="small"
-                      aria-label="edit"
-                      onClick={() => handleEdit(gasto)}
-                      sx={{ color: '#0d6efd' }}
-                    >
-                      <EditIcon fontSize="small" />
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      aria-label="delete"
-                      onClick={() => handleDelete(gasto.id)}
-                      sx={{ color: "#dc3545" }}
-                    >
-                      <DeleteIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
+      {filteredGastos.length > 0 ? (
+        <>
+          <TableContainer sx={{ mb: 4 }}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Fecha</TableCell>
+                  <TableCell>Categoría</TableCell>
+                  <TableCell>Precio €</TableCell>
+                  <TableCell>Descripción</TableCell>
+                  <TableCell align="center">Acciones</TableCell>
                 </TableRow>
-              ))}
-          </TableBody>
-        </Table>
-        <TablePagination
-          component="div"
-          count={filteredGastos.length}
-          page={page}
-          onPageChange={handleChangePage}
-          rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-        />
-      </TableContainer>
-      {filteredGastos.length > 0 && (
-        <Box sx={{ mb: 4, display: "flex", gap: 2 }}>
-          <Button variant="outlined" onClick={handleExportPdf}>
-            Exportar PDF
-          </Button>
-          <Button variant="outlined" onClick={handleExportCsv}>
-            Exportar CSV
-          </Button>
-        </Box>
-      )}
+              </TableHead>
+              <TableBody>
+                {filteredGastos
+                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                  .map((gasto) => (
+                    <TableRow key={gasto.id}>
+                      <TableCell>
+                        {dayjs(gasto.fecha).format("DD/MM/YYYY")}
+                      </TableCell>
+                      <TableCell>
+                        {gasto.categoriaNombre ||
+                          categorias.find(
+                            (c) => Number(c.id) === Number(gasto.categoriaId),
+                          )?.nombre}
+                      </TableCell>
+                      <TableCell sx={{ fontWeight: 600 }}>
+                        {Number(gasto.cantidad).toFixed(2)}
+                      </TableCell>
+                      <TableCell>{gasto.descripcion}</TableCell>
 
-      <Card variant="outlined">
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Gastos por día de la semana
-          </Typography>
-          <BarChart
-            colors={Object.values(colors)}
-            borderRadius={8}
-            height={250}
-            xAxis={[
-              {
-                scaleType: "band",
-                data: ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"],
-              },
-            ]}
-            series={[{ data: weeklyStats }]}
-            margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
-            grid={{ horizontal: true }}
-          />
-        </CardContent>
-      </Card>
+                      <TableCell align="center">
+                        <IconButton
+                          size="small"
+                          aria-label="edit"
+                          onClick={() => handleEdit(gasto)}
+                          sx={{ color: '#0d6efd' }}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                        <IconButton
+                          size="small"
+                          aria-label="delete"
+                          onClick={() => handleDelete(gasto.id)}
+                          sx={{ color: "#dc3545" }}
+                        >
+                          <DeleteIcon fontSize="small" />
+                        </IconButton>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={filteredGastos.length}
+              page={page}
+              onPageChange={handleChangePage}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
+            />
+          </TableContainer>
+          <Box sx={{ mb: 4, display: "flex", gap: 2 }}>
+            <Button variant="outlined" onClick={handleExportPdf}>
+              Exportar PDF
+            </Button>
+            <Button variant="outlined" onClick={handleExportCsv}>
+              Exportar CSV
+            </Button>
+          </Box>
+
+          <Card variant="outlined">
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Gastos por día de la semana
+              </Typography>
+              <BarChart
+                colors={Object.values(colors)}
+                borderRadius={8}
+                height={250}
+                xAxis={[
+                  {
+                    scaleType: "band",
+                    data: ["Lun", "Mar", "Mié", "Jue", "Vie", "Sáb", "Dom"],
+                  },
+                ]}
+                series={[{ data: weeklyStats }]}
+                margin={{ left: 30, right: 10, top: 20, bottom: 20 }}
+                grid={{ horizontal: true }}
+              />
+            </CardContent>
+          </Card>
+        </>
+      ) : (
+        <Typography>
+          Aún no se han insertado datos de gastos
+        </Typography>
+      )}
       <GastoForm
         open={openForm}
         onClose={handleCloseForm}


### PR DESCRIPTION
## Summary
- avoid showing Alimentación table and graphs when there's no data
- hide Cuidados table and stats chart if no entries exist
- display notice instead of Gastos reports when dataset is empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4d573a6f48327a1c8e85202f4299e