### PR TITLE
Use red snackbar notifications for deletions

### DIFF
--- a/frontend-baby/src/dashboard/pages/Alimentacion.js
+++ b/frontend-baby/src/dashboard/pages/Alimentacion.js
@@ -16,6 +16,8 @@ import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -47,6 +49,8 @@ export default function Alimentacion() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selected, setSelected] = useState(null);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
   const bebeId = activeBaby?.id;
@@ -199,14 +203,14 @@ export default function Alimentacion() {
 
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
-    if (window.confirm('¿Eliminar registro?')) {
-      eliminarRegistro(usuarioId, bebeId, id)
-        .then(() => {
-          fetchRegistros();
-          fetchEstadisticas(tab);
-        })
-        .catch((err) => console.error('Error deleting registro:', err));
-    }
+    eliminarRegistro(usuarioId, bebeId, id)
+      .then(() => {
+        fetchRegistros();
+        fetchEstadisticas(tab);
+        setSnackbarMessage('Registro eliminado');
+        setOpenSnackbar(true);
+      })
+      .catch((err) => console.error('Error deleting registro:', err));
   };
 
   const handleFormSubmit = (data) => {
@@ -232,6 +236,11 @@ export default function Alimentacion() {
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setOpenSnackbar(false);
   };
 
   const headersMap = {
@@ -506,6 +515,19 @@ export default function Alimentacion() {
         onSubmit={handleFormSubmit}
         initialData={selected}
       />
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="error"
+          sx={{ bgcolor: '#ffcdd2', color: '#b71c1c' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend-baby/src/dashboard/pages/Crecimiento.js
+++ b/frontend-baby/src/dashboard/pages/Crecimiento.js
@@ -17,6 +17,8 @@ import TablePagination from "@mui/material/TablePagination";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
 import TextField from "@mui/material/TextField";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
 import dayjs from "dayjs";
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
@@ -69,6 +71,8 @@ export default function Crecimiento() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedRegistro, setSelectedRegistro] = useState(null);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
   const [tipos, setTipos] = useState([]);
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
@@ -140,11 +144,13 @@ export default function Crecimiento() {
 
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
-    if (window.confirm("¿Eliminar registro?")) {
-      eliminarRegistro(usuarioId, id)
-        .then(() => fetchRegistros())
-        .catch((err) => console.error("Error deleting registro:", err));
-    }
+    eliminarRegistro(usuarioId, id)
+      .then(() => {
+        fetchRegistros();
+        setSnackbarMessage("Registro eliminado");
+        setOpenSnackbar(true);
+      })
+      .catch((err) => console.error("Error deleting registro:", err));
   };
 
   const handleFormSubmit = (data) => {
@@ -170,6 +176,11 @@ export default function Crecimiento() {
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === "clickaway") return;
+    setOpenSnackbar(false);
   };
 
   return (
@@ -308,6 +319,19 @@ export default function Crecimiento() {
         onSubmit={handleFormSubmit}
         initialData={selectedRegistro}
       />
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="error"
+          sx={{ bgcolor: '#ffcdd2', color: '#b71c1c' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend-baby/src/dashboard/pages/Cuidados.js
+++ b/frontend-baby/src/dashboard/pages/Cuidados.js
@@ -16,6 +16,8 @@ import TableRow from "@mui/material/TableRow";
 import TablePagination from "@mui/material/TablePagination";
 import Tabs from "@mui/material/Tabs";
 import Typography from "@mui/material/Typography";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
 import dayjs from "dayjs";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
@@ -42,6 +44,8 @@ export default function Cuidados() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedCuidado, setSelectedCuidado] = useState(null);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
   const [tipos, setTipos] = useState([]);
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
@@ -133,13 +137,15 @@ export default function Cuidados() {
 
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
-    if (window.confirm("¿Eliminar cuidado?")) {
-      eliminarCuidado(usuarioId, id)
-        .then(() => fetchCuidados())
-        .catch((error) => {
-          console.error("Error deleting cuidado:", error);
-        });
-    }
+    eliminarCuidado(usuarioId, id)
+      .then(() => {
+        fetchCuidados();
+        setSnackbarMessage('Registro eliminado');
+        setOpenSnackbar(true);
+      })
+      .catch((error) => {
+        console.error("Error deleting cuidado:", error);
+      });
   };
 
   const handleFormSubmit = (data) => {
@@ -167,6 +173,11 @@ export default function Cuidados() {
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setOpenSnackbar(false);
   };
   // Exporta datos con columnas específicas según el tipo seleccionado.
   const handleExportCsv = () => {
@@ -385,6 +396,19 @@ export default function Cuidados() {
         onSubmit={handleFormSubmit}
         initialData={selectedCuidado}
       />
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="error"
+          sx={{ bgcolor: '#ffcdd2', color: '#b71c1c' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend-baby/src/dashboard/pages/Gastos.js
+++ b/frontend-baby/src/dashboard/pages/Gastos.js
@@ -17,6 +17,8 @@ import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+import Snackbar from "@mui/material/Snackbar";
+import Alert from "@mui/material/Alert";
 import AddIcon from "@mui/icons-material/Add";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -46,6 +48,8 @@ export default function Gastos() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedGasto, setSelectedGasto] = useState(null);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("0");
   const [categorias, setCategorias] = useState([]);
   const [monthFilter, setMonthFilter] = useState(dayjs().format("YYYY-MM"));
@@ -137,13 +141,15 @@ export default function Gastos() {
 
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
-    if (window.confirm("¿Eliminar gasto?")) {
-      eliminarGasto(usuarioId, id)
-        .then(() => fetchGastos())
-        .catch((error) => {
-          console.error("Error deleting gasto:", error);
-        });
-    }
+    eliminarGasto(usuarioId, id)
+      .then(() => {
+        fetchGastos();
+        setSnackbarMessage("Registro eliminado");
+        setOpenSnackbar(true);
+      })
+      .catch((error) => {
+        console.error("Error deleting gasto:", error);
+      });
   };
 
   const handleFormSubmit = (data) => {
@@ -171,6 +177,11 @@ export default function Gastos() {
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setOpenSnackbar(false);
   };
 
   const handleExportCsv = () => {
@@ -381,6 +392,19 @@ export default function Gastos() {
         onSubmit={handleFormSubmit}
         initialData={selectedGasto}
       />
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="error"
+          sx={{ bgcolor: '#ffcdd2', color: '#b71c1c' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }

--- a/frontend-baby/src/dashboard/pages/Rutinas.js
+++ b/frontend-baby/src/dashboard/pages/Rutinas.js
@@ -15,6 +15,8 @@ import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -60,6 +62,8 @@ export default function Rutinas() {
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [openForm, setOpenForm] = useState(false);
   const [selectedRutina, setSelectedRutina] = useState(null);
+  const [openSnackbar, setOpenSnackbar] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
   const { activeBaby } = React.useContext(BabyContext);
   const { user } = React.useContext(AuthContext);
   const usuarioId = user?.id;
@@ -105,13 +109,15 @@ export default function Rutinas() {
 
   const handleDelete = (id) => {
     if (!bebeId || !usuarioId) return;
-    if (window.confirm('¿Eliminar rutina?')) {
-      eliminarRutina(usuarioId, id)
-        .then(() => fetchRutinas())
-        .catch((error) => {
-          console.error('Error deleting rutina:', error);
-        });
-    }
+    eliminarRutina(usuarioId, id)
+      .then(() => {
+        fetchRutinas();
+        setSnackbarMessage('Registro eliminado');
+        setOpenSnackbar(true);
+      })
+      .catch((error) => {
+        console.error('Error deleting rutina:', error);
+      });
   };
 
   const handleDuplicate = (id) => {
@@ -148,6 +154,11 @@ export default function Rutinas() {
   const handleChangeRowsPerPage = (event) => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setOpenSnackbar(false);
   };
 
   return (
@@ -282,6 +293,19 @@ export default function Rutinas() {
         onSubmit={handleFormSubmit}
         initialData={selectedRutina}
       />
+      <Snackbar
+        open={openSnackbar}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="error"
+          sx={{ bgcolor: '#ffcdd2', color: '#b71c1c' }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- replace native confirm dialogs with red snackbar alerts
- show deletion toast on Alimentacion, Gastos, Crecimiento, Rutinas and Cuidados pages

## Testing
- `npm test -- --watchAll=false` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c593891360832780ad3565c21ec8f4