### PR TITLE
refactor: centralize outlined input styles

### DIFF
--- a/frontend-baby/src/dashboard/pages/AnadirBebe.js
+++ b/frontend-baby/src/dashboard/pages/AnadirBebe.js
@@ -25,6 +25,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
 import { saveButton, cancelButton, primaryButton } from '../../theme/buttonStyles';
+import { outlinedTextField } from '../../theme/inputStyles';
 
 export default function AnadirBebe() {
   const navigate = useNavigate();
@@ -162,10 +163,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -180,10 +178,7 @@ export default function AnadirBebe() {
                         textField: {
                           required: true,
                           variant: 'outlined',
-                          sx: {
-                            '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                            '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                          },
+                          sx: outlinedTextField,
                           fullWidth: true,
                           disabled: loading,
                           InputLabelProps: { shrink: true },
@@ -225,10 +220,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -243,10 +235,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -261,10 +250,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -279,10 +265,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                 </Grid>
@@ -296,18 +279,7 @@ export default function AnadirBebe() {
                     <FormControl
                       fullWidth
                       variant="outlined"
-                      sx={{
-
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-
-                        minWidth: 160,
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: 'divider',
-                          borderRadius: 1,
-                        },
-
-                      }}
+                      sx={{ ...outlinedTextField, minWidth: 160 }}
                     >
                       <InputLabel id="grupo-sanguineo-label" shrink>Grupo sanguíneo</InputLabel>
                       <Select
@@ -331,18 +303,7 @@ export default function AnadirBebe() {
                     <FormControl
                       fullWidth
                       variant="outlined"
-                      sx={{
-
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-
-                        minWidth: 160,
-                        '& .MuiOutlinedInput-notchedOutline': {
-                          borderColor: 'divider',
-                          borderRadius: 1,
-                        },
-
-                      }}
+                      sx={{ ...outlinedTextField, minWidth: 160 }}
                     >
                       <InputLabel id="alergias-label" shrink>Alergias</InputLabel>
                       <Select
@@ -372,10 +333,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                 </Grid>
@@ -395,10 +353,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -411,10 +366,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -427,10 +379,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                   <Grid item xs={12} sm={6}>
@@ -443,10 +392,7 @@ export default function AnadirBebe() {
                       onChange={handleChange}
                       disabled={loading}
                       variant="outlined"
-                      sx={{
-                        '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                        '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      }}
+                      sx={outlinedTextField}
                     />
                   </Grid>
                 </Grid>
@@ -464,10 +410,7 @@ export default function AnadirBebe() {
                   onChange={handleChange}
                   disabled={loading}
                   variant="outlined"
-                  sx={{
-                    '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                    '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                  }}
+                  sx={outlinedTextField}
                 />
               </Box>
             </Grid>

--- a/frontend-baby/src/dashboard/pages/EditarBebe.js
+++ b/frontend-baby/src/dashboard/pages/EditarBebe.js
@@ -23,6 +23,7 @@ import { BabyContext } from '../../context/BabyContext';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import { outlinedTextField } from '../../theme/inputStyles';
 
 export default function EditarBebe() {
   const navigate = useNavigate();
@@ -195,10 +196,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -213,10 +211,7 @@ export default function EditarBebe() {
                       textField: {
                         required: true,
                         variant: 'outlined',
-                        sx: {
-                          '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                          '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                        },
+                        sx: outlinedTextField,
                         fullWidth: true,
                         disabled: loading,
                         InputLabelProps: { shrink: true },
@@ -259,10 +254,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -277,10 +269,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -295,10 +284,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -313,10 +299,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
               </Grid>
@@ -331,15 +314,7 @@ export default function EditarBebe() {
                   <FormControl
                     fullWidth
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      minWidth: 160,
-                      '& .MuiOutlinedInput-notchedOutline': {
-                        borderColor: 'divider',
-                        borderRadius: 1,
-                      },
-                    }}
+                    sx={{ ...outlinedTextField, minWidth: 160 }}
                   >
                     <InputLabel id="grupo-sanguineo-label" shrink>
                       Grupo sanguíneo
@@ -365,15 +340,7 @@ export default function EditarBebe() {
                   <FormControl
                     fullWidth
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      minWidth: 160,
-                      '& .MuiOutlinedInput-notchedOutline': {
-                        borderColor: 'divider',
-                        borderRadius: 1,
-                      },
-                    }}
+                    sx={{ ...outlinedTextField, minWidth: 160 }}
                   >
                     <InputLabel id="alergias-label" shrink>
                       Alergias
@@ -405,10 +372,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
               </Grid>
@@ -429,10 +393,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -445,10 +406,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -461,10 +419,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
                 <Grid item xs={12} sm={6}>
@@ -477,10 +432,7 @@ export default function EditarBebe() {
                     onChange={handleChange}
                     disabled={loading}
                     variant="outlined"
-                    sx={{
-                      '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                      '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    }}
+                    sx={outlinedTextField}
                   />
                 </Grid>
               </Grid>
@@ -499,10 +451,7 @@ export default function EditarBebe() {
                 onChange={handleChange}
                 disabled={loading}
                 variant="outlined"
-                sx={{
-                  '& .MuiOutlinedInput-root': { borderRadius: 1 },
-                  '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                }}
+                sx={outlinedTextField}
               />
             </Box>
           </Grid>

--- a/frontend-baby/src/theme/inputStyles.js
+++ b/frontend-baby/src/theme/inputStyles.js
@@ -1,0 +1,4 @@
+export const outlinedTextField = {
+  '& .MuiOutlinedInput-root': { borderRadius: 1 },
+  '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
+};


### PR DESCRIPTION
## Summary
- centralize MUI outlined input styling via new `outlinedTextField` theme helper
- apply shared style to baby creation and edit pages

## Testing
- `npm test -- --watchAll=false` *(fails: Test suite failed to run - Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a1492c98832783a9f3d6bc7c2593