### PR TITLE
Use pastel blue alert in baby edit page

### DIFF
--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -550,12 +550,8 @@ export default function EditarBebe() {
           autoHideDuration={6000}
           onClose={handleCloseSnackbar}
         >
-          <Alert
-            onClose={handleCloseSnackbar}
-            severity="success"
-            sx={{ width: '100%' }}
-          >
-            Bebé actualizado correctamente
+          <Alert onClose={handleCloseSnackbar} severity="info">
+            Registro actualizado
           </Alert>
         </Snackbar>
     </Box>


### PR DESCRIPTION
## Summary
- adjust alert copy to "Registro actualizado" in EditarBebe
- show pastel blue info alert instead of success and remove custom styles

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: RecentCareCard.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c597c481e08327ab4d3b62498571b6