### PR TITLE
Remove edit baby menu option

### DIFF
--- a/frontend-baby/src/dashboard/components/MenuContent.js
+++ b/frontend-baby/src/dashboard/components/MenuContent.js
@@ -31,7 +31,6 @@ const mainListItems = [
 
 const secondaryListItems = [
   { text: 'Añadir bebé', icon: <AddCircleRoundedIcon />, to: '/dashboard/anadir-bebe' },
-  { text: 'Editar/borrar bebé', icon: <EditRoundedIcon />, to: '/dashboard/editar-bebe' },
   { text: 'Acerca de', icon: <InfoRoundedIcon />, to: '/dashboard/acerca' },
 ];
 


### PR DESCRIPTION
## Summary
- Remove "Editar/borrar bebé" item from secondary menu so edit page accessible only via avatar

## Testing
- `npm test -- --watchAll=false` *(fails: Test suite failed to run: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c560036858832795b510db2a70eaf2