### PR TITLE
feat: show weight trend arrow

### DIFF
--- a/frontend-baby/src/dashboard/components/StatsOverview.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.js
@@ -10,6 +10,7 @@ import LocalDrinkIcon from '@mui/icons-material/LocalDrink';
 import HotelIcon from '@mui/icons-material/Hotel';
 import BabyChangingStationIcon from '@mui/icons-material/BabyChangingStation';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
+import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
@@ -279,7 +280,11 @@ export default function StatsOverview() {
         <Card sx={{ backgroundColor: cardBg, color: theme.palette.text.primary }}>
           <CardContent>
             <Stack direction="row" spacing={2} alignItems="center">
-              <TrendingUpIcon color={stats.weight.diffValue >= 0 ? 'success' : 'error'} />
+              {stats.weight.diffValue >= 0 ? (
+                <TrendingUpIcon color="success" />
+              ) : (
+                <TrendingDownIcon color="error" />
+              )}
               <Box>
                 <Typography variant="subtitle2">Peso actual</Typography>
                 <Stack direction="row" spacing={1} alignItems="baseline">

--- a/frontend-baby/src/dashboard/components/StatsOverview.test.js
+++ b/frontend-baby/src/dashboard/components/StatsOverview.test.js
@@ -4,7 +4,7 @@ import { AuthContext } from '../../context/AuthContext';
 import { BabyContext } from '../../context/BabyContext';
 import { obtenerStatsRapidas } from '../../services/cuidadosService';
 import { obtenerUltimoBiberon } from '../../services/alimentacionService';
-import { listarTipos } from '../../services/crecimientoService';
+import { listarTipos, listarUltimosPorTipo } from '../../services/crecimientoService';
 
 jest.mock('../../services/cuidadosService', () => ({
   obtenerStatsRapidas: jest.fn(),
@@ -74,6 +74,42 @@ describe('StatsOverview', () => {
     await waitFor(() => {
       expect(screen.getByText('Sin datos')).toBeInTheDocument();
     });
+  });
+
+  it('muestra flecha hacia arriba cuando el peso aumenta', async () => {
+    obtenerStatsRapidas.mockResolvedValue({ data: {} });
+    listarTipos.mockResolvedValue({ data: [{ id: 1, nombre: 'Peso' }] });
+    listarUltimosPorTipo.mockResolvedValue({
+      data: [
+        { valor: 5.5 },
+        { valor: 4.0 },
+      ],
+    });
+    obtenerUltimoBiberon.mockResolvedValue({ data: {} });
+
+    renderComponent();
+
+    await waitFor(() => expect(listarUltimosPorTipo).toHaveBeenCalled());
+    const icon = await screen.findByTestId('TrendingUpIcon');
+    expect(icon).toHaveClass('MuiSvgIcon-colorSuccess');
+  });
+
+  it('muestra flecha hacia abajo cuando el peso disminuye', async () => {
+    obtenerStatsRapidas.mockResolvedValue({ data: {} });
+    listarTipos.mockResolvedValue({ data: [{ id: 1, nombre: 'Peso' }] });
+    listarUltimosPorTipo.mockResolvedValue({
+      data: [
+        { valor: 4.0 },
+        { valor: 5.5 },
+      ],
+    });
+    obtenerUltimoBiberon.mockResolvedValue({ data: {} });
+
+    renderComponent();
+
+    await waitFor(() => expect(listarUltimosPorTipo).toHaveBeenCalled());
+    const icon = await screen.findByTestId('TrendingDownIcon');
+    expect(icon).toHaveClass('MuiSvgIcon-colorError');
   });
 });
 


### PR DESCRIPTION
## Summary
- show green trending-up arrow when baby's weight increases
- show red trending-down arrow when baby's weight decreases
- test weight trend arrow rendering

## Testing
- `npm test -- --watchAll=false` *(fails: Test suite failed to run: Your test suite must contain at least one test.)*
- `npm test -- src/dashboard/components/StatsOverview.test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68c5351df8808327aa7a851943627755