### PR TITLE
feat: update alert feedback colors

### DIFF
--- a/frontend-baby/src/shared-theme/customizations/feedback.js
+++ b/frontend-baby/src/shared-theme/customizations/feedback.js
@@ -1,5 +1,5 @@
 import { alpha } from '@mui/material/styles';
-import { gray, orange } from '../themePrimitives';
+import { gray, chartPastel } from '../themePrimitives';
 
 /* eslint-disable import/prefer-default-export */
 export const feedbackCustomizations = {
@@ -7,15 +7,15 @@ export const feedbackCustomizations = {
     styleOverrides: {
       root: ({ theme }) => ({
         borderRadius: 10,
-        backgroundColor: orange[100],
+        backgroundColor: chartPastel.babyBlue,
         color: (theme.vars || theme).palette.text.primary,
-        border: `1px solid ${alpha(orange[300], 0.5)}`,
+        border: `1px solid ${alpha(chartPastel.babyBlue, 0.5)}`,
         '& .MuiAlert-icon': {
-          color: orange[500],
+          color: chartPastel.babyBlue,
         },
         ...theme.applyStyles('dark', {
-          backgroundColor: `${alpha(orange[900], 0.5)}`,
-          border: `1px solid ${alpha(orange[800], 0.5)}`,
+          backgroundColor: `${alpha(chartPastel.babyBlue, 0.2)}`,
+          border: `1px solid ${alpha(chartPastel.babyBlue, 0.3)}`,
         }),
       }),
     },


### PR DESCRIPTION
## Summary
- use chartPastel baby blue for alert background, border, and icon
- tweak dark mode feedback colors to match pastel blue tones

## Testing
- `CI=true npm test --silent` *(fails: src/dashboard/pages/Crecimiento.test.js: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5971b074c832784416a6f09844646