### PR TITLE
Add baby avatar to dashboard headers

### DIFF
--- a/frontend-baby/src/dashboard/components/AppNavbar.js
+++ b/frontend-baby/src/dashboard/components/AppNavbar.js
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import { styled } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
 import MuiToolbar from '@mui/material/Toolbar';
 import { tabsClasses } from '@mui/material/Tabs';
 import SelectContent from './SelectContent';
@@ -11,6 +12,7 @@ import SideMenuMobile from './SideMenuMobile';
 import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
 import { Link } from 'react-router-dom';
+import { BabyContext } from '../../context/BabyContext';
 
 const Toolbar = styled(MuiToolbar)({
   width: '100%',
@@ -30,6 +32,7 @@ const Toolbar = styled(MuiToolbar)({
 
 export default function AppNavbar() {
   const [open, setOpen] = React.useState(false);
+  const { activeBaby } = useContext(BabyContext);
 
   const toggleDrawer = (newOpen) => () => {
     setOpen(newOpen);
@@ -69,6 +72,18 @@ export default function AppNavbar() {
             </Box>
           </Stack>
           <ColorModeIconDropdown />
+          <Avatar
+            component={Link}
+            to="/dashboard/editar-bebe"
+            src={
+              activeBaby?.imagenBebe
+                ? `data:image/*;base64,${activeBaby.imagenBebe}`
+                : undefined
+            }
+          >
+            {!activeBaby?.imagenBebe &&
+              activeBaby?.nombre?.[0]?.toUpperCase()}
+          </Avatar>
           <MenuButton aria-label="menú" onClick={toggleDrawer(true)}>
             <MenuRoundedIcon />
           </MenuButton>

--- a/frontend-baby/src/dashboard/components/Header.js
+++ b/frontend-baby/src/dashboard/components/Header.js
@@ -1,10 +1,14 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import Stack from '@mui/material/Stack';
+import Avatar from '@mui/material/Avatar';
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
+import { Link } from 'react-router-dom';
 import MenuButton from './MenuButton';
 import ColorModeIconDropdown from '../../shared-theme/ColorModeIconDropdown';
+import { BabyContext } from '../../context/BabyContext';
 
 export default function Header() {
+  const { activeBaby } = useContext(BabyContext);
   return (
     <Stack
       direction="row"
@@ -22,6 +26,18 @@ export default function Header() {
         <NotificationsRoundedIcon />
       </MenuButton>
       <ColorModeIconDropdown />
+      <Avatar
+        component={Link}
+        to="/dashboard/editar-bebe"
+        src={
+          activeBaby?.imagenBebe
+            ? `data:image/*;base64,${activeBaby.imagenBebe}`
+            : undefined
+        }
+      >
+        {!activeBaby?.imagenBebe &&
+          activeBaby?.nombre?.[0]?.toUpperCase()}
+      </Avatar>
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- show active baby's initial or photo in desktop header
- add same avatar link in mobile navigation bar

## Testing
- `npm test -- --watchAll=false` *(fails: src/dashboard/pages/Crecimiento.test.js - Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c55f03ed7c832797fb1df4a40be1e4