### PR TITLE
feat: add notifications button to header

### DIFF
--- a/frontend-baby/src/dashboard/components/Header.js
+++ b/frontend-baby/src/dashboard/components/Header.js
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import Stack from '@mui/material/Stack';
+import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
+import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
 
 export default function Header() {
@@ -16,6 +18,9 @@ export default function Header() {
         gap: 1,
       }}
     >
+      <MenuButton showBadge>
+        <NotificationsRoundedIcon />
+      </MenuButton>
       <ColorModeIconDropdown />
     </Stack>
   );


### PR DESCRIPTION
## Summary
- add MenuButton with Notifications icon in dashboard header
- keep Stack layout aligned to right with gap

## Testing
- `npm test -- --watchAll=false` *(fails: Your test suite must contain at least one test in src/dashboard/pages/Crecimiento.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c5563705888327ae398b1389e48556